### PR TITLE
feat: add showMarkers toggle for stack trace collapsed markers

### DIFF
--- a/apps/web/server/lib/logger/__tests__/format.test.ts
+++ b/apps/web/server/lib/logger/__tests__/format.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { formatStackTrace } from '../patches/format';
+import type { StackTraceConfig } from '../config';
+
+function makeCallSite(
+    file: string,
+    line: number,
+    column: number,
+    functionName: string | null = null
+): NodeJS.CallSite {
+    return {
+        getFileName: () => file,
+        getScriptNameOrSourceURL: () => file,
+        getLineNumber: () => line,
+        getColumnNumber: () => column,
+        getFunctionName: () => functionName,
+        getMethodName: () => null,
+        isAsync: () => false,
+        getTypeName: () => null,
+        getThis: () => undefined,
+        getFunction: () => undefined,
+        getEvalOrigin: () => undefined,
+        isToplevel: () => false,
+        isEval: () => false,
+        isNative: () => false,
+        isConstructor: () => false,
+        isPromiseAll: () => false,
+        getPromiseIndex: () => null,
+    } as NodeJS.CallSite;
+}
+
+function makeConfig(
+    overrides: Partial<StackTraceConfig> = {}
+): StackTraceConfig {
+    return {
+        enabled: true,
+        projectRoot: '/test/project',
+        colorEnabled: false,
+        maxProjectFrames: 2,
+        showVendor: false,
+        showMarkers: false,
+        codeFrameContext: 0,
+        ...overrides,
+    };
+}
+
+describe('formatStackTrace showMarkers', () => {
+    // Build frames that will produce a collapsed vendor marker:
+    // 1 project frame + 3 vendor frames → triggers vendor collapse
+    const frames = [
+        makeCallSite('/test/project/src/app.ts', 10, 1, 'handler'),
+        makeCallSite(
+            '/test/project/node_modules/lib/index.js',
+            5,
+            1,
+            'vendorA'
+        ),
+        makeCallSite('/test/project/node_modules/lib/util.js', 8, 1, 'vendorB'),
+        makeCallSite(
+            '/test/project/node_modules/lib/core.js',
+            12,
+            1,
+            'vendorC'
+        ),
+    ];
+    const error = new Error('test');
+
+    it('hides collapsed markers when showMarkers is false', () => {
+        const output = formatStackTrace(
+            error,
+            frames,
+            makeConfig({ showMarkers: false })
+        );
+
+        expect(output).not.toContain('frames hidden');
+        expect(output).not.toContain('more project frames');
+        // Should still contain the project frame
+        expect(output).toContain('handler');
+    });
+
+    it('shows collapsed markers when showMarkers is true', () => {
+        const output = formatStackTrace(
+            error,
+            frames,
+            makeConfig({ showMarkers: true })
+        );
+
+        expect(output).toContain('3 frames hidden');
+    });
+
+    it('shows project collapse markers when showMarkers is true', () => {
+        const projectFrames = [
+            makeCallSite('/test/project/src/a.ts', 1, 1, 'fnA'),
+            makeCallSite('/test/project/src/b.ts', 2, 1, 'fnB'),
+            makeCallSite('/test/project/src/c.ts', 3, 1, 'fnC'),
+            makeCallSite('/test/project/src/d.ts', 4, 1, 'fnD'),
+        ];
+
+        const output = formatStackTrace(
+            error,
+            projectFrames,
+            makeConfig({ showMarkers: true, maxProjectFrames: 2 })
+        );
+
+        expect(output).toContain('2 more project frames');
+    });
+
+    it('hides project collapse markers when showMarkers is false', () => {
+        const projectFrames = [
+            makeCallSite('/test/project/src/a.ts', 1, 1, 'fnA'),
+            makeCallSite('/test/project/src/b.ts', 2, 1, 'fnB'),
+            makeCallSite('/test/project/src/c.ts', 3, 1, 'fnC'),
+            makeCallSite('/test/project/src/d.ts', 4, 1, 'fnD'),
+        ];
+
+        const output = formatStackTrace(
+            error,
+            projectFrames,
+            makeConfig({ showMarkers: false, maxProjectFrames: 2 })
+        );
+
+        expect(output).not.toContain('more project frames');
+        // Should still contain the kept frames
+        expect(output).toContain('fnA');
+        expect(output).toContain('fnB');
+    });
+});

--- a/apps/web/server/lib/logger/config.ts
+++ b/apps/web/server/lib/logger/config.ts
@@ -11,6 +11,8 @@ export interface StackTraceConfig {
     maxProjectFrames: number;
     /** Whether to show vendor/node_modules frames */
     showVendor: boolean;
+    /** Whether to show collapsed frame markers ("… x frames hidden …") */
+    showMarkers: boolean;
     /** Lines of code context to show around error location */
     codeFrameContext: number;
 }
@@ -42,6 +44,7 @@ export function loadConfig(): StackTraceConfig {
         colorEnabled: detectColorSupport(),
         maxProjectFrames: parseIntEnv('STACKTRACE_MAX_PROJECT', 10),
         showVendor: process.env.STACKTRACE_SHOW_VENDOR === '1',
+        showMarkers: process.env.STACKTRACE_SHOW_MARKERS === '1',
         codeFrameContext: parseIntEnv('STACKTRACE_CODEFRAME_CONTEXT', 2),
     };
 }

--- a/apps/web/server/lib/logger/patches/format.ts
+++ b/apps/web/server/lib/logger/patches/format.ts
@@ -78,7 +78,11 @@ export function formatStackTrace(
     // Format each frame or marker
     for (const item of collapsed) {
         if (isCollapsedMarker(item)) {
-            lines.push(formatCollapsedMarker(item.count, item.kind, colors));
+            if (config.showMarkers) {
+                lines.push(
+                    formatCollapsedMarker(item.count, item.kind, colors)
+                );
+            }
         } else {
             lines.push(
                 formatFrameLine(


### PR DESCRIPTION
## Summary
- Adds `showMarkers` config option (`STACKTRACE_SHOW_MARKERS` env var) to control whether collapsed frame markers ("… x frames hidden …" / "… x more project frames …") appear in formatted stack traces
- Defaults to hidden (`false`); set `STACKTRACE_SHOW_MARKERS=1` to restore markers

Closes #108

## Changes
- `config.ts`: Added `showMarkers: boolean` to `StackTraceConfig` interface and env var parsing in `loadConfig()`
- `format.ts`: Wrapped `formatCollapsedMarker()` call with `config.showMarkers` guard
- `format.test.ts`: New test file with 4 tests covering show/hide behavior for both vendor and project markers

## Test Plan
- [x] `pnpm check` passes (lint + build + test)
- [x] New tests verify markers hidden when `showMarkers: false`
- [x] New tests verify markers shown when `showMarkers: true`
- [x] Both vendor collapse markers and project collapse markers covered
- [x] Existing tests unaffected (156 total pass)