### PR TITLE
feat: add testing utilities for tRPC and S3

### DIFF
--- a/apps/web/lib/storage/testing.ts
+++ b/apps/web/lib/storage/testing.ts
@@ -1,0 +1,94 @@
+/**
+ * Testing utilities for mocking S3 storage operations
+ *
+ * These utilities provide deterministic mocks for `@/lib/storage` functions,
+ * allowing unit tests to run without AWS credentials.
+ *
+ * @example
+ * ```typescript
+ * import { vi, describe, it, beforeEach } from 'vitest';
+ * import { createPresignedMocks } from '@/lib/storage/testing';
+ *
+ * // Mock the storage module
+ * vi.mock('@/lib/storage', () => ({
+ *   s3: createPresignedMocks(),
+ * }));
+ *
+ * describe('file upload', () => {
+ *   it('generates upload URL', async () => {
+ *     const { s3 } = await import('@/lib/storage');
+ *     const url = await s3.presigned.put('user123/file456');
+ *     expect(url).toBe('https://mock-s3.test/test-bucket/user123/file456');
+ *   });
+ * });
+ * ```
+ */
+
+const MOCK_BUCKET = 'test-bucket';
+const MOCK_HOST = 'https://mock-s3.test';
+
+function createMockUrl(key: string): string {
+    return `${MOCK_HOST}/${MOCK_BUCKET}/${key}`;
+}
+
+const presignedMocks = {
+    put: async (key: string): Promise<string> => createMockUrl(key),
+    get: async (key: string): Promise<string> => createMockUrl(key),
+};
+
+const glacierMocks = {
+    restore: async (): Promise<void> => {},
+    checkStatus: async (): Promise<{
+        status: 'available' | 'restoring' | 'archived';
+    }> => ({ status: 'available' }),
+};
+
+const objectsMocks = {
+    remove: async (): Promise<void> => {},
+};
+
+interface MockS3 {
+    presigned: typeof presignedMocks;
+    glacier: typeof glacierMocks;
+    objects: typeof objectsMocks;
+}
+
+/**
+ * Creates mock implementations for the s3 storage module
+ *
+ * Returns an object matching the structure of `@/lib/storage`'s `s3` export.
+ * All mocks are deterministic: the same key always produces the same URL.
+ *
+ * @example
+ * ```typescript
+ * // In your test file:
+ * import { vi } from 'vitest';
+ * import { createPresignedMocks } from '@/lib/storage/testing';
+ *
+ * vi.mock('@/lib/storage', () => ({
+ *   s3: createPresignedMocks(),
+ * }));
+ *
+ * // Now s3.presigned.put('key') returns 'https://mock-s3.test/test-bucket/key'
+ * // And s3.presigned.get('key') returns 'https://mock-s3.test/test-bucket/key'
+ * ```
+ */
+export function createPresignedMocks(): MockS3 {
+    return {
+        presigned: presignedMocks,
+        glacier: glacierMocks,
+        objects: objectsMocks,
+    };
+}
+
+/**
+ * Pre-built mock s3 object for simple mock setups
+ *
+ * @example
+ * ```typescript
+ * vi.mock('@/lib/storage', () => ({
+ *   s3: mockS3,
+ * }));
+ * ```
+ */
+export const mockS3: MockS3 = createPresignedMocks();

--- a/apps/web/server/db/repositories/fixtures.ts
+++ b/apps/web/server/db/repositories/fixtures.ts
@@ -1,7 +1,12 @@
+import * as schema from '../schema';
 import type { File, NewFile } from './files';
 
 export const TEST_USER_ID = 'user_test123';
 export const TEST_FILE_ID = 'file_test456';
+export const TEST_STORAGE_USAGE_ID = 'storage_test789';
+
+export type User = typeof schema.user.$inferSelect;
+export type StorageUsage = typeof schema.storageUsage.$inferSelect;
 
 export function createFileFixture(overrides: Partial<File> = {}): File {
     const now = new Date();
@@ -32,6 +37,36 @@ export function createNewFileFixture(
         size: 1024000,
         mimeType: 'application/pdf',
         s3Key: `${TEST_USER_ID}/${TEST_FILE_ID}`,
+        ...overrides,
+    };
+}
+
+export function createUserFixture(overrides: Partial<User> = {}): User {
+    const now = new Date();
+    const id = overrides.id ?? crypto.randomUUID();
+    return {
+        id,
+        name: 'Test User',
+        email: `${id}@test.example`,
+        emailVerified: false,
+        image: null,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+    };
+}
+
+export function createStorageUsageFixture(
+    overrides: Partial<StorageUsage> = {}
+): StorageUsage {
+    const now = new Date();
+    return {
+        id: overrides.id ?? crypto.randomUUID(),
+        userId: overrides.userId ?? TEST_USER_ID,
+        usedBytes: 0,
+        fileCount: 0,
+        createdAt: now,
+        updatedAt: now,
         ...overrides,
     };
 }

