### PR TITLE
fix: transform stack traces to show source locations in dev logs

### DIFF
--- a/apps/web/server/lib/logger.test.ts
+++ b/apps/web/server/lib/logger.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { formatStackFrame, parseStackFrame } from './logger';
+
+describe('parseStackFrame', () => {
+    it('parses stack frame with function name', () => {
+        const line = '    at myFunction (/path/to/file.js:10:5)';
+        const result = parseStackFrame(line);
+
+        expect(result).toEqual({
+            functionName: 'myFunction',
+            filePath: '/path/to/file.js',
+            line: 10,
+            column: 5,
+        });
+    });
+
+    it('parses stack frame without function name', () => {
+        const line = '    at /path/to/file.js:10:5';
+        const result = parseStackFrame(line);
+
+        expect(result).toEqual({
+            functionName: undefined,
+            filePath: '/path/to/file.js',
+            line: 10,
+            column: 5,
+        });
+    });
+
+    it('parses stack frame with method call', () => {
+        const line = '    at Object.method (/path/to/file.js:42:15)';
+        const result = parseStackFrame(line);
+
+        expect(result).toEqual({
+            functionName: 'Object.method',
+            filePath: '/path/to/file.js',
+            line: 42,
+            column: 15,
+        });
+    });
+
+    it('parses stack frame with anonymous function', () => {
+        const line = '    at <anonymous> (/path/to/file.js:1:1)';
+        const result = parseStackFrame(line);
+
+        expect(result).toEqual({
+            functionName: '<anonymous>',
+            filePath: '/path/to/file.js',
+            line: 1,
+            column: 1,
+        });
+    });
+
+    it('parses Turbopack-style paths', () => {
+        const line =
+            '    at resolveMiddleware (/Users/thomas/projects/nexus/apps/web/.next/dev/server/chunks/0866b_@trpc_server_dist_09eb4b4a._.js:3810:36)';
+        const result = parseStackFrame(line);
+
+        expect(result).toEqual({
+            functionName: 'resolveMiddleware',
+            filePath:
+                '/Users/thomas/projects/nexus/apps/web/.next/dev/server/chunks/0866b_@trpc_server_dist_09eb4b4a._.js',
+            line: 3810,
+            column: 36,
+        });
+    });
+
+    it('returns null for non-stack-frame lines', () => {
+        expect(parseStackFrame('Error: Something went wrong')).toBeNull();
+        expect(parseStackFrame('Some random text')).toBeNull();
+        expect(parseStackFrame('')).toBeNull();
+    });
+
+    it('returns null for malformed stack frames', () => {
+        expect(parseStackFrame('    at file.js')).toBeNull();
+        expect(parseStackFrame('    at file.js:10')).toBeNull();
+    });
+});
+
+describe('formatStackFrame', () => {
+    it('formats frame with function name', () => {
+        const frame = {
+            functionName: 'myFunction',
+            filePath: '/path/to/file.ts',
+            line: 42,
+            column: 8,
+        };
+
+        expect(formatStackFrame(frame)).toBe(
+            '    at myFunction (/path/to/file.ts:42:8)'
+        );
+    });
+
+    it('formats frame without function name', () => {
+        const frame = {
+            filePath: '/path/to/file.ts',
+            line: 42,
+            column: 8,
+        };
+
+        expect(formatStackFrame(frame)).toBe('    at /path/to/file.ts:42:8');
+    });
+});

--- a/apps/web/server/lib/logger.ts
+++ b/apps/web/server/lib/logger.ts
@@ -1,10 +1,96 @@
+import { findSourceMap } from 'node:module';
+import * as nodeModule from 'node:module';
 import pino from 'pino';
 
 export const isDev = process.env.NODE_ENV === 'development';
 
+// Enable source map support in development for better stack traces
+// setSourceMapsSupport was added in Node.js 22.14+
+if (isDev && 'setSourceMapsSupport' in nodeModule) {
+    (nodeModule.setSourceMapsSupport as (enabled: boolean) => void)(true);
+}
+
 export type ErrorVerbosity = 'minimal' | 'standard' | 'full';
 
 export const errorVerbosity: ErrorVerbosity = isDev ? 'full' : 'standard';
