### PR TITLE
feat: agent-triggered visual-compare with autonomous mode

### DIFF
--- a/.claude/agents/work-agent.md
+++ b/.claude/agents/work-agent.md
@@ -7,3 +7,37 @@ tools: Bash, Task, AskUserQuestion, Read, Grep, Glob, Edit, Write
 You are an interactive development agent that helps implement GitHub issues.
 
 **Critical:** When you need user input or decisions, you MUST use the AskUserQuestion tool to present options interactively. Never just output numbered text options - always use the AskUserQuestion tool for any user choices.
+
+## Visual Compare Integration
+
+When modifying CSS variables or design tokens during implementation, you can invoke `visual-compare-agent` to generate and compare options visually. Use autonomous mode for programmatic changes; use interactive mode when the user should choose.
+
+**Autonomous** (agent picks the best option):
+
+```
+Task tool call:
+  subagent_type: visual-compare-agent
+  prompt: |
+    Compare CSS variable options:
+    - variable: --destructive
+    - file: apps/web/app/globals.css
+    - mode: dark
+    - context: error states and destructive action buttons
+    - autonomous: true
+```
+
+**Interactive** (user picks via AskUserQuestion):
+
+```
+Task tool call:
+  subagent_type: visual-compare-agent
+  prompt: |
+    Compare CSS variable options:
+    - variable: --destructive
+    - file: apps/web/app/globals.css
+    - mode: dark
+    - context: error states and destructive action buttons
+    - autonomous: false
+```
+
+Then present the returned OPTIONS to the user and resume the agent with the choice.

--- a/.claude/skills/visual-compare/SKILL.md
+++ b/.claude/skills/visual-compare/SKILL.md
@@ -34,3 +34,21 @@ Resume the same agent using the Task tool's `resume` parameter:
 - **prompt:** `User chose: <selected option label>. Apply the value to the target CSS file, clean up data.json, and return a final summary.`
 
 Report the final summary back to the user.
+
+## Autonomous Mode (programmatic use)
+
+When another agent invokes visual-compare-agent with `autonomous: true`, the entire flow collapses into a single Task invocation — no user interaction or resume needed.
+
+```
+Task tool call:
+  subagent_type: visual-compare-agent
+  prompt: |
+    Compare CSS variable options:
+    - variable: --destructive
+    - file: apps/web/app/globals.css
+    - mode: dark
+    - context: error states and destructive action buttons
+    - autonomous: true
+```
+
+The agent generates options, picks the best fit, applies it, cleans up data.json, and returns a `CHOSEN: / APPLIED:` summary. See the agent definition for full details on selection criteria and return format.

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -253,7 +253,23 @@ If user selected "Resume":
 
     If migrations fail, show the error and ask user how to proceed.
 
-6. **If implementation reveals issues:**
+6. **For CSS variable or design token changes**, invoke `visual-compare-agent` to visually compare options:
+
+    ```
+    Task tool call:
+      subagent_type: visual-compare-agent
+      prompt: |
+        Compare CSS variable options:
+        - variable: <variable name>
+        - file: <path to CSS file>
+        - mode: <light | dark | both>
+        - context: <what the variable is used for>
+        - autonomous: true
+    ```
+
+    Use `autonomous: true` when the change is part of a larger implementation and the agent should pick the best option. Use `autonomous: false` when the user should review and choose.
+
+7. **If implementation reveals issues:**
     - Scope creep: Note it, stay focused on acceptance criteria
     - Blockers: Ask user how to proceed
     - New issues discovered: Offer to create follow-up issues


### PR DESCRIPTION
## Summary

Enables other agents to programmatically invoke `visual-compare-agent` via the Task tool and adds an autonomous mode where the agent picks the best design token option without user interaction.

Closes #120

## Changes

- **visual-compare-agent.md**: Added "Programmatic Invocation" section with structured prompt template, autonomous mode selection criteria, and return formats (CHOSEN/APPLIED). Extended Step 5 to branch between interactive and autonomous flows.
- **work-agent.md**: Added "Visual Compare Integration" section with examples for both autonomous and interactive invocation.
- **visual-compare/SKILL.md**: Added "Autonomous Mode" section documenting the single-invocation flow.
- **work/SKILL.md**: Added step 6 in Implementation for CSS variable/design token changes with visual-compare-agent invocation.

## Test Plan

- [x] Verify `/visual-compare` still works interactively (backward-compatible)
- [x] Test autonomous invocation by spawning `visual-compare-agent` with `autonomous: true` from another agent context
- [x] Confirm the structured prompt template is parseable by the agent