--- a/apps/web/server/trpc/test-utils.ts
+++ b/apps/web/server/trpc/test-utils.ts
@@ -1,0 +1,137 @@
+import type { RequestLogger, LoggingContext } from './middleware/logging';
+import { createMockDb } from '../db/repositories/mocks';
+import { createUserFixture, type User } from '../db/repositories/fixtures';
+import type { Context, LoggedContext } from './init';
+
+/**
+ * Options for creating a mock tRPC context
+ */
+export interface MockContextOptions {
+    /**
+     * Whether to include an authenticated session
+     * @default true
+     */
+    authenticated?: boolean;
+    /**
+     * Partial user data to override defaults
+     * Only used when authenticated is true
+     */
+    user?: Partial<User>;
+}
+
+/**
+ * Mock session matching BetterAuth session structure
+ */
+export interface MockSession {
+    user: User;
+    session: {
+        id: string;
+        token: string;
+        expiresAt: Date;
+        userId: string;
+        createdAt: Date;
+        updatedAt: Date;
+        ipAddress?: string | null;
+        userAgent?: string | null;
+    };
+}
+
+/**
+ * Return type of createMockContext for use in tests
+ */
+export interface MockContext {
+    ctx: LoggedContext;
+    mocks: ReturnType<typeof createMockDb>['mocks'];
+    session: MockSession | null;
+}
+
+/**
+ * Creates a no-op request logger for testing
+ * All methods are functional but don't emit logs
+ */
+function createMockRequestLogger(): RequestLogger {
+    return {
+        setField: () => {},
+        timed: async <T>(_label: string, fn: () => T | Promise<T>) => fn(),
+        time: () => {},
+        timeEnd: () => {},
+    };
+}
+
+/**
+ * Creates a mock tRPC context for unit testing protected procedures
+ *
+ * @example
+ * ```typescript
+ * import { createMockContext } from '@/server/trpc/test-utils';
+ *
+ * describe('myProcedure', () => {
+ *   it('works with authenticated user', () => {
+ *     const { ctx, mocks } = createMockContext();
+ *     // ctx.session is populated with mock user
+ *     // mocks contains database mock functions for assertions
+ *   });
+ *
+ *   it('handles unauthenticated requests', () => {
+ *     const { ctx } = createMockContext({ authenticated: false });
+ *     // ctx.session is null
+ *   });
+ *
+ *   it('uses custom user data', () => {
+ *     const { ctx } = createMockContext({
+ *       user: { id: 'custom-id', name: 'Custom User' }
+ *     });
+ *   });
+ * });
+ * ```
+ */
+export function createMockContext(
+    options: MockContextOptions = {}
+): MockContext {
+    const { authenticated = true, user: userOverrides } = options;
+
+    const { db, mocks } = createMockDb();
+    const requestId = crypto.randomUUID();
+    const log = createMockRequestLogger();
+
+    let session: MockSession | null = null;
+
+    if (authenticated) {
+        const user = createUserFixture(userOverrides);
+        const now = new Date();
+        session = {
+            user,
+            session: {
+                id: crypto.randomUUID(),
+                token: crypto.randomUUID(),
+                expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
+                userId: user.id,
+                createdAt: now,
+                updatedAt: now,
+                ipAddress: null,
+                userAgent: null,
+            },
+        };
+    }
+
+    const loggingContext: LoggingContext = {
+        requestId,
+        log,
+    };
+
+    const baseContext: Context = {
+        db,
+        session,
+    };
+
+    const ctx: LoggedContext = {
+        ...baseContext,
+        ...loggingContext,
+    };
+
+    return {
+        ctx,
+        mocks,
+        session,
+    };
+}

--- a/docs/ai/changelog.md
+++ b/docs/ai/changelog.md
@@ -19,6 +19,40 @@ Recent changes made by AI assistants. **Read this first** to understand recent c
 
 ---
 
+## 2026-01-27
+
+### Session: Testing utilities for tRPC and S3 (#80)
+
+Added test utilities for unit testing backend features that depend on tRPC protected procedures, S3 storage operations, and database records.
+
+**New Files:**
+
+- `server/trpc/test-utils.ts` - `createMockContext()` for testing tRPC procedures with mock authenticated sessions
+- `lib/storage/testing.ts` - `createPresignedMocks()` and `mockS3` for mocking S3 operations
+
+**Files Modified:**
+
+- `server/db/repositories/fixtures.ts` - Added `createUserFixture()` and `createStorageUsageFixture()`
+
+**Usage:**
+
+```typescript
+// Testing tRPC procedures
+import { createMockContext } from '@/server/trpc/test-utils';
+
+const { ctx, mocks } = createMockContext(); // authenticated by default
+const { ctx: unauthCtx } = createMockContext({ authenticated: false });
+
+// Testing S3 operations
+import { createPresignedMocks, mockS3 } from '@/lib/storage/testing';
+
+vi.mock('@/lib/storage', () => ({
+    s3: createPresignedMocks(),
+}));
+```
+
+---
+
 ## 2026-01-26
 
 ### Session: Auto-updating timestamps (#78)


### PR DESCRIPTION
## Summary

Closes #80

Add testing utilities for unit testing backend features that depend on tRPC protected procedures, S3 storage operations, and database records.

## Changes

- `createMockContext()` in `server/trpc/test-utils.ts` for testing protected procedures
- `createUserFixture()` and `createStorageUsageFixture()` in `server/db/repositories/fixtures.ts`
- `createPresignedMocks()` and `mockS3` in `lib/storage/testing.ts` for mocking S3

## Test Plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] Review that mock context matches LoggedContext type
- [ ] Review that S3 mocks match s3 namespace structure