### PR TITLE
feat: add background_jobs table and user role column

### DIFF
--- a/apps/web/server/db/migrations/0006_cool_bug.sql
+++ b/apps/web/server/db/migrations/0006_cool_bug.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "public"."job_status" AS ENUM('pending', 'processing', 'completed', 'failed');--> statement-breakpoint
+CREATE TYPE "public"."user_role" AS ENUM('user', 'admin');--> statement-breakpoint
+CREATE TABLE "background_jobs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"type" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"status" "job_status" DEFAULT 'pending' NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"error" text,
+	"started_at" timestamp,
+	"completed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "role" "user_role" DEFAULT 'user' NOT NULL;--> statement-breakpoint
+CREATE INDEX "background_jobs_status_created_at_idx" ON "background_jobs" USING btree ("status","created_at");

--- a/apps/web/server/db/migrations/meta/0006_snapshot.json
+++ b/apps/web/server/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,924 @@
+{
+  "id": "296cbae8-2619-4d68-b6b8-35cad86fc30c",
+  "prevId": "0bf0daaa-01fa-4a20-8b42-56eb36500705",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.background_jobs": {
+      "name": "background_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "background_jobs_status_created_at_idx": {
+          "name": "background_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "storage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'glacier'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_user_id_idx": {
+          "name": "files_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_status_idx": {
+          "name": "files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_storage_tier_idx": {
+          "name": "files_storage_tier_idx",
+          "columns": [
+            {
+              "expression": "storage_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_user_id_fk": {
+          "name": "files_user_id_user_id_fk",
+          "tableFrom": "files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_s3_key_unique": {
+          "name": "files_s3_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "s3_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrievals": {
+      "name": "retrievals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "retrieval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "retrieval_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retrievals_file_id_idx": {
+          "name": "retrievals_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_user_id_idx": {
+          "name": "retrievals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_status_idx": {
+          "name": "retrievals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_expires_at_idx": {
+          "name": "retrievals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retrievals_file_id_files_id_fk": {
+          "name": "retrievals_file_id_files_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_user_id_user_id_fk": {
+          "name": "retrievals_user_id_user_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_usage": {
+      "name": "storage_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_bytes": {
+          "name": "used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_usage_user_id_idx": {
+          "name": "storage_usage_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_usage_user_id_user_id_fk": {
+          "name": "storage_usage_user_id_user_id_fk",
+          "tableFrom": "storage_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_usage_user_id_unique": {
+          "name": "storage_usage_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "available",
+        "restoring",
+        "deleted"
+      ]
+    },
+    "public.retrieval_status": {
+      "name": "retrieval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "ready",
+        "expired",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.retrieval_tier": {
+      "name": "retrieval_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "bulk",
+        "expedited"
+      ]
+    },
+    "public.storage_tier": {
+      "name": "storage_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "glacier",
+        "deep_archive"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/server/db/migrations/meta/_journal.json
+++ b/apps/web/server/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1769553025708,
       "tag": "0005_overrated_kingpin",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1770591872034,
+      "tag": "0006_cool_bug",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/db/repositories/fixtures.ts
+++ b/apps/web/server/db/repositories/fixtures.ts
@@ -1,9 +1,11 @@
 import * as schema from '../schema';
 import type { File, NewFile } from './files';
+import type { Job, NewJob } from './jobs';
 
 export const TEST_USER_ID = 'user_test123';
 export const TEST_FILE_ID = 'file_test456';
 export const TEST_STORAGE_USAGE_ID = 'storage_test789';
+export const TEST_JOB_ID = 'job_test101';
 
 export type User = typeof schema.user.$inferSelect;
 export type StorageUsage = typeof schema.storageUsage.$inferSelect;
@@ -50,6 +52,7 @@ export function createUserFixture(overrides: Partial<User> = {}): User {
         email: `${id}@test.example`,
         emailVerified: false,
         image: null,
+        role: 'user',
         createdAt: now,
         updatedAt: now,
         ...overrides,
@@ -67,6 +70,31 @@ export function createStorageUsageFixture(
         fileCount: 0,
         createdAt: now,
         updatedAt: now,
+        ...overrides,
+    };
+}
+
+export function createJobFixture(overrides: Partial<Job> = {}): Job {
+    const now = new Date();
+    return {
+        id: TEST_JOB_ID,
+        type: 'delete-account',
+        payload: { userId: TEST_USER_ID },
+        status: 'pending',
+        attempts: 0,
+        error: null,
+        startedAt: null,
+        completedAt: null,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+    };
+}
+
+export function createNewJobFixture(overrides: Partial<NewJob> = {}): NewJob {
+    return {
+        type: 'delete-account',
+        payload: { userId: TEST_USER_ID },
         ...overrides,
     };
 }

--- a/apps/web/server/db/repositories/index.ts
+++ b/apps/web/server/db/repositories/index.ts
@@ -1,1 +1,2 @@
 export * from './files';
+export * from './jobs';

--- a/apps/web/server/db/repositories/jobs.test.ts
+++ b/apps/web/server/db/repositories/jobs.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createMockDb } from './mocks';
+import { createJobFixture, createNewJobFixture, TEST_JOB_ID } from './fixtures';
+import { findJobs, countJobsByStatus, insertJob, updateJob } from './jobs';
+
+describe('jobs repository', () => {
+    let db: ReturnType<typeof createMockDb>['db'];
+    let mocks: ReturnType<typeof createMockDb>['mocks'];
+
+    beforeEach(() => {
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+    });
+
+    describe('findJobs', () => {
+        it('returns jobs and total count', async () => {
+            const jobs = [
+                createJobFixture({ id: 'job1' }),
+                createJobFixture({ id: 'job2' }),
+            ];
+            mocks.findMany.mockResolvedValue(jobs);
+            mocks.where.mockResolvedValue([{ count: 2 }]);
+
+            const result = await findJobs(db);
+
+            expect(result.jobs).toEqual(jobs);
+            expect(result.total).toBe(2);
+        });
+
+        it('uses default pagination (limit: 50, offset: 0)', async () => {
+            mocks.findMany.mockResolvedValue([]);
+            mocks.where.mockResolvedValue([{ count: 0 }]);
+
+            await findJobs(db);
+
+            expect(mocks.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    limit: 50,
+                    offset: 0,
+                })
+            );
+        });
+
+        it('respects custom pagination options', async () => {
+            mocks.findMany.mockResolvedValue([]);
+            mocks.where.mockResolvedValue([{ count: 0 }]);
+
+            await findJobs(db, { limit: 10, offset: 20 });
+
+            expect(mocks.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    limit: 10,
+                    offset: 20,
+                })
+            );
+        });
+
+        it('returns empty result when no jobs exist', async () => {
+            mocks.findMany.mockResolvedValue([]);
+            mocks.where.mockResolvedValue([{ count: 0 }]);
+
+            const result = await findJobs(db);
+
+            expect(result.jobs).toEqual([]);
+            expect(result.total).toBe(0);
+        });
+
+        it('filters by status when provided', async () => {
+            mocks.findMany.mockResolvedValue([]);
+            mocks.where.mockResolvedValue([{ count: 0 }]);
+
+            await findJobs(db, { limit: 50, offset: 0, status: 'failed' });
+
+            expect(mocks.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.anything(),
+                })
+            );
+        });
+    });
+
+    describe('countJobsByStatus', () => {
+        it('returns counts per status', async () => {
+            mocks.groupBy.mockResolvedValue([
+                { status: 'pending', count: 5 },
+                { status: 'processing', count: 2 },
+                { status: 'completed', count: 10 },
+                { status: 'failed', count: 1 },
+            ]);
+
+            const result = await countJobsByStatus(db);
+
+            expect(result).toEqual({
+                pending: 5,
+                processing: 2,
+                completed: 10,
+                failed: 1,
+            });
+        });
+
+        it('returns zero for statuses with no jobs', async () => {
+            mocks.groupBy.mockResolvedValue([]);
+
+            const result = await countJobsByStatus(db);
+
+            expect(result).toEqual({
+                pending: 0,
+                processing: 0,
+                completed: 0,
+                failed: 0,
+            });
+        });
+    });
+
+    describe('insertJob', () => {
+        it('returns inserted job', async () => {
+            const newJob = createNewJobFixture();
+            const insertedJob = createJobFixture();
+            mocks.returning.mockResolvedValue([insertedJob]);
+
+            const result = await insertJob(db, newJob);
+
+            expect(result).toEqual(insertedJob);
+            expect(mocks.insert).toHaveBeenCalledOnce();
+            expect(mocks.values).toHaveBeenCalledWith(newJob);
+        });
+    });
+
+    describe('updateJob', () => {
+        it('returns updated job', async () => {
+            const updatedJob = createJobFixture({
+                status: 'processing',
+                startedAt: new Date(),
+            });
+            mocks.returning.mockResolvedValue([updatedJob]);
+
+            const result = await updateJob(db, TEST_JOB_ID, {
+                status: 'processing',
+                startedAt: new Date(),
+            });
+
+            expect(result).toEqual(updatedJob);
+            expect(mocks.update).toHaveBeenCalledOnce();
+        });
+
+        it('returns undefined when job not found', async () => {
+            mocks.returning.mockResolvedValue([]);
+
+            const result = await updateJob(db, 'nonexistent', {
+                status: 'failed',
+                error: 'Something went wrong',
+            });
+
+            expect(result).toBeUndefined();
+        });
+    });
+});

--- a/apps/web/server/db/repositories/jobs.ts
+++ b/apps/web/server/db/repositories/jobs.ts
@@ -1,0 +1,93 @@
+import { eq, desc, sql } from 'drizzle-orm';
+import type { DB } from '../index';
+import * as schema from '../schema';
+
+export type Job = typeof schema.backgroundJobs.$inferSelect;
+export type NewJob = typeof schema.backgroundJobs.$inferInsert;
+
+interface FindJobsOptions {
+    limit: number;
+    offset: number;
+    status?: Job['status'];
+}
+
+interface FindJobsResult {
+    jobs: Job[];
+    total: number;
+}
+
+export async function findJobs(
+    db: DB,
+    opts: FindJobsOptions = { limit: 50, offset: 0 }
+): Promise<FindJobsResult> {
+    const whereClause = opts.status
+        ? eq(schema.backgroundJobs.status, opts.status)
+        : undefined;
+
+    const [jobs, [countResult]] = await Promise.all([
+        db.query.backgroundJobs.findMany({
+            where: whereClause,
+            orderBy: desc(schema.backgroundJobs.createdAt),
+            limit: opts.limit,
+            offset: opts.offset,
+        }),
+        db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(schema.backgroundJobs)
+            .where(whereClause),
+    ]);
+
+    return { jobs, total: countResult?.count ?? 0 };
+}
+
+interface JobStatusCounts {
+    pending: number;
+    processing: number;
+    completed: number;
+    failed: number;
+}
+
+export async function countJobsByStatus(db: DB): Promise<JobStatusCounts> {
+    const rows = await db
+        .select({
+            status: schema.backgroundJobs.status,
+            count: sql<number>`count(*)::int`,
+        })
+        .from(schema.backgroundJobs)
+        .groupBy(schema.backgroundJobs.status);
+
+    const counts: JobStatusCounts = {
+        pending: 0,
+        processing: 0,
+        completed: 0,
+        failed: 0,
+    };
+
+    for (const row of rows) {
+        counts[row.status] = row.count;
+    }
+
+    return counts;
+}
+
+export async function insertJob(db: DB, data: NewJob): Promise<Job> {
+    const [job] = await db
+        .insert(schema.backgroundJobs)
+        .values(data)
+        .returning();
+    return job;
+}
+
+export async function updateJob(
+    db: DB,
+    id: string,
+    data: Partial<Omit<NewJob, 'id'>>
+): Promise<Job | undefined> {
+    const [job] = await db
+        .update(schema.backgroundJobs)
+        .set(data)
+        .where(eq(schema.backgroundJobs.id, id))
+        .returning();
+
+    return job;
+}

--- a/apps/web/server/db/repositories/mocks.ts
+++ b/apps/web/server/db/repositories/mocks.ts
@@ -8,10 +8,11 @@ export function createMockDb() {
     const findFirst: AnyMock = vi.fn();
     const findMany: AnyMock = vi.fn();
     const returning: AnyMock = vi.fn();
-    const where: AnyMock = vi.fn(() => ({ returning }));
+    const groupBy: AnyMock = vi.fn();
+    const where: AnyMock = vi.fn(() => ({ returning, groupBy }));
     const set: AnyMock = vi.fn(() => ({ where }));
     const values: AnyMock = vi.fn(() => ({ returning }));
-    const from: AnyMock = vi.fn(() => ({ where }));
+    const from: AnyMock = vi.fn(() => ({ where, groupBy }));
     const select: AnyMock = vi.fn(() => ({ from }));
     const insert: AnyMock = vi.fn(() => ({ values }));
     const update: AnyMock = vi.fn(() => ({ set }));
@@ -20,6 +21,7 @@ export function createMockDb() {
     const db = {
         query: {
             files: { findFirst, findMany },
+            backgroundJobs: { findFirst, findMany },
         },
         select,
         insert,
@@ -43,6 +45,7 @@ export function createMockDb() {
             set,
             delete: deleteFn,
             returning,
+            groupBy,
         },
     };
 }

--- a/apps/web/server/db/schema/auth.ts
+++ b/apps/web/server/db/schema/auth.ts
@@ -1,5 +1,7 @@
-import { pgTable, text, timestamp, boolean } from 'drizzle-orm/pg-core';
+import { pgTable, pgEnum, text, timestamp, boolean } from 'drizzle-orm/pg-core';
 import { timestamps } from './helpers';
+
+export const userRoleEnum = pgEnum('user_role', ['user', 'admin']);
 
 // BetterAuth tables
 
@@ -9,6 +11,7 @@ export const user = pgTable('user', {
     email: text('email').notNull().unique(),
     emailVerified: boolean('email_verified').notNull().default(false),
     image: text('image'),
+    role: userRoleEnum('role').notNull().default('user'),
     ...timestamps(),
 });
 

--- a/apps/web/server/db/schema/index.ts
+++ b/apps/web/server/db/schema/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
+export * from './jobs';
 export * from './storage';
 export * from './helpers';

--- a/apps/web/server/db/schema/jobs.ts
+++ b/apps/web/server/db/schema/jobs.ts
@@ -1,0 +1,40 @@
+import {
+    pgTable,
+    pgEnum,
+    text,
+    timestamp,
+    integer,
+    jsonb,
+    index,
+} from 'drizzle-orm/pg-core';
+import { timestamps } from './helpers';
+
+export const jobStatusEnum = pgEnum('job_status', [
+    'pending',
+    'processing',
+    'completed',
+    'failed',
+]);
+
+export const backgroundJobs = pgTable(
+    'background_jobs',
+    {
+        id: text('id')
+            .primaryKey()
+            .$defaultFn(() => crypto.randomUUID()),
+        type: text('type').notNull(),
+        payload: jsonb('payload').notNull(),
+        status: jobStatusEnum('status').notNull().default('pending'),
+        attempts: integer('attempts').notNull().default(0),
+        error: text('error'),
+        startedAt: timestamp('started_at'),
+        completedAt: timestamp('completed_at'),
+        ...timestamps(),
+    },
+    (table) => [
+        index('background_jobs_status_created_at_idx').on(
+            table.status,
+            table.createdAt
+        ),
+    ]
+);


### PR DESCRIPTION
## Summary

Add database schema for background job tracking and admin authorization, as the foundation for async job infrastructure.

Closes #128

## Changes

- Add `jobStatusEnum` (`pending`, `processing`, `completed`, `failed`) and `userRoleEnum` (`user`, `admin`) pgEnums
- Create `backgroundJobs` table in `server/db/schema/jobs.ts` with id, type, payload (jsonb), status, attempts, error, startedAt, completedAt, and timestamps
- Add composite index on `(status, createdAt)` for dashboard queries
- Add `role` column to `user` table with default `user`
- Create jobs repository (`findJobs`, `countJobsByStatus`, `insertJob`, `updateJob`) following existing patterns
- Add `createJobFixture` and `createNewJobFixture` in fixtures
- Update `createUserFixture` to include `role` field
- Add `backgroundJobs` and `groupBy` support to mock DB
- Unit tests for all repository functions (10 tests)
- Generate and apply migration `0006_cool_bug.sql`

## Test Plan

- [x] `pnpm check` passes (lint + build + 166 tests)
- [x] Schema test validates `updatedAt` `$onUpdate()` on new table
- [x] Jobs repository tests cover pagination, status filtering, CRUD, and edge cases
- [x] Migration applies cleanly