+
+// V8 stack traces have two formats: named function and anonymous
+const STACK_FRAME_REGEX = /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/;
+
+export interface StackFrame {
+    functionName?: string;
+    filePath: string;
+    line: number;
+    column: number;
+}
+
+export function parseStackFrame(line: string): StackFrame | null {
+    const match = line.match(STACK_FRAME_REGEX);
+    if (!match) return null;
+
+    return {
+        functionName: match[1] || undefined,
+        filePath: match[2],
+        line: parseInt(match[3], 10),
+        column: parseInt(match[4], 10),
+    };
+}
+
+export function formatStackFrame(frame: StackFrame): string {
+    const location = `${frame.filePath}:${frame.line}:${frame.column}`;
+    if (frame.functionName) {
+        return `    at ${frame.functionName} (${location})`;
+    }
+    return `    at ${location}`;
+}
+
+/**
+ * Transforms a stack trace by applying source maps to each frame.
+ * Only active in development mode.
+ */
+export function transformStackTrace(
+    stack: string | undefined
+): string | undefined {
+    if (!stack || !isDev) return stack;
+
+    const lines = stack.split('\n');
+    const transformedLines: string[] = [];
+
+    for (const line of lines) {
+        const frame = parseStackFrame(line);
+
+        if (!frame) {
+            transformedLines.push(line);
+            continue;
+        }
+
+        const sourceMap = findSourceMap(frame.filePath);
+        if (!sourceMap) {
+            transformedLines.push(line);
+            continue;
+        }
+
+        // findOrigin returns {} if no mapping found
+        const origin = sourceMap.findOrigin(frame.line, frame.column) as
+            | { source: string; line: number; column: number; name?: string }
+            | undefined;
+        if (!origin || !origin.source) {
+            transformedLines.push(line);
+            continue;
+        }
+
+        const transformedFrame: StackFrame = {
+            functionName: origin.name || frame.functionName,
+            filePath: origin.source,
+            line: origin.line,
+            column: origin.column,
+        };
+
+        transformedLines.push(formatStackFrame(transformedFrame));
+    }
+
+    return transformedLines.join('\n');
+}
 
 const transport = isDev
     ? {

--- a/apps/web/server/trpc/middleware/logging.ts
+++ b/apps/web/server/trpc/middleware/logging.ts
@@ -1,4 +1,9 @@
-import { errorVerbosity, isDev, logger } from '@/server/lib/logger';
+import {
+    errorVerbosity,
+    isDev,
+    logger,
+    transformStackTrace,
+} from '@/server/lib/logger';
 import type { TRPCError } from '@trpc/server';
 
 export interface RequestLogger {
@@ -50,7 +55,7 @@ function formatErrorCause(
     }
 
     if (errorVerbosity === 'full') {
-        formatted.stack = cause.stack;
+        formatted.stack = transformStackTrace(cause.stack);
         formatted.cause = formatErrorCause(cause, depth + 1);
     }
 
@@ -65,7 +70,7 @@ export function formatError(error: TRPCError): FormattedError {
     }
 
     if (errorVerbosity === 'full') {
-        formatted.stack = error.stack;
+        formatted.stack = transformStackTrace(error.stack);
         formatted.cause = formatErrorCause(error, 0);
     }
 

--- a/docs/ai/changelog.md
+++ b/docs/ai/changelog.md
@@ -19,6 +19,40 @@ Recent changes made by AI assistants. **Read this first** to understand recent c
 
 ---
 
+## 2026-01-26
+
+### Session: Source Map Stack Traces (#71)
+
+Added source map transformation for error stack traces in development, making logs show original TypeScript source locations instead of bundled file paths.
+
+**Files Modified:**
+
+- `server/lib/logger.ts` - Added `transformStackTrace()`, `parseStackFrame()`, `formatStackFrame()`, enabled Node.js source map support via `setSourceMapsSupport()`
+- `server/trpc/middleware/logging.ts` - Updated `formatError()` and `formatErrorCause()` to apply stack trace transformation
+- `server/lib/logger.test.ts` - Unit tests for stack frame parsing/formatting
+
+**Key Pattern:**
+
+```typescript
+import { transformStackTrace } from '@/server/lib/logger';
+
+// In formatError:
+if (errorVerbosity === 'full') {
+    formatted.stack = transformStackTrace(error.stack);
+}
+```
+
+The `transformStackTrace()` function:
+
+1. Parses each stack frame line using regex
+2. Looks up source maps via Node.js `findSourceMap()` API
+3. Maps bundled locations back to original source locations
+4. Falls back to original line if no source map found
+
+**Note:** Only active in development mode (`isDev`). Production stack traces are unchanged.
+
+---
+
 ## 2026-01-25
 
 ### Session: Configurable Error Verbosity (#30)


### PR DESCRIPTION
## Summary

Error stack traces in development logs now show original TypeScript source locations instead of bundled file paths.

Closes #71

## Changes

- Added `transformStackTrace()` function that uses Node.js `findSourceMap()` API to translate stack frames
- Added `parseStackFrame()` and `formatStackFrame()` helper functions with unit tests
- Enabled source map support via `setSourceMapsSupport()` in development mode
- Updated `formatError()` and `formatErrorCause()` to apply transformation

## Test Plan

- [x] Unit tests pass for stack frame parsing and formatting
- [x] TypeScript type check passes
- [x] ESLint passes
- [ ] Manual verification: Trigger an error in development and verify stack trace shows original source locations