### PR TITLE
feat: self-extending sampler generation for visual-compare agent

### DIFF
--- a/.claude/skills/visual-compare/SKILL.md
+++ b/.claude/skills/visual-compare/SKILL.md
@@ -14,9 +14,10 @@ Two-phase workflow. AskUserQuestion does not work reliably in subprocess agents,
 Use the Task tool to spawn the comparison agent:
 
 - **subagent_type:** `visual-compare-agent`
-- **prompt:** `$ARGUMENTS`
+- **max_turns:** `20`
+- **prompt:** `$ARGUMENTS\n\nRemember: complete Step 3 (Sampler Check) before generating options.`
 
-The agent will research the target CSS variable, generate 4 options, write them to the preview page (`data.json`), and return a structured summary with the option labels and descriptions.
+The agent will check the sampler registry (generating a new sampler if the target token isn't covered), then generate 4 options, write them to the preview page (`data.json`), and return a structured summary with the option labels and descriptions.
 
 ## Phase 2: User Picks (main thread)
 
@@ -42,6 +43,7 @@ When another agent invokes visual-compare-agent with `autonomous: true`, the ent
 ```
 Task tool call:
   subagent_type: visual-compare-agent
+  max_turns: 20
   prompt: |
     Compare CSS variable options:
     - variable: --destructive
@@ -49,6 +51,8 @@ Task tool call:
     - mode: dark
     - context: error states and destructive action buttons
     - autonomous: true
+
+    Remember: complete Step 3 (Sampler Check) before generating options.
 ```
 
-The agent generates options, picks the best fit, applies it, cleans up data.json, and returns a `CHOSEN: / APPLIED:` summary. See the agent definition for full details on selection criteria and return format.
+The agent generates options, picks the best fit, applies it, cleans up data.json, and returns a `SAMPLER: / CHOSEN: / APPLIED:` summary. See the agent definition for full details on selection criteria and return format.

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -258,6 +258,7 @@ If user selected "Resume":
     ```
     Task tool call:
       subagent_type: visual-compare-agent
+      max_turns: 20
       prompt: |
         Compare CSS variable options:
         - variable: <variable name>
@@ -265,6 +266,8 @@ If user selected "Resume":
         - mode: <light | dark | both>
         - context: <what the variable is used for>
         - autonomous: true
+
+        Remember: complete Step 3 (Sampler Check) before generating options.
     ```
 
     Use `autonomous: true` when the change is part of a larger implementation and the agent should pick the best option. Use `autonomous: false` when the user should review and choose.

--- a/apps/web/app/dev/preview/samplers/FocusRings.tsx
+++ b/apps/web/app/dev/preview/samplers/FocusRings.tsx
@@ -1,0 +1,41 @@
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+
+/**
+ * Sampler that displays interactive elements with focus rings always visible.
+ * Uses the same ring utilities as production components (border-ring, ring-ring/50,
+ * ring-[3px]) but applied unconditionally so the --ring color is visible without
+ * requiring keyboard focus.
+ */
+export function FocusRings() {
+    const ringClasses = 'border-ring ring-ring/50 ring-[3px]';
+
+    return (
+        <div className="space-y-3">
+            <p className="text-xs font-medium text-muted-foreground">
+                Focus rings
+            </p>
+            <div className="flex flex-wrap items-center gap-3">
+                <Button size="sm" className={ringClasses}>
+                    Button
+                </Button>
+                <Button variant="outline" size="sm" className={ringClasses}>
+                    Outline
+                </Button>
+                <Button variant="secondary" size="sm" className={ringClasses}>
+                    Secondary
+                </Button>
+            </div>
+            <div className="max-w-xs">
+                <Input placeholder="Input field" className={ringClasses} />
+            </div>
+            <div className="flex items-center gap-2">
+                <Checkbox id="focus-demo" className={ringClasses} />
+                <label htmlFor="focus-demo" className="text-sm text-foreground">
+                    Checkbox
+                </label>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/app/dev/preview/samplers/index.ts
+++ b/apps/web/app/dev/preview/samplers/index.ts
@@ -4,6 +4,7 @@ import { BadgeVariants } from './BadgeVariants';
 import { ButtonVariants } from './ButtonVariants';
 import { ColorSwatches } from './ColorSwatches';
 import { ComposedComponents } from './ComposedComponents';
+import { FocusRings } from './FocusRings';
 import { TextColors } from './TextColors';
 
 interface SamplerEntry {
@@ -16,6 +17,7 @@ export const allSamplers: SamplerEntry[] = [
     { name: 'buttons', component: ButtonVariants },
     { name: 'badges', component: BadgeVariants },
     { name: 'text', component: TextColors },
+    { name: 'focus-rings', component: FocusRings },
     { name: 'composed', component: ComposedComponents },
 ];
 


### PR DESCRIPTION
## Summary

Closes #121

- Adds **Step 2.5: Sampler Discovery & Generation** to the visual-compare agent, between Research and Generate Options
- Agent now automatically scans `samplers/` directory and `index.ts` to discover existing samplers
- Infers the target CSS variable's token category via variable name + CSS context analysis (with a reference mapping table)
- Generates new sampler components on the fly when no matching one exists, following existing patterns
- Replaces hardcoded sampler list with dynamic discovery instruction
- Adds `SAMPLER:` line to both interactive and autonomous return formats
- Clarifies that generated samplers persist through data.json cleanup

## Changes
- `.claude/agents/visual-compare-agent.md` — new Step 2.5 with discovery, inference, and generation instructions; updated return formats; updated sampler list reference; updated cleanup step

## Test Plan
- [x] Invoke `/visual-compare` with a variable that has an existing sampler (e.g., `--destructive`) — verify agent uses existing samplers without generating new ones
- [x] Invoke `/visual-compare` with a variable that lacks a sampler (e.g., `--ring`, `--chart-1`) — verify agent generates a new sampler component and registers it
- [x] After generation, verify HMR picks up the new sampler file without dev server restart
- [x] Invoke autonomous mode from work agent — verify `SAMPLER:` line appears in return format