### PR TITLE
chore: add auto-updating updatedAt timestamps to schema

### DIFF
--- a/apps/web/server/db/schema/auth.ts
+++ b/apps/web/server/db/schema/auth.ts
@@ -1,4 +1,5 @@
 import { pgTable, text, timestamp, boolean } from 'drizzle-orm/pg-core';
+import { timestamps } from './helpers';
 
 // BetterAuth tables
 
@@ -8,16 +9,14 @@ export const user = pgTable('user', {
     email: text('email').notNull().unique(),
     emailVerified: boolean('email_verified').notNull().default(false),
     image: text('image'),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    ...timestamps(),
 });
 
 export const session = pgTable('session', {
     id: text('id').primaryKey(),
     expiresAt: timestamp('expires_at').notNull(),
     token: text('token').notNull().unique(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    ...timestamps(),
     ipAddress: text('ip_address'),
     userAgent: text('user_agent'),
     userId: text('user_id')
@@ -39,8 +38,7 @@ export const account = pgTable('account', {
     refreshTokenExpiresAt: timestamp('refresh_token_expires_at'),
     scope: text('scope'),
     password: text('password'),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    ...timestamps(),
 });
 
 export const verification = pgTable('verification', {
@@ -48,6 +46,5 @@ export const verification = pgTable('verification', {
     identifier: text('identifier').notNull(),
     value: text('value').notNull(),
     expiresAt: timestamp('expires_at').notNull(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    ...timestamps(),
 });

--- a/apps/web/server/db/schema/helpers.ts
+++ b/apps/web/server/db/schema/helpers.ts
@@ -1,0 +1,16 @@
+import { timestamp } from 'drizzle-orm/pg-core';
+
+/**
+ * Standard timestamp columns for all tables.
+ * Use by spreading into table definition: `...timestamps()`.
+ *
+ * - `createdAt` - Set once on insert via database default
+ * - `updatedAt` - Auto-updates on every Drizzle update via $onUpdate()
+ */
+export const timestamps = () => ({
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at')
+        .notNull()
+        .defaultNow()
+        .$onUpdate(() => new Date()),
+});

--- a/apps/web/server/db/schema/index.ts
+++ b/apps/web/server/db/schema/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './storage';
+export * from './helpers';

--- a/apps/web/server/db/schema/schema.test.ts
+++ b/apps/web/server/db/schema/schema.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getTableConfig, type PgTable } from 'drizzle-orm/pg-core';
+import * as schema from './index';
+
+/**
+ * Get all Drizzle table objects from the schema exports.
+ * Tables are identified by having a Symbol.toStringTag of 'PgTable'.
+ */
+function getAllTables(): Array<{ name: string; table: PgTable }> {
+    const tables: Array<{ name: string; table: PgTable }> = [];
+
+    for (const [exportName, exportValue] of Object.entries(schema)) {
+        if (
+            exportValue &&
+            typeof exportValue === 'object' &&
+            Symbol.toStringTag in exportValue &&
+            (exportValue as { [Symbol.toStringTag]: string })[
+                Symbol.toStringTag
+            ] === 'PgTable'
+        ) {
+            tables.push({ name: exportName, table: exportValue as PgTable });
+        }
+    }
+
+    return tables;
+}
+
+describe('schema timestamps', () => {
+    it('all updatedAt columns have $onUpdate defined', () => {
+        const tables = getAllTables();
+        const violations: string[] = [];
+
+        for (const { name, table } of tables) {
+            const config = getTableConfig(table);
+
+            for (const column of config.columns) {
+                if (column.name === 'updated_at') {
+                    // Access the internal config to check for onUpdateFn
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const columnConfig = (column as any).config;
+                    if (!columnConfig?.onUpdateFn) {
+                        violations.push(
+                            `Table "${name}" has updatedAt column without $onUpdate()`
+                        );
+                    }
+                }
+            }
+        }
+
+        expect(violations).toEqual([]);
+    });
+
+    it('timestamps helper produces correct column configuration', () => {
+        const { timestamps } = schema;
+        const cols = timestamps();
+
+        expect(cols.createdAt).toBeDefined();
+        expect(cols.updatedAt).toBeDefined();
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const updatedAtConfig = (cols.updatedAt as any).config;
+        expect(updatedAtConfig.onUpdateFn).toBeDefined();
+        expect(typeof updatedAtConfig.onUpdateFn).toBe('function');
+    });
+});

--- a/apps/web/server/db/schema/storage.ts
+++ b/apps/web/server/db/schema/storage.ts
@@ -8,6 +8,7 @@ import {
     index,
 } from 'drizzle-orm/pg-core';
 import { user } from './auth';
+import { timestamps } from './helpers';
 
 // Nexus domain tables
 
@@ -39,8 +40,7 @@ export const files = pgTable(
             .notNull()
             .default('glacier'),
         status: fileStatusEnum('status').notNull().default('uploading'),
-        createdAt: timestamp('created_at').notNull().defaultNow(),
-        updatedAt: timestamp('updated_at').notNull().defaultNow(),
+        ...timestamps(),
         lastAccessedAt: timestamp('last_accessed_at'),
         deletedAt: timestamp('deleted_at'),
     },
@@ -63,8 +63,7 @@ export const storageUsage = pgTable(
             .notNull()
             .default(0),
         fileCount: integer('file_count').notNull().default(0),
-        createdAt: timestamp('created_at').notNull().defaultNow(),
-        updatedAt: timestamp('updated_at').notNull().defaultNow(),
+        ...timestamps(),
     },
     (table) => [index('storage_usage_user_id_idx').on(table.userId)]
 );

--- a/docs/ai/changelog.md
+++ b/docs/ai/changelog.md
@@ -21,6 +21,35 @@ Recent changes made by AI assistants. **Read this first** to understand recent c
 
 ## 2026-01-26
 
+### Session: Auto-updating timestamps (#78)
+
+Added `timestamps()` helper to schema that auto-updates `updatedAt` on every Drizzle update using `$onUpdate()`. Previously, `updatedAt` only had `defaultNow()` which sets the initial value but doesn't auto-update.
+
+**New Files:**
+
+- `server/db/schema/helpers.ts` - `timestamps()` helper with `createdAt` and `updatedAt`
+- `server/db/schema/schema.test.ts` - Unit test verifying all `updatedAt` columns have `$onUpdate()`
+
+**Files Modified:**
+
+- `server/db/schema/auth.ts` - Refactored 4 tables to use `...timestamps()`
+- `server/db/schema/storage.ts` - Refactored 2 tables to use `...timestamps()`
+- `server/db/schema/index.ts` - Re-exports helpers
+- `docs/ai/conventions.md` - Added "Timestamp Columns" section
+
+**Usage:**
+
+```typescript
+import { timestamps } from './helpers';
+
+export const myTable = pgTable('my_table', {
+    id: text('id').primaryKey(),
+    ...timestamps(),
+});
+```
+
+---
+
 ### Session: S3 Storage Module (#32)
 
 Created foundational S3 storage module at `lib/storage/` for file operations. Establishes the "structured namespace export" pattern for the codebase.


### PR DESCRIPTION
## Summary

Add `timestamps()` helper that uses Drizzle's `$onUpdate()` feature so `updatedAt` columns automatically update on every row modification. Previously, application code had to manually set `updatedAt` on updates.

Closes #78

## Changes

- Create `server/db/schema/helpers.ts` with reusable `timestamps()` helper
- Refactor all 6 tables to use `...timestamps()`: user, session, account, verification, files, storageUsage
- Add unit test verifying all `updatedAt` columns have `$onUpdate()` configured
- Document timestamp pattern in `docs/ai/conventions.md`

## Test Plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (includes new schema tests)
- [ ] Manually verify updates set `updatedAt` (requires local dev environment)