### PR TITLE
feat: add Lambda worker workspace for SQS job processing

### DIFF
--- a/apps/worker/eslint.config.mjs
+++ b/apps/worker/eslint.config.mjs
@@ -1,0 +1,18 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+    js.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+        rules: {
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+            ],
+        },
+    },
+    {
+        ignores: ['dist/**', 'node_modules/**'],
+    }
+);

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "@nexus/worker",
+    "version": "0.1.0",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "build": "tsup",
+        "lint": "eslint .",
+        "test": "vitest",
+        "test:run": "vitest run",
+        "typecheck": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@nexus/db": "workspace:*",
+        "drizzle-orm": "^0.45.1",
+        "postgres": "^3.4.7"
+    },
+    "devDependencies": {
+        "@eslint/js": "^9.28.0",
+        "@types/aws-lambda": "^8.10.149",
+        "@types/node": "^20",
+        "eslint": "^9.28.0",
+        "tsup": "^8.5.0",
+        "typescript": "^5",
+        "typescript-eslint": "^8.36.0",
+        "vitest": "^4.0.16"
+    }
+}

--- a/apps/worker/src/handler.test.ts
+++ b/apps/worker/src/handler.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SQSRecord } from 'aws-lambda';
+import { createMockDb, TEST_JOB_ID, TEST_USER_ID } from '@nexus/db';
+
+// Mock @nexus/db module to prevent real DB connection
+vi.mock('@nexus/db', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@nexus/db')>();
+    return {
+        ...actual,
+        createDb: vi.fn(() => actual.createMockDb().db),
+    };
+});
+
+// Mock handlers/index to prevent side-effect import
+vi.mock('./handlers/index', () => ({}));
+
+import { processRecord } from './handler';
+import { registerHandler } from './registry';
+
+function createSqsRecord(body: object): SQSRecord {
+    return {
+        messageId: 'msg-1',
+        receiptHandle: 'receipt-1',
+        body: JSON.stringify(body),
+        attributes: {
+            ApproximateReceiveCount: '1',
+            SentTimestamp: '1234567890',
+            SenderId: 'sender',
+            ApproximateFirstReceiveTimestamp: '1234567890',
+        },
+        messageAttributes: {},
+        md5OfBody: 'md5',
+        eventSource: 'aws:sqs',
+        eventSourceARN: 'arn:aws:sqs:us-east-1:123456789:test',
+        awsRegion: 'us-east-1',
+    };
+}
+
+describe('processRecord', () => {
+    let db: ReturnType<typeof createMockDb>['db'];
+    let mocks: ReturnType<typeof createMockDb>['mocks'];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+
+        // Register a successful handler
+        registerHandler('delete-account', async () => {});
+    });
+
+    it('marks job as processing then completed on success', async () => {
+        const record = createSqsRecord({
+            jobId: TEST_JOB_ID,
+            type: 'delete-account',
+            payload: { userId: TEST_USER_ID },
+        });
+
+        mocks.returning.mockResolvedValue([{ id: TEST_JOB_ID }]);
+
+        await processRecord(db, record);
+
+        // markJobProcessing: update → set (status: processing) → where
+        // updateJob: update → set (status: completed) → where → returning
+        expect(mocks.update).toHaveBeenCalledTimes(2);
+        expect(mocks.set).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'processing' })
+        );
+        expect(mocks.set).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'completed' })
+        );
+    });
+
+    it('marks job as failed and re-throws on handler error', async () => {
+        registerHandler('delete-account', async () => {
+            throw new Error('handler failed');
+        });
+
+        const record = createSqsRecord({
+            jobId: TEST_JOB_ID,
+            type: 'delete-account',
+            payload: { userId: TEST_USER_ID },
+        });
+
+        mocks.returning.mockResolvedValue([{ id: TEST_JOB_ID }]);
+
+        await expect(processRecord(db, record)).rejects.toThrow(
+            'handler failed'
+        );
+
+        // Should have called updateJob with failed status and error message
+        expect(mocks.set).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: 'failed',
+                error: 'handler failed',
+            })
+        );
+    });
+});

--- a/apps/worker/src/handler.ts
+++ b/apps/worker/src/handler.ts
@@ -1,0 +1,51 @@
+import type { SQSEvent } from 'aws-lambda';
+import {
+    createDb,
+    markJobProcessing,
+    updateJob,
+    type DB,
+    type SqsMessageBody,
+} from '@nexus/db';
+import { getHandler } from './registry';
+
+// Register all job handlers
+import './handlers/index';
+
+const db = createDb(process.env.DATABASE_URL!, { prepare: false });
+
+export async function processRecord(
+    db: DB,
+    record: SQSEvent['Records'][number]
+): Promise<void> {
+    const message: SqsMessageBody = JSON.parse(record.body);
+    const { jobId, type, payload } = message;
+
+    await markJobProcessing(db, jobId);
+
+    try {
+        const jobHandler = getHandler(type);
+        await jobHandler({ jobId, payload, db });
+
+        await updateJob(db, jobId, {
+            status: 'completed',
+            completedAt: new Date(),
+        });
+    } catch (error) {
+        const errorMessage =
+            error instanceof Error ? error.message : String(error);
+
+        await updateJob(db, jobId, {
+            status: 'failed',
+            error: errorMessage,
+        });
+
+        // Re-throw so SQS retries / sends to DLQ
+        throw error;
+    }
+}
+
+export async function handler(event: SQSEvent): Promise<void> {
+    for (const record of event.Records) {
+        await processRecord(db, record);
+    }
+}

--- a/apps/worker/src/handlers/deleteAccount.ts
+++ b/apps/worker/src/handlers/deleteAccount.ts
@@ -1,0 +1,7 @@
+import type { HandlerContext } from '../registry';
+
+export async function deleteAccount(
+    _ctx: HandlerContext<'delete-account'>
+): Promise<void> {
+    throw new Error('delete-account handler not yet implemented');
+}

