### PR TITLE
feat(trpc-devtools): add resizable request/response panels

### DIFF
--- a/packages/trpc-studio/src/components/studio/procedure-view.tsx
+++ b/packages/trpc-studio/src/components/studio/procedure-view.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { motion } from 'framer-motion';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ResizablePanels } from '@/components/ui/resizable-panels';
 import { Skeleton } from '@/components/ui/skeleton';
 import { SchemaForm } from './schema-form';
 import { ResponseViewer } from './response-viewer';
@@ -138,39 +139,41 @@ export function ProcedureView({
                 </motion.div>
             )}
 
-            {/* Main content grid */}
-            <div className="flex-1 grid grid-cols-2 gap-4 min-h-0">
-                {/* Input panel */}
-                <Card className="flex flex-col overflow-hidden">
-                    <CardHeader className="py-3 px-4 border-b border-border">
-                        <CardTitle className="text-sm font-medium">
-                            Request
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent className="flex-1 p-4 overflow-auto">
-                        <SchemaForm
-                            schema={procedure.inputSchema}
-                            value={input}
-                            onChange={setInput}
-                            onSubmit={handleSubmit}
-                            isLoading={isLoading}
-                            procedureType={procedure.type}
-                        />
-                    </CardContent>
-                </Card>
-
-                {/* Response panel */}
-                <Card className="flex flex-col overflow-hidden">
-                    <CardHeader className="py-3 px-4 border-b border-border">
-                        <CardTitle className="text-sm font-medium">
-                            Response
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent className="flex-1 p-0 overflow-hidden">
-                        <ResponseViewer response={response} />
-                    </CardContent>
-                </Card>
-            </div>
+            {/* Main content - resizable panels */}
+            <ResizablePanels
+                className="flex-1"
+                first={
+                    <Card className="flex flex-col overflow-hidden h-full">
+                        <CardHeader className="py-3 px-4 border-b border-border">
+                            <CardTitle className="text-sm font-medium">
+                                Request
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="flex-1 p-4 overflow-auto">
+                            <SchemaForm
+                                schema={procedure.inputSchema}
+                                value={input}
+                                onChange={setInput}
+                                onSubmit={handleSubmit}
+                                isLoading={isLoading}
+                                procedureType={procedure.type}
+                            />
+                        </CardContent>
+                    </Card>
+                }
+                second={
+                    <Card className="flex flex-col overflow-hidden h-full">
+                        <CardHeader className="py-3 px-4 border-b border-border">
+                            <CardTitle className="text-sm font-medium">
+                                Response
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="flex-1 p-0 overflow-hidden">
+                            <ResponseViewer response={response} />
+                        </CardContent>
+                    </Card>
+                }
+            />
         </motion.div>
     );
 }
@@ -184,41 +187,43 @@ export function ProcedureViewSkeleton() {
                 <Skeleton className="h-6 w-48" />
             </div>
 
-            {/* Main content grid */}
-            <div className="flex-1 grid grid-cols-2 gap-4 min-h-0">
-                {/* Request panel skeleton */}
-                <Card className="flex flex-col overflow-hidden">
-                    <CardHeader className="py-3 px-4 border-b border-border">
-                        <CardTitle className="text-sm font-medium">
-                            Request
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent className="flex-1 p-4 space-y-4">
-                        {/* Schema toggle skeleton */}
-                        <Skeleton className="h-4 w-24" />
-                        {/* Schema box skeleton */}
-                        <Skeleton className="h-24 w-full rounded-md" />
-                        {/* Input label skeleton */}
-                        <Skeleton className="h-4 w-20" />
-                        {/* Textarea skeleton */}
-                        <Skeleton className="h-28 w-full rounded-md" />
-                        {/* Button skeleton */}
-                        <Skeleton className="h-11 w-full rounded-md" />
-                    </CardContent>
-                </Card>
-
-                {/* Response panel skeleton */}
-                <Card className="flex flex-col overflow-hidden">
-                    <CardHeader className="py-3 px-4 border-b border-border">
-                        <CardTitle className="text-sm font-medium">
-                            Response
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent className="flex-1 p-4 flex items-center justify-center">
-                        <Skeleton className="h-4 w-56" />
-                    </CardContent>
-                </Card>
-            </div>
+            {/* Main content - resizable panels skeleton */}
+            <ResizablePanels
+                className="flex-1"
+                first={
+                    <Card className="flex flex-col overflow-hidden h-full">
+                        <CardHeader className="py-3 px-4 border-b border-border">
+                            <CardTitle className="text-sm font-medium">
+                                Request
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="flex-1 p-4 space-y-4">
+                            {/* Schema toggle skeleton */}
+                            <Skeleton className="h-4 w-24" />
+                            {/* Schema box skeleton */}
+                            <Skeleton className="h-24 w-full rounded-md" />
+                            {/* Input label skeleton */}
+                            <Skeleton className="h-4 w-20" />
+                            {/* Textarea skeleton */}
+                            <Skeleton className="h-28 w-full rounded-md" />
+                            {/* Button skeleton */}
+                            <Skeleton className="h-11 w-full rounded-md" />
+                        </CardContent>
+                    </Card>
+                }
+                second={
+                    <Card className="flex flex-col overflow-hidden h-full">
+                        <CardHeader className="py-3 px-4 border-b border-border">
+                            <CardTitle className="text-sm font-medium">
+                                Response
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="flex-1 p-4 flex items-center justify-center">
+                            <Skeleton className="h-4 w-56" />
+                        </CardContent>
+                    </Card>
+                }
+            />
         </div>
     );
 }

