### PR TITLE
refactor: split database schema by domain

### DIFF
--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -3,7 +3,7 @@ config({ path: '.env.local' });
 import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({
-    schema: './server/db/schema.ts',
+    schema: './server/db/schema/*.ts',
     out: './server/db/migrations',
     dialect: 'postgresql',
     dbCredentials: {

--- a/apps/web/server/db/schema/auth.ts
+++ b/apps/web/server/db/schema/auth.ts
@@ -1,14 +1,7 @@
-import {
-    pgTable,
-    pgEnum,
-    text,
-    timestamp,
-    boolean,
-    bigint,
-    index,
-} from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, boolean } from 'drizzle-orm/pg-core';
 
 // BetterAuth tables
+
 export const user = pgTable('user', {
     id: text('id').primaryKey(),
     name: text('name').notNull(),
@@ -58,45 +51,3 @@ export const verification = pgTable('verification', {
     createdAt: timestamp('created_at').notNull().defaultNow(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
 });
-
-// Nexus domain tables
-
-export const storageTierEnum = pgEnum('storage_tier', [
-    'standard',
-    'glacier',
-    'deep_archive',
-]);
-
-export const fileStatusEnum = pgEnum('file_status', [
-    'uploading',
-    'available',
-    'restoring',
-    'deleted',
-]);
-
-export const files = pgTable(
-    'files',
-    {
-        id: text('id').primaryKey(),
-        userId: text('user_id')
-            .notNull()
-            .references(() => user.id, { onDelete: 'cascade' }),
-        name: text('name').notNull(),
-        size: bigint('size', { mode: 'number' }).notNull(),
-        mimeType: text('mime_type'),
-        s3Key: text('s3_key').notNull().unique(),
-        storageTier: storageTierEnum('storage_tier')
-            .notNull()
-            .default('glacier'),
-        status: fileStatusEnum('status').notNull().default('uploading'),
-        createdAt: timestamp('created_at').notNull().defaultNow(),
-        updatedAt: timestamp('updated_at').notNull().defaultNow(),
-        lastAccessedAt: timestamp('last_accessed_at'),
-        deletedAt: timestamp('deleted_at'),
-    },
-    (table) => [
-        index('files_user_id_idx').on(table.userId),
-        index('files_status_idx').on(table.status),
-        index('files_storage_tier_idx').on(table.storageTier),
-    ]
-);

--- a/apps/web/server/db/schema/index.ts
+++ b/apps/web/server/db/schema/index.ts
@@ -1,0 +1,2 @@
+export * from './auth';
+export * from './storage';

--- a/apps/web/server/db/schema/storage.ts
+++ b/apps/web/server/db/schema/storage.ts
@@ -1,0 +1,51 @@
+import {
+    pgTable,
+    pgEnum,
+    text,
+    timestamp,
+    bigint,
+    index,
+} from 'drizzle-orm/pg-core';
+import { user } from './auth';
+
+// Nexus domain tables
+
+export const storageTierEnum = pgEnum('storage_tier', [
+    'standard',
+    'glacier',
+    'deep_archive',
+]);
+
+export const fileStatusEnum = pgEnum('file_status', [
+    'uploading',
+    'available',
+    'restoring',
+    'deleted',
+]);
+
+export const files = pgTable(
+    'files',
+    {
+        id: text('id').primaryKey(),
+        userId: text('user_id')
+            .notNull()
+            .references(() => user.id, { onDelete: 'cascade' }),
+        name: text('name').notNull(),
+        size: bigint('size', { mode: 'number' }).notNull(),
+        mimeType: text('mime_type'),
+        s3Key: text('s3_key').notNull().unique(),
+        storageTier: storageTierEnum('storage_tier')
+            .notNull()
+            .default('glacier'),
+        status: fileStatusEnum('status').notNull().default('uploading'),
+        createdAt: timestamp('created_at').notNull().defaultNow(),
+        updatedAt: timestamp('updated_at').notNull().defaultNow(),
+        lastAccessedAt: timestamp('last_accessed_at'),
+        deletedAt: timestamp('deleted_at'),
+    },
+    (table) => [
+        index('files_user_id_idx').on(table.userId),
+        index('files_status_idx').on(table.status),
+        index('files_storage_tier_idx').on(table.storageTier),
+    ]
+);


### PR DESCRIPTION
## Summary

Organizes the database schema into domain-based modules for better maintainability as the schema grows.

Closes #55

## Changes

- Split `server/db/schema.ts` into:
  - `schema/auth.ts` - BetterAuth tables (user, session, account, verification)
  - `schema/storage.ts` - Nexus tables (storageTierEnum, fileStatusEnum, files)
  - `schema/index.ts` - Re-exports all tables and enums
- Updated `drizzle.config.ts` to use glob pattern (`./server/db/schema/*.ts`)
- Cross-domain references import directly from source module

## Test Plan

- [x] `db:generate` produces no diff (schema unchanged)
- [x] `typecheck` passes
- [x] `lint` passes (existing warning unrelated)