--- a/apps/worker/src/handlers/index.ts
+++ b/apps/worker/src/handlers/index.ts
@@ -1,0 +1,4 @@
+import { registerHandler } from '../registry';
+import { deleteAccount } from './deleteAccount';
+
+registerHandler('delete-account', deleteAccount);

--- a/apps/worker/src/registry.test.ts
+++ b/apps/worker/src/registry.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getHandler, registerHandler } from './registry';
+
+describe('registry', () => {
+    beforeEach(() => {
+        // Register a test handler for each test
+        registerHandler('delete-account', async () => {});
+    });
+
+    it('returns the registered handler for a known job type', () => {
+        const handler = getHandler('delete-account');
+        expect(handler).toBeTypeOf('function');
+    });
+
+    it('throws for an unknown job type', () => {
+        expect(() => getHandler('nonexistent-type')).toThrow(
+            'No handler registered for job type: nonexistent-type'
+        );
+    });
+});

--- a/apps/worker/src/registry.ts
+++ b/apps/worker/src/registry.ts
@@ -1,0 +1,28 @@
+import type { DB, JobType, JobPayloadMap } from '@nexus/db';
+
+export interface HandlerContext<T extends JobType = JobType> {
+    jobId: string;
+    payload: JobPayloadMap[T];
+    db: DB;
+}
+
+type JobHandler<T extends JobType = JobType> = (
+    ctx: HandlerContext<T>
+) => Promise<void>;
+
+const handlers: Partial<Record<JobType, JobHandler>> = {};
+
+export function registerHandler<T extends JobType>(
+    type: T,
+    handler: JobHandler<T>
+): void {
+    handlers[type] = handler as JobHandler;
+}
+
+export function getHandler(type: string): JobHandler {
+    const handler = handlers[type as JobType];
+    if (!handler) {
+        throw new Error(`No handler registered for job type: ${type}`);
+    }
+    return handler;
+}

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "lib": ["ES2022"],
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/apps/worker/tsup.config.ts
+++ b/apps/worker/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/handler.ts'],
+    format: ['esm'],
+    target: 'node22',
+    platform: 'node',
+    outDir: 'dist',
+    clean: true,
+    noExternal: [/.*/],
+});

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['src/**/*.test.ts'],
+    },
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,9 +1,12 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
-import postgres from 'postgres';
+import postgres, { type Options } from 'postgres';
 import * as schema from './schema';
 
-export function createDb(url: string) {
-    const client = postgres(url);
+export function createDb(
+    url: string,
+    options?: Options<Record<string, never>>
+) {
+    const client = postgres(url, options);
     return drizzle(client, { schema });
 }
 

--- a/packages/db/src/repositories/jobs.ts
+++ b/packages/db/src/repositories/jobs.ts
@@ -91,3 +91,14 @@ export async function updateJob(
 
     return job;
 }
+
+export async function markJobProcessing(db: DB, id: string): Promise<void> {
+    await db
+        .update(schema.backgroundJobs)
+        .set({
+            status: 'processing',
+            attempts: sql`${schema.backgroundJobs.attempts} + 1`,
+            startedAt: new Date(),
+        })
+        .where(eq(schema.backgroundJobs.id, id));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,43 @@ importers:
         specifier: ^4.0.16
         version: 4.0.16(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)
 
+  apps/worker:
+    dependencies:
+      '@nexus/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(kysely@0.28.9)(postgres@3.4.7)
+      postgres:
+        specifier: ^3.4.7
+        version: 3.4.7
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.28.0
+        version: 9.39.2
+      '@types/aws-lambda':
+        specifier: ^8.10.149
+        version: 8.10.160
+      '@types/node':
+        specifier: ^20
+        version: 20.19.27
+      eslint:
+        specifier: ^9.28.0
+        version: 9.39.2(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.36.0
+        version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)
+
   packages/db:
     dependencies:
       drizzle-orm:
@@ -2170,6 +2207,9 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/aws-lambda@8.10.160':
+    resolution: {integrity: sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -7107,6 +7147,8 @@ snapshots:
     optional: true
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/aws-lambda@8.10.160': {}
 
   '@types/babel__core@7.20.5':
     dependencies:


### PR DESCRIPTION
## Summary

Add the `apps/worker/` monorepo workspace — a Lambda function that consumes SQS messages and processes background jobs. Includes workspace setup, SQS event handler, job type registry, database access with PgBouncer compatibility, and unit tests.

Closes #130

## Changes

- Create `apps/worker/` workspace with package.json, tsconfig, tsup, vitest, and eslint configs
- Add `handler.ts` — SQS event handler that deserializes messages, updates job status lifecycle (processing → completed/failed), and dispatches to registered handlers
- Add `registry.ts` — type-safe job type → handler mapping with clear errors for unknown types
- Add `handlers/deleteAccount.ts` — stub handler (throws "not implemented" until feature issue)
- Add `markJobProcessing()` repository function in `@nexus/db` for atomic status + attempt increment
- Extend `createDb()` in `@nexus/db` to accept postgres options (needed for `prepare: false` with PgBouncer)
- Build produces self-contained Lambda artifact via tsup (`dist/handler.js`, ~293KB)

## Test Plan

- [x] `pnpm check` passes (lint + build + test across all 4 packages)
- [x] Handler test: mock SQS event verifies job marked processing then completed on success
- [x] Handler test: mock SQS event verifies job marked failed and error re-thrown on handler failure
- [x] Registry test: unknown job type throws clear error message
- [x] Worker build produces `dist/handler.js` deployable artifact
- [x] Existing web and db tests unaffected