### PR TITLE
docs: add SNS topic for S3 restore notifications (#38)

### DIFF
--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -53,7 +53,7 @@ External Provider                Nexus (Next.js / Vercel)
 apps/web/
 ├── app/api/webhooks/
 │   ├── stripe/route.ts          # Stripe webhook endpoint
-│   └── sns/route.ts             # AWS SNS endpoint (future)
+│   └── s3-restore/route.ts      # AWS SNS S3 restore endpoint (future)
 ├── lib/stripe/
 │   ├── client.ts                # Stripe SDK singleton
 │   ├── webhooks.ts              # Signature verification + event construction
@@ -478,7 +478,7 @@ Fire SNS-shaped payloads to test the SNS endpoint locally:
 
 ```bash
 # Subscription confirmation (one-time)
-curl -X POST http://localhost:3000/api/webhooks/sns \
+curl -X POST http://localhost:3000/api/webhooks/s3-restore \
   -H 'Content-Type: application/json' \
   -H 'x-amz-sns-message-type: SubscriptionConfirmation' \
   -d '{
@@ -490,7 +490,7 @@ curl -X POST http://localhost:3000/api/webhooks/sns \
   }'
 
 # S3 event notification via SNS
-curl -X POST http://localhost:3000/api/webhooks/sns \
+curl -X POST http://localhost:3000/api/webhooks/s3-restore \
   -H 'Content-Type: application/json' \
   -H 'x-amz-sns-message-type: Notification' \
   -d '{


### PR DESCRIPTION
## Summary

Document manual AWS setup steps for the SNS topic that receives S3 Glacier restore lifecycle events. Includes provisioning commands, IAM policies, verification, and cleanup.

Closes #38

## Changes

- **`docs/infra/aws-manual-setup.md`** — Added SNS section with 6 numbered provisioning steps (DLQ, topic, topic policy, DLQ policy, HTTPS subscription, S3 event notifications), verification commands, and cleanup commands. Added YAML frontmatter. Used shell variables for ARNs/account IDs to reduce duplication and make env adaptation easier.
- **`docs/guides/webhooks.md`** — Aligned SNS endpoint path from `/api/webhooks/sns` to `/api/webhooks/s3-restore` to match the issue spec and aws-manual-setup.md.

## Test Plan

- [ ] Review provisioning CLI commands for correctness (especially IAM policies and JSON escaping)
- [ ] Verify shell variable interpolation works correctly when copy-pasting commands
- [ ] Confirm the DLQ policy heredoc + `jq` approach produces valid JSON