--- a/packages/trpc-studio/src/components/ui/index.ts
+++ b/packages/trpc-studio/src/components/ui/index.ts
@@ -13,3 +13,4 @@ export { Badge, type BadgeProps } from './badge';
 export { ScrollArea } from './scroll-area';
 export { Skeleton } from './skeleton';
 export { Spinner, type SpinnerProps } from './spinner';
+export { ResizablePanels } from './resizable-panels';

--- a/packages/trpc-studio/src/components/ui/resizable-panels.tsx
+++ b/packages/trpc-studio/src/components/ui/resizable-panels.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { loadPanelSizes, savePanelSizes, type PanelSizes } from '@/lib/storage';
+
+const MIN_PANEL_SIZE = 200; // px
+const RESIZE_STEP = 10; // px for keyboard navigation
+const DEFAULT_SIZES: PanelSizes = { horizontal: 50, vertical: 50 };
+
+interface ResizablePanelsProps {
+    first: React.ReactNode;
+    second: React.ReactNode;
+    className?: string;
+}
+
+export function ResizablePanels({
+    first,
+    second,
+    className,
+}: ResizablePanelsProps) {
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    const sizesRef = React.useRef<PanelSizes>(DEFAULT_SIZES);
+    const [sizes, setSizes] = React.useState<PanelSizes>(DEFAULT_SIZES);
+    const [isHorizontal, setIsHorizontal] = React.useState(true);
+    const [isDragging, setIsDragging] = React.useState(false);
+
+    // Keep ref in sync for use in pointer up handler
+    React.useEffect(() => {
+        sizesRef.current = sizes;
+    }, [sizes]);
+
+    // Load persisted sizes on mount
+    React.useEffect(() => {
+        setSizes(loadPanelSizes());
+    }, []);
+
+    // Handle responsive layout switching
+    React.useEffect(() => {
+        const checkWidth = () => {
+            setIsHorizontal(window.innerWidth >= 768);
+        };
+
+        checkWidth();
+        window.addEventListener('resize', checkWidth);
+        return () => window.removeEventListener('resize', checkWidth);
+    }, []);
+
+    // Get the current size based on layout direction
+    const currentSize = isHorizontal ? sizes.horizontal : sizes.vertical;
+
+    const handlePointerDown = React.useCallback(
+        (e: React.PointerEvent<HTMLDivElement>) => {
+            e.preventDefault();
+            const target = e.currentTarget;
+            target.setPointerCapture(e.pointerId);
+            setIsDragging(true);
+        },
+        []
+    );
+
+    const handlePointerMove = React.useCallback(
+        (e: React.PointerEvent<HTMLDivElement>) => {
+            if (!isDragging || !containerRef.current) return;
+
+            const container = containerRef.current;
+            const rect = container.getBoundingClientRect();
+
+            let newPercentage: number;
+
+            if (isHorizontal) {
+                const x = e.clientX - rect.left;
+                const minPercent = (MIN_PANEL_SIZE / rect.width) * 100;
+                const maxPercent = 100 - minPercent;
+                newPercentage = Math.max(
+                    minPercent,
+                    Math.min(maxPercent, (x / rect.width) * 100)
+                );
+            } else {
+                const y = e.clientY - rect.top;
+                const minPercent = (MIN_PANEL_SIZE / rect.height) * 100;
+                const maxPercent = 100 - minPercent;
+                newPercentage = Math.max(
+                    minPercent,
+                    Math.min(maxPercent, (y / rect.height) * 100)
+                );
+            }
+
+            setSizes((prev) => ({
+                ...prev,
+                [isHorizontal ? 'horizontal' : 'vertical']: newPercentage,
+            }));
+        },
+        [isDragging, isHorizontal]
+    );
+
+    const handlePointerUp = React.useCallback(
+        (e: React.PointerEvent<HTMLDivElement>) => {
+            e.currentTarget.releasePointerCapture(e.pointerId);
+            setIsDragging(false);
+            // Save only when drag completes to avoid excessive localStorage writes
+            savePanelSizes(sizesRef.current);
+        },
+        []
+    );
+
+    const handleDoubleClick = React.useCallback(() => {
+        const updated = {
+            ...sizesRef.current,
+            [isHorizontal ? 'horizontal' : 'vertical']: 50,
+        };
+        setSizes(updated);
+        savePanelSizes(updated);
+    }, [isHorizontal]);
+
+    const handleKeyDown = React.useCallback(
+        (e: React.KeyboardEvent<HTMLDivElement>) => {
+            const container = containerRef.current;
+            if (!container) return;
+
+            const rect = container.getBoundingClientRect();
+            let delta = 0;
+
+            if (isHorizontal) {
+                if (e.key === 'ArrowLeft') delta = -RESIZE_STEP;
+                else if (e.key === 'ArrowRight') delta = RESIZE_STEP;
+            } else {
+                if (e.key === 'ArrowUp') delta = -RESIZE_STEP;
+                else if (e.key === 'ArrowDown') delta = RESIZE_STEP;
+            }
+
+            if (delta === 0) return;
+
+            e.preventDefault();
+
+            const dimension = isHorizontal ? rect.width : rect.height;
+            const deltaPercent = (delta / dimension) * 100;
+
+            setSizes((prev) => {
+                const key = isHorizontal ? 'horizontal' : 'vertical';
+                const minPercent = (MIN_PANEL_SIZE / dimension) * 100;
+                const maxPercent = 100 - minPercent;
+                const newValue = Math.max(
+                    minPercent,
+                    Math.min(maxPercent, prev[key] + deltaPercent)
+                );
+
+                const updated = { ...prev, [key]: newValue };
+                savePanelSizes(updated);
+                return updated;
+            });
+        },
+        [isHorizontal]
+    );
+
+    return (
+        <div
+            ref={containerRef}
+            className={cn(
+                'flex min-h-0',
+                isHorizontal ? 'flex-row' : 'flex-col',
+                className
+            )}
+        >
+            {/* First panel */}
+            <div
+                className="min-h-0 min-w-0 overflow-hidden"
+                style={{
+                    [isHorizontal ? 'width' : 'height']:
+                        `calc(${currentSize}% - 4px)`,
+                }}
+            >
+                {first}
+            </div>
+
+            {/* Divider */}
+            <div
+                role="separator"
+                aria-orientation={isHorizontal ? 'vertical' : 'horizontal'}
+                aria-valuenow={Math.round(currentSize)}
+                aria-valuemin={10}
+                aria-valuemax={90}
+                tabIndex={0}
+                className={cn(
+                    'group relative flex-shrink-0 select-none',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                    isHorizontal
+                        ? 'w-2 cursor-col-resize'
+                        : 'h-2 cursor-row-resize',
+                    isDragging && 'cursor-grabbing'
+                )}
+                onPointerDown={handlePointerDown}
+                onPointerMove={handlePointerMove}
+                onPointerUp={handlePointerUp}
+                onPointerCancel={handlePointerUp}
+                onDoubleClick={handleDoubleClick}
+                onKeyDown={handleKeyDown}
+                style={{ touchAction: 'none' }}
+            >
+                {/* Visual handle */}
+                <div
+                    className={cn(
+                        'absolute rounded-full bg-border transition-colors',
+                        'group-hover:bg-primary group-focus-visible:bg-primary',
+                        isDragging && 'bg-primary',
+                        isHorizontal
+                            ? 'left-1/2 top-1/2 h-8 w-1 -translate-x-1/2 -translate-y-1/2'
+                            : 'left-1/2 top-1/2 h-1 w-8 -translate-x-1/2 -translate-y-1/2'
+                    )}
+                />
+            </div>
+
+            {/* Second panel */}
+            <div
+                className="min-h-0 min-w-0 overflow-hidden"
+                style={{
+                    [isHorizontal ? 'width' : 'height']:
+                        `calc(${100 - currentSize}% - 4px)`,
+                }}
+            >
+                {second}
+            </div>
+        </div>
+    );
+}

