### PR TITLE
chore: add LOG_ERROR_VERBOSITY env var config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,12 @@ import { env } from '@/lib/env';
 const bucket = env.S3_BUCKET; // Validated at runtime
 ```
 
+**Optional overrides:**
+
+| Variable              | Values                        | Default                           |
+| --------------------- | ----------------------------- | --------------------------------- |
+| `LOG_ERROR_VERBOSITY` | `minimal`, `standard`, `full` | `full` in dev, `standard` in prod |
+
 ## Dev Logs
 
 In development, server logs are written to `apps/web/.dev.log` in NDJSON format. The file is truncated on each dev server start.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -17,3 +17,6 @@ STRIPE_WEBHOOK_SECRET=whsec_xxx
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Logging (optional)
+# LOG_ERROR_VERBOSITY=full  # minimal | standard | full (defaults: full in dev, standard in prod)

--- a/apps/web/lib/env/schema.ts
+++ b/apps/web/lib/env/schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+export const logErrorVerbositySchema = z.enum(['minimal', 'standard', 'full']);
+
 // Server-side env vars (not exposed to client)
 export const serverSchema = z.object({
     DATABASE_URL: z.string().url(),
@@ -12,6 +14,7 @@ export const serverSchema = z.object({
     STRIPE_SECRET_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
     BETTER_AUTH_SECRET: z.string().min(32),
+    LOG_ERROR_VERBOSITY: logErrorVerbositySchema.optional(),
 });
 
 // Client-side env vars (NEXT_PUBLIC_ prefix)

--- a/apps/web/server/lib/logger.ts
+++ b/apps/web/server/lib/logger.ts
@@ -1,15 +1,20 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import pino from 'pino';
+import type { z } from 'zod';
 
 // Install source-mapped stack traces in development
 import './logger/patches/install';
 
+import { env } from '@/lib/env';
+import { logErrorVerbositySchema } from '@/lib/env/schema';
+
 export const isDev = process.env.NODE_ENV === 'development';
 
-export type ErrorVerbosity = 'minimal' | 'standard' | 'full';
+export type ErrorVerbosity = z.infer<typeof logErrorVerbositySchema>;
 
-export const errorVerbosity: ErrorVerbosity = isDev ? 'full' : 'standard';
+export const errorVerbosity: ErrorVerbosity =
+    env.LOG_ERROR_VERBOSITY ?? (isDev ? 'full' : 'standard');
 
 const DEV_LOG_PATH = path.join(process.cwd(), '.dev.log');
 


### PR DESCRIPTION
## Summary

Add user-configurable `LOG_ERROR_VERBOSITY` environment variable so error verbosity can be changed without code modifications. Falls back to existing defaults (`full` in dev, `standard` in prod) when not set.

Closes #31

## Changes

- Add `logErrorVerbositySchema` Zod enum and `LOG_ERROR_VERBOSITY` optional field to server env schema
- Derive `ErrorVerbosity` type from the Zod schema (single source of truth)
- Wire `errorVerbosity` in logger to read from `env.LOG_ERROR_VERBOSITY` with fallback
- Document in `.env.example` and CLAUDE.md

## Test Plan

- [x] `pnpm check` passes (lint + build + 128 web tests including all logging verbosity tests)
- [x] Set `LOG_ERROR_VERBOSITY=minimal` in `.env.local`, verify tRPC errors only show code
- [x] Unset the variable, verify default behavior unchanged (full in dev, standard in prod)