### PR TITLE
feat: runtime CSS injection for trpc-devtools

### DIFF
--- a/apps/web/app/dev/studio/page.tsx
+++ b/apps/web/app/dev/studio/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { TRPCStudio } from 'trpc-devtools';
-import 'trpc-devtools/styles.css';
 
 export default function StudioPage() {
     return (

--- a/packages/trpc-studio/README.md
+++ b/packages/trpc-studio/README.md
@@ -49,7 +49,6 @@ Then visit `/api/trpc-studio` to view the full studio UI.
 ```tsx
 // app/dev/studio/page.tsx
 import { TRPCStudio } from 'trpc-devtools';
-import 'trpc-devtools/styles.css';
 
 export default function StudioPage() {
     return (
@@ -57,6 +56,8 @@ export default function StudioPage() {
     );
 }
 ```
+
+> **Note:** CSS is automatically injected at runtime — no separate CSS import needed.
 
 ## API Reference
 
@@ -68,7 +69,6 @@ import { createTRPCStudio, introspectRouter } from 'trpc-devtools/server';
 
 // Client-side (React components)
 import { TRPCStudio } from 'trpc-devtools';
-import 'trpc-devtools/styles.css';
 ```
 
 ### `createTRPCStudio(config)`

--- a/packages/trpc-studio/build/embed-css-esbuild-plugin.ts
+++ b/packages/trpc-studio/build/embed-css-esbuild-plugin.ts
@@ -1,0 +1,58 @@
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import type { Plugin } from 'esbuild';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * esbuild plugin that intercepts CSS imports and replaces them with
+ * runtime CSS injection code. The compiled CSS (from Tailwind CLI)
+ * is embedded as a string constant in the JS bundle.
+ *
+ * At runtime, the CSS is injected into a <style> tag in <head> on
+ * first import, with deduplication via a data attribute.
+ */
+export function embedCssPlugin(): Plugin {
+    const cssPath = join(__dirname, '..', 'dist', 'styles.css');
+
+    return {
+        name: 'embed-css',
+        setup(build) {
+            build.onResolve({ filter: /\.css$/ }, () => ({
+                path: 'embedded-css',
+                namespace: 'embed-css',
+            }));
+
+            build.onLoad({ filter: /.*/, namespace: 'embed-css' }, () => {
+                if (!existsSync(cssPath)) {
+                    console.warn(
+                        '[embed-css] dist/styles.css not found. Tailwind CLI must run before tsup.'
+                    );
+                    return {
+                        contents: `
+                            console.warn('trpc-devtools: CSS not embedded. Build may be incomplete.');
+                        `,
+                        loader: 'js',
+                    };
+                }
+
+                const css = readFileSync(cssPath, 'utf-8');
+
+                return {
+                    contents: `
+                        const STYLE_ID = 'trpc-devtools-styles';
+
+                        if (typeof document !== 'undefined' && !document.querySelector('style[data-' + STYLE_ID + ']')) {
+                            const style = document.createElement('style');
+                            style.setAttribute('data-' + STYLE_ID, '');
+                            style.textContent = ${JSON.stringify(css)};
+                            document.head.appendChild(style);
+                        }
+                    `,
+                    loader: 'js',
+                };
+            });
+        },
+    };
+}

--- a/packages/trpc-studio/package.json
+++ b/packages/trpc-studio/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trpc-devtools",
-    "version": "0.1.7",
+    "version": "0.2.0",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/packages/trpc-studio/src/styles/globals.css
+++ b/packages/trpc-studio/src/styles/globals.css
@@ -1,4 +1,6 @@
-@import 'tailwindcss';
+@layer theme, base, components, utilities;
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/utilities.css' layer(utilities);
 
 @theme {
     /* Custom theme colors */

--- a/packages/trpc-studio/tsup.lib.config.ts
+++ b/packages/trpc-studio/tsup.lib.config.ts
@@ -1,23 +1,6 @@
 import { defineConfig } from 'tsup';
-import type { Plugin } from 'esbuild';
 import { embedAssetsPlugin } from './build/embed-assets-esbuild-plugin';
-
-// Plugin to ignore CSS imports (handled by Tailwind CLI)
-function ignoreCssPlugin(): Plugin {
-    return {
-        name: 'ignore-css',
-        setup(build) {
-            build.onResolve({ filter: /\.css$/ }, () => ({
-                path: 'ignored',
-                namespace: 'ignore-css',
-            }));
-            build.onLoad({ filter: /.*/, namespace: 'ignore-css' }, () => ({
-                contents: '',
-                loader: 'js',
-            }));
-        },
-    };
-}
+import { embedCssPlugin } from './build/embed-css-esbuild-plugin';
 
 export default defineConfig({
     entry: { index: 'src/index.ts', server: 'src/server.ts' },
@@ -28,7 +11,7 @@ export default defineConfig({
     treeshake: true,
     minify: false,
     dts: true,
-    esbuildPlugins: [ignoreCssPlugin(), embedAssetsPlugin()],
+    esbuildPlugins: [embedCssPlugin(), embedAssetsPlugin()],
     esbuildOptions(options) {
         options.jsx = 'automatic';
         options.alias = { '@': './src' };


### PR DESCRIPTION
## Summary

Consumers no longer need `import 'trpc-devtools/styles.css'` — CSS is automatically injected at runtime.

Closes #107

## Changes

- **New `embed-css-esbuild-plugin`**: Reads compiled `dist/styles.css` at build time and embeds it as a string constant in the JS bundle. At runtime, injects CSS into `<head>` via a `<style>` tag with deduplication via `data-trpc-devtools-styles` attribute
- **Stripped Tailwind preflight**: Replaced `@import 'tailwindcss'` with selective `tailwindcss/theme.css` + `tailwindcss/utilities.css` imports, eliminating global `*`, `html`, `body` resets that pollute consumer styles
- **Updated lib build config**: Replaced `ignoreCssPlugin()` with `embedCssPlugin()` in `tsup.lib.config.ts`
- **Backwards compatible**: `import 'trpc-devtools/styles.css'` still works (file is still produced by Tailwind CLI)
- **Version bump**: 0.1.7 → 0.2.0

## Test Plan

- [x] `pnpm check` passes (lint + build + tests across all packages)
- [x] `dist/styles.css` contains no preflight resets (no `box-sizing`, `margin: 0`, global `html`/`body`)
- [x] `dist/index.js` contains embedded CSS string and `trpc-devtools-styles` deduplication logic
- [x] Next.js build succeeds with the CSS import removed from `apps/web/app/dev/studio/page.tsx`
- [x] Manual: verify `/dev/studio` renders correctly with styling intact