--- a/packages/trpc-studio/src/lib/storage.ts
+++ b/packages/trpc-studio/src/lib/storage.ts
@@ -1,6 +1,7 @@
 import type { TRPCRequest, TRPCResponse } from './request';
 
 const STORAGE_KEY = 'trpc-studio-history';
+const PANEL_SIZES_KEY = 'trpc-studio-panel-sizes';
 const MAX_HISTORY_ITEMS = 50;
 
 export interface HistoryItem {
@@ -93,5 +94,49 @@ export function deleteHistoryItem(id: string): void {
         localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
     } catch {
         // Ignore errors
+    }
+}
+
+// Panel sizes storage
+
+export interface PanelSizes {
+    horizontal: number; // percentage for first panel (0-100)
+    vertical: number;
+}
+
+const DEFAULT_PANEL_SIZES: PanelSizes = { horizontal: 50, vertical: 50 };
+
+export function loadPanelSizes(): PanelSizes {
+    if (typeof window === 'undefined') return DEFAULT_PANEL_SIZES;
+
+    try {
+        const stored = localStorage.getItem(PANEL_SIZES_KEY);
+        if (!stored) return DEFAULT_PANEL_SIZES;
+
+        const parsed = JSON.parse(stored);
+        if (
+            typeof parsed.horizontal !== 'number' ||
+            typeof parsed.vertical !== 'number'
+        ) {
+            return DEFAULT_PANEL_SIZES;
+        }
+
+        // Validate ranges
+        return {
+            horizontal: Math.max(10, Math.min(90, parsed.horizontal)),
+            vertical: Math.max(10, Math.min(90, parsed.vertical)),
+        };
+    } catch {
+        return DEFAULT_PANEL_SIZES;
+    }
+}
+
+export function savePanelSizes(sizes: PanelSizes): void {
+    if (typeof window === 'undefined') return;
+
+    try {
+        localStorage.setItem(PANEL_SIZES_KEY, JSON.stringify(sizes));
+    } catch {
+        // Storage might be full or disabled
     }
 }


### PR DESCRIPTION
## Summary

Add custom ResizablePanels component that allows users to resize the request and response panels with a draggable divider.

Closes #94

## Changes

- **New component**: `ResizablePanels` in `src/components/ui/resizable-panels.tsx`
- **Updated**: `procedure-view.tsx` to use the new component
- **Updated**: `storage.ts` with panel size persistence utilities

## Features

- Draggable divider with grab cursor and accent color highlight on drag
- Pointer events for unified mouse and touch support
- Panel sizes persist in localStorage (separate values for horizontal/vertical layouts)
- Minimum panel size of 200px enforced
- Double-click divider resets to 50/50 split
- Auto-switch to vertical layout below 768px viewport width
- Keyboard accessibility (Left/Right arrows for horizontal, Up/Down for vertical)
- ARIA attributes (`role=separator`, `aria-valuenow`, etc.)
- Graceful handling of invalid localStorage data

## Test Plan

- [ ] Drag divider to resize panels - should work smoothly
- [ ] Resize browser below 768px - should switch to vertical layout
- [ ] Refresh page - panel sizes should persist
- [ ] Double-click divider - should reset to 50/50
- [ ] Focus divider and use arrow keys - should resize by 10px increments
- [ ] Touch device - drag should work on mobile