### PR TITLE
test: add integration test for background job publish pipeline

### DIFF
--- a/apps/web/lib/jobs/publish.integration.test.ts
+++ b/apps/web/lib/jobs/publish.integration.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { createDb, backgroundJobs, type DB, type Job } from '@nexus/db';
+import { publish } from './publish';
+
+const db: DB = createDb(process.env.DATABASE_URL!);
+const createdJobs: Job[] = [];
+
+afterAll(async () => {
+    for (const job of createdJobs) {
+        await db.delete(backgroundJobs).where(eq(backgroundJobs.id, job.id));
+    }
+});
+
+describe('jobs.publish() integration', () => {
+    it('inserts a DB record and publishes to SQS without error', async () => {
+        const job = await publish(db, {
+            type: 'delete-account',
+            payload: { userId: 'integration-test-user' },
+        });
+        createdJobs.push(job);
+
+        expect(job.id).toBeDefined();
+        expect(job.type).toBe('delete-account');
+        expect(job.status).toBe('pending');
+        expect(job.payload).toEqual({ userId: 'integration-test-user' });
+
+        const found = await db.query.backgroundJobs.findFirst({
+            where: eq(backgroundJobs.id, job.id),
+        });
+
+        expect(found).toBeDefined();
+        expect(found!.status).toBe('pending');
+    });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,8 @@
         "test:e2e": "playwright test",
         "test:e2e:smoke": "playwright test e2e/smoke",
         "test:e2e:ui": "playwright test --ui",
-        "test:coverage": "vitest run --coverage"
+        "test:coverage": "vitest run --coverage",
+        "test:integration": "vitest run --config vitest.integration.config.ts"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.975.0",

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, defaultExclude } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
@@ -9,6 +9,7 @@ export default defineConfig({
         environment: 'jsdom',
         setupFiles: ['./vitest.setup.ts'],
         include: ['**/*.test.{ts,tsx}'],
+        exclude: [...defaultExclude, '**/*.integration.test.*'],
         coverage: {
             provider: 'v8',
             reporter: ['text', 'html', 'json-summary'],

--- a/apps/web/vitest.integration.config.ts
+++ b/apps/web/vitest.integration.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        setupFiles: ['./vitest.integration.setup.ts'],
+        include: ['**/*.integration.test.ts'],
+    },
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './'),
+        },
+    },
+});

--- a/apps/web/vitest.integration.setup.ts
+++ b/apps/web/vitest.integration.setup.ts
@@ -1,0 +1,3 @@
+import { config } from 'dotenv';
+
+config({ path: '.env.local' });


### PR DESCRIPTION
## Summary

Add a publish-side integration test for the background job pipeline that exercises `jobs.publish()` against real AWS SQS and the dev database. Includes a separate vitest config, setup, and documentation.

Closes #145

## Changes

- Add `vitest.integration.config.ts` with `node` environment and dotenv setup file
- Exclude `*.integration.test.ts` from default `vitest.config.ts` (preserving `defaultExclude`)
- Add `publish.integration.test.ts` — connects to real DB, publishes via SQS, asserts DB record + no-throw, cleans up in `afterAll`
- Add `test:integration` script to `apps/web/package.json`
- Update `docs/guides/background-jobs.md` with integration test section

## Test Plan

- [x] `pnpm check` passes (lint + build + test)
- [ ] `pnpm -F web test:integration` runs the integration test against real dev infra