### PR TITLE
feat: add Glacier retrieval system (#20)

### DIFF
--- a/apps/web/lib/storage/glacier.ts
+++ b/apps/web/lib/storage/glacier.ts
@@ -31,6 +31,21 @@ export async function restore(
 }
 
 /**
+ * Start restore operations for multiple objects in Glacier Deep Archive.
+ * S3 doesn't have a native batch restore API, so each key gets an individual call.
+ * @param keys - S3 object keys
+ * @param tier - Restore speed for all objects
+ * @param daysToKeep - Days to keep restored copies accessible (default: 7)
+ */
+export async function restoreMany(
+    keys: string[],
+    tier: RestoreTier,
+    daysToKeep = 7
+): Promise<void> {
+    await Promise.all(keys.map((key) => restore(key, tier, daysToKeep)));
+}
+
+/**
  * Check the restore status of a Glacier object
  * @param key - S3 object key
  * @returns Status object with restore state and expiration (if completed)

--- a/apps/web/lib/storage/testing.ts
+++ b/apps/web/lib/storage/testing.ts
@@ -38,6 +38,7 @@ const presignedMocks = {
 
 const glacierMocks = {
     restore: async (): Promise<void> => {},
+    restoreMany: async (): Promise<void> => {},
     checkStatus: async (): Promise<{
         status: 'available' | 'restoring' | 'archived';
     }> => ({ status: 'available' }),

--- a/apps/web/server/services/retrieval.test.ts
+++ b/apps/web/server/services/retrieval.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+    createMockDb,
+    createFileFixture,
+    createRetrievalFixture,
+    TEST_USER_ID,
+    TEST_FILE_ID,
+} from '@nexus/db';
+import { mockS3 } from '@/lib/storage/testing';
+import { NotFoundError, InvalidStateError } from '@/server/errors';
+import { retrievalService } from './retrieval';
+
+vi.mock('@/lib/storage', () => ({
+    s3: mockS3,
+}));
+
+describe('retrieval service', () => {
+    let db: ReturnType<typeof createMockDb>['db'];
+    let mocks: ReturnType<typeof createMockDb>['mocks'];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+    });
+
+    describe('requestRetrieval', () => {
+        it('creates retrieval for Glacier file', async () => {
+            const file = createFileFixture({ storageTier: 'glacier' });
+            const retrieval = createRetrievalFixture();
+
+            // requestRetrieval delegates to requestBulkRetrieval:
+            // findUserFiles -> findByFileIds -> s3.glacier.restoreMany -> insertMany
+            mocks.findMany
+                .mockResolvedValueOnce([file]) // findUserFiles
+                .mockResolvedValueOnce([]); // findByFileIds (no existing)
+            mocks.returning.mockResolvedValue([retrieval]);
+
+            const result = await retrievalService.requestRetrieval(
+                db,
+                TEST_USER_ID,
+                TEST_FILE_ID,
+                'standard'
+            );
+
+            expect(result).toEqual(retrieval);
+            expect(mocks.insert).toHaveBeenCalledOnce();
+        });
+
+        it('creates retrieval for deep_archive file', async () => {
+            const file = createFileFixture({ storageTier: 'deep_archive' });
+            const retrieval = createRetrievalFixture({ tier: 'bulk' });
+
+            mocks.findMany
+                .mockResolvedValueOnce([file])
+                .mockResolvedValueOnce([]);
+            mocks.returning.mockResolvedValue([retrieval]);
+
+            const result = await retrievalService.requestRetrieval(
+                db,
+                TEST_USER_ID,
+                TEST_FILE_ID,
+                'bulk'
+            );
+
+            expect(result).toEqual(retrieval);
+        });
+
+        it('returns existing active retrieval (idempotent)', async () => {
+            const file = createFileFixture({ storageTier: 'glacier' });
+            const existing = createRetrievalFixture({ status: 'pending' });
+
+            mocks.findMany
+                .mockResolvedValueOnce([file]) // findUserFiles
+                .mockResolvedValueOnce([existing]); // findByFileIds returns active retrieval
+
+            const result = await retrievalService.requestRetrieval(
+                db,
+                TEST_USER_ID,
+                TEST_FILE_ID
+            );
+
+            expect(result).toEqual(existing);
+            expect(mocks.insert).not.toHaveBeenCalled();
+        });
+
+        it('throws NotFoundError when file does not exist', async () => {
+            mocks.findMany.mockResolvedValueOnce([]); // findUserFiles returns empty
+
+            await expect(
+                retrievalService.requestRetrieval(
+                    db,
+                    TEST_USER_ID,
+                    'nonexistent'
+                )
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('throws InvalidStateError when file is not in Glacier tier', async () => {
+            const file = createFileFixture({ storageTier: 'standard' });
+
+            mocks.findMany
+                .mockResolvedValueOnce([file]) // findUserFiles
+                .mockResolvedValueOnce([]); // findByFileIds (no existing)
+
+            await expect(
+                retrievalService.requestRetrieval(
+                    db,
+                    TEST_USER_ID,
+                    TEST_FILE_ID
+                )
+            ).rejects.toThrow(InvalidStateError);
+        });
+    });
+
+    describe('requestBulkRetrieval', () => {
+        it('creates retrievals for multiple files', async () => {
+            const files = [
+                createFileFixture({
+                    id: 'file1',
+                    s3Key: 'user/file1',
+                    storageTier: 'glacier',
+                }),
+                createFileFixture({
+                    id: 'file2',
+                    s3Key: 'user/file2',
+                    storageTier: 'glacier',
+                }),
+            ];
+            const newRetrievals = [
+                createRetrievalFixture({ id: 'r1', fileId: 'file1' }),
+                createRetrievalFixture({ id: 'r2', fileId: 'file2' }),
+            ];
+
+            mocks.findMany
+                .mockResolvedValueOnce(files) // findUserFiles
+                .mockResolvedValueOnce([]); // findByFileIds (no existing)
+            mocks.returning.mockResolvedValue(newRetrievals);
+
+            const result = await retrievalService.requestBulkRetrieval(
+                db,
+                TEST_USER_ID,
+                ['file1', 'file2'],
+                'standard'
+            );
+
+            expect(result).toHaveLength(2);
+            expect(mocks.insert).toHaveBeenCalledOnce();
+        });
+
+        it('returns existing retrievals for files with active retrievals', async () => {
+            const files = [
+                createFileFixture({
+                    id: 'file1',
+                    s3Key: 'user/file1',
+                    storageTier: 'glacier',
+                }),
+                createFileFixture({
+                    id: 'file2',
+                    s3Key: 'user/file2',
+                    storageTier: 'glacier',
+                }),
+            ];
+            const existingRetrieval = createRetrievalFixture({
+                id: 'r1',
+                fileId: 'file1',
+                status: 'in_progress',
+            });
+            const newRetrieval = createRetrievalFixture({
+                id: 'r2',
+                fileId: 'file2',
+            });
+
+            mocks.findMany
+                .mockResolvedValueOnce(files) // findUserFiles
+                .mockResolvedValueOnce([existingRetrieval]); // findByFileIds
+            mocks.returning.mockResolvedValue([newRetrieval]);
+
+            const result = await retrievalService.requestBulkRetrieval(
+                db,
+                TEST_USER_ID,
+                ['file1', 'file2']
+            );
+
+            expect(result).toHaveLength(2);
+        });
+
+        it('throws NotFoundError when any file is missing', async () => {
+            const files = [createFileFixture({ id: 'file1' })];
+            mocks.findMany.mockResolvedValueOnce(files);
+
+            await expect(
+                retrievalService.requestBulkRetrieval(db, TEST_USER_ID, [
+                    'file1',
+                    'file2',
+                ])
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('throws InvalidStateError when any file is not in Glacier tier', async () => {
+            const files = [
+                createFileFixture({
+                    id: 'file1',
+                    storageTier: 'glacier',
+                }),
+                createFileFixture({
+                    id: 'file2',
+                    storageTier: 'standard',
+                }),
+            ];
+
+            mocks.findMany
+                .mockResolvedValueOnce(files) // findUserFiles
+                .mockResolvedValueOnce([]); // findByFileIds (no existing)
+
+            await expect(
+                retrievalService.requestBulkRetrieval(db, TEST_USER_ID, [
+                    'file1',
+                    'file2',
+                ])
+            ).rejects.toThrow(InvalidStateError);
+        });
+
+        it('returns only existing retrievals when all files already have active retrievals', async () => {
+            const files = [
+                createFileFixture({ id: 'file1', storageTier: 'glacier' }),
+            ];
+            const existingRetrieval = createRetrievalFixture({
+                id: 'r1',
+                fileId: 'file1',
+                status: 'ready',
+            });
+
+            mocks.findMany
+                .mockResolvedValueOnce(files) // findUserFiles
+                .mockResolvedValueOnce([existingRetrieval]); // findByFileIds
+
+            const result = await retrievalService.requestBulkRetrieval(
+                db,
+                TEST_USER_ID,
+                ['file1']
+            );
+
+            expect(result).toEqual([existingRetrieval]);
+            expect(mocks.insert).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getDownloadUrl', () => {
+        it('returns presigned URL when retrieval is ready', async () => {
+            const file = createFileFixture();
+            const retrieval = createRetrievalFixture({ status: 'ready' });
+
+            mocks.findFirst
+                .mockResolvedValueOnce(file) // findUserFile
+                .mockResolvedValueOnce(retrieval); // findByFileId
+
+            const result = await retrievalService.getDownloadUrl(
+                db,
+                TEST_USER_ID,
+                TEST_FILE_ID
+            );
+
+            expect(result).toHaveProperty('url');
+            expect(result).toHaveProperty('expiresAt');
+            expect(result.url).toContain('https://mock-s3.test/test-bucket/');
+            expect(result.expiresAt).toBeInstanceOf(Date);
+        });
+
+        it('throws NotFoundError when file does not exist', async () => {
+            mocks.findFirst.mockResolvedValue(undefined);
+
+            await expect(
+                retrievalService.getDownloadUrl(db, TEST_USER_ID, 'nonexistent')
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('throws InvalidStateError when no retrieval exists', async () => {
+            const file = createFileFixture();
+
+            mocks.findFirst
+                .mockResolvedValueOnce(file) // findUserFile
+                .mockResolvedValueOnce(undefined); // findByFileId (no retrieval)
+
+            await expect(
+                retrievalService.getDownloadUrl(db, TEST_USER_ID, TEST_FILE_ID)
+            ).rejects.toThrow(InvalidStateError);
+        });
+
+        it('throws InvalidStateError when retrieval is not ready', async () => {
+            const file = createFileFixture();
+            const retrieval = createRetrievalFixture({ status: 'pending' });
+
+            mocks.findFirst
+                .mockResolvedValueOnce(file) // findUserFile
+                .mockResolvedValueOnce(retrieval); // findByFileId
+
+            await expect(
+                retrievalService.getDownloadUrl(db, TEST_USER_ID, TEST_FILE_ID)
+            ).rejects.toThrow(InvalidStateError);
+        });
+    });
+});

--- a/apps/web/server/services/retrieval.ts
+++ b/apps/web/server/services/retrieval.ts
@@ -1,0 +1,109 @@
+import type { DB, Retrieval, File } from '@nexus/db';
+import * as fileRepo from '@nexus/db';
+import * as retrievalRepo from '@nexus/db';
+import { NotFoundError, InvalidStateError } from '@/server/errors';
+import { s3 } from '@/lib/storage';
+import type { RestoreTier } from '@/lib/storage';
+
+const DOWNLOAD_URL_EXPIRY_SECONDS = 3600; // 1 hour
+
+// Only objects stored in Glacier-class tiers can be restored
+const GLACIER_TIERS: File['storageTier'][] = ['glacier', 'deep_archive'];
+
+async function requestRetrieval(
+    db: DB,
+    userId: string,
+    fileId: string,
+    tier: RestoreTier = 'standard'
+): Promise<Retrieval> {
+    const retrievals = await requestBulkRetrieval(db, userId, [fileId], tier);
+    return retrievals[0];
+}
+
+async function requestBulkRetrieval(
+    db: DB,
+    userId: string,
+    fileIds: string[],
+    tier: RestoreTier = 'standard'
+): Promise<Retrieval[]> {
+    const files = await fileRepo.findUserFiles(db, userId, fileIds);
+    if (files.length !== fileIds.length) {
+        const foundIds = new Set(files.map((f) => f.id));
+        const missingId = fileIds.find((id) => !foundIds.has(id));
+        throw new NotFoundError('File', missingId!);
+    }
+
+    const existingRetrievals = await retrievalRepo.findByFileIds(db, fileIds);
+    const existingFileIds = new Set(existingRetrievals.map((r) => r.fileId));
+
+    const filesToRestore = files.filter((f) => !existingFileIds.has(f.id));
+
+    const nonGlacierFile = filesToRestore.find(
+        (f) => !GLACIER_TIERS.includes(f.storageTier)
+    );
+    if (nonGlacierFile) {
+        throw new InvalidStateError(
+            `File is not in a Glacier storage tier (current: ${nonGlacierFile.storageTier})`
+        );
+    }
+
+    if (filesToRestore.length > 0) {
+        await s3.glacier.restoreMany(
+            filesToRestore.map((f) => f.s3Key),
+            tier
+        );
+
+        const now = new Date();
+        const newRetrievals = await retrievalRepo.insertMany(
+            db,
+            filesToRestore.map((f) => ({
+                id: crypto.randomUUID(),
+                fileId: f.id,
+                userId,
+                tier,
+                status: 'pending' as const,
+                initiatedAt: now,
+            }))
+        );
+
+        return [...existingRetrievals, ...newRetrievals];
+    }
+
+    return existingRetrievals;
+}
+
+interface DownloadUrlResult {
+    url: string;
+    expiresAt: Date;
+}
+
+async function getDownloadUrl(
+    db: DB,
+    userId: string,
+    fileId: string
+): Promise<DownloadUrlResult> {
+    const file = await fileRepo.findUserFile(db, userId, fileId);
+    if (!file) {
+        throw new NotFoundError('File', fileId);
+    }
+
+    const retrieval = await retrievalRepo.findByFileId(db, fileId);
+    if (!retrieval || retrieval.status !== 'ready') {
+        throw new InvalidStateError('File retrieval is not ready for download');
+    }
+
+    const url = await s3.presigned.get(file.s3Key, {
+        expiresIn: DOWNLOAD_URL_EXPIRY_SECONDS,
+        filename: file.name,
+    });
+
+    const expiresAt = new Date(Date.now() + DOWNLOAD_URL_EXPIRY_SECONDS * 1000);
+
+    return { url, expiresAt };
+}
+
+export const retrievalService = {
+    requestRetrieval,
+    requestBulkRetrieval,
+    getDownloadUrl,
+} as const;

--- a/apps/web/server/trpc/router.ts
+++ b/apps/web/server/trpc/router.ts
@@ -4,6 +4,7 @@ import { authRouter } from './routers/auth';
 import { dashboardRouter } from './routers/dashboard';
 import { debugRouter } from './routers/debug';
 import { filesRouter } from './routers/files';
+import { retrievalsRouter } from './routers/retrievals';
 
 export const appRouter = router({
     admin: adminRouter,
@@ -11,6 +12,7 @@ export const appRouter = router({
     dashboard: dashboardRouter,
     debug: debugRouter,
     files: filesRouter,
+    retrievals: retrievalsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
+import { RESTORE_TIERS } from '@nexus/db';
 import * as fileRepo from '@nexus/db';
 import { fileService } from '@/server/services/files';
+import { retrievalService } from '@/server/services/retrieval';
 import { protectedProcedure, router } from '../init';
 
 export const filesRouter = router({
@@ -86,6 +88,48 @@ export const filesRouter = router({
                 ctx.db,
                 ctx.session.user.id,
                 input.ids
+            );
+        }),
+
+    requestRetrieval: protectedProcedure
+        .input(
+            z.object({
+                fileId: z.string().uuid(),
+                tier: z.enum(RESTORE_TIERS).default('standard'),
+            })
+        )
+        .mutation(({ ctx, input }) => {
+            return retrievalService.requestRetrieval(
+                ctx.db,
+                ctx.session.user.id,
+                input.fileId,
+                input.tier
+            );
+        }),
+
+    requestBulkRetrieval: protectedProcedure
+        .input(
+            z.object({
+                fileIds: z.array(z.string().uuid()).min(1).max(100),
+                tier: z.enum(RESTORE_TIERS).default('standard'),
+            })
+        )
+        .mutation(({ ctx, input }) => {
+            return retrievalService.requestBulkRetrieval(
+                ctx.db,
+                ctx.session.user.id,
+                input.fileIds,
+                input.tier
+            );
+        }),
+
+    getDownloadUrl: protectedProcedure
+        .input(z.object({ fileId: z.string().uuid() }))
+        .query(({ ctx, input }) => {
+            return retrievalService.getDownloadUrl(
+                ctx.db,
+                ctx.session.user.id,
+                input.fileId
             );
         }),
 });

--- a/apps/web/server/trpc/routers/retrievals.ts
+++ b/apps/web/server/trpc/routers/retrievals.ts
@@ -1,0 +1,8 @@
+import * as retrievalRepo from '@nexus/db';
+import { protectedProcedure, router } from '../init';
+
+export const retrievalsRouter = router({
+    list: protectedProcedure.query(({ ctx }) => {
+        return retrievalRepo.findByUser(ctx.db, ctx.session.user.id);
+    }),
+});

--- a/packages/db/src/repositories/fixtures.ts
+++ b/packages/db/src/repositories/fixtures.ts
@@ -1,11 +1,13 @@
 import * as schema from '../schema';
 import type { File, NewFile } from './files';
 import type { Job, NewJob } from './jobs';
+import type { Retrieval } from './retrievals';
 
 export const TEST_USER_ID = 'user_test123';
 export const TEST_FILE_ID = 'file_test456';
 export const TEST_STORAGE_USAGE_ID = 'storage_test789';
 export const TEST_JOB_ID = 'job_test101';
+export const TEST_RETRIEVAL_ID = 'retrieval_test202';
 
 export type User = typeof schema.user.$inferSelect;
 export type StorageUsage = typeof schema.storageUsage.$inferSelect;
@@ -95,6 +97,27 @@ export function createNewJobFixture(overrides: Partial<NewJob> = {}): NewJob {
     return {
         type: 'delete-account',
         payload: { userId: TEST_USER_ID },
+        ...overrides,
+    };
+}
+
+export function createRetrievalFixture(
+    overrides: Partial<Retrieval> = {}
+): Retrieval {
+    const now = new Date();
+    return {
+        id: TEST_RETRIEVAL_ID,
+        fileId: TEST_FILE_ID,
+        userId: TEST_USER_ID,
+        status: 'pending',
+        tier: 'standard',
+        initiatedAt: null,
+        readyAt: null,
+        expiresAt: null,
+        failedAt: null,
+        errorMessage: null,
+        createdAt: now,
+        updatedAt: now,
         ...overrides,
     };
 }

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -1,4 +1,5 @@
 export * from './files';
 export * from './jobs';
+export * from './retrievals';
 export * from './mocks';
 export * from './fixtures';

--- a/packages/db/src/repositories/mocks.ts
+++ b/packages/db/src/repositories/mocks.ts
@@ -22,6 +22,7 @@ export function createMockDb() {
         query: {
             files: { findFirst, findMany },
             backgroundJobs: { findFirst, findMany },
+            retrievals: { findFirst, findMany },
         },
         select,
         insert,

--- a/packages/db/src/repositories/retrievals.test.ts
+++ b/packages/db/src/repositories/retrievals.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createMockDb } from './mocks';
+import {
+    createRetrievalFixture,
+    TEST_USER_ID,
+    TEST_FILE_ID,
+    TEST_RETRIEVAL_ID,
+} from './fixtures';
+import {
+    findByFileId,
+    findByFileIds,
+    findByUser,
+    insert,
+    insertMany,
+    updateStatus,
+} from './retrievals';
+
+describe('retrievals repository', () => {
+    let db: ReturnType<typeof createMockDb>['db'];
+    let mocks: ReturnType<typeof createMockDb>['mocks'];
+
+    beforeEach(() => {
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+    });
+
+    describe('findByFileId', () => {
+        it('returns active retrieval when found', async () => {
+            const retrieval = createRetrievalFixture();
+            mocks.findFirst.mockResolvedValue(retrieval);
+
+            const result = await findByFileId(db, TEST_FILE_ID);
+
+            expect(result).toEqual(retrieval);
+            expect(mocks.findFirst).toHaveBeenCalledOnce();
+        });
+
+        it('returns undefined when no active retrieval exists', async () => {
+            mocks.findFirst.mockResolvedValue(undefined);
+
+            const result = await findByFileId(db, 'nonexistent');
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('findByFileIds', () => {
+        it('returns active retrievals for multiple files', async () => {
+            const retrievals = [
+                createRetrievalFixture({ id: 'r1', fileId: 'file1' }),
+                createRetrievalFixture({ id: 'r2', fileId: 'file2' }),
+            ];
+            mocks.findMany.mockResolvedValue(retrievals);
+
+            const result = await findByFileIds(db, ['file1', 'file2']);
+
+            expect(result).toEqual(retrievals);
+            expect(mocks.findMany).toHaveBeenCalledOnce();
+        });
+
+        it('returns empty array when given empty ids', async () => {
+            const result = await findByFileIds(db, []);
+
+            expect(result).toEqual([]);
+            expect(mocks.findMany).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('findByUser', () => {
+        it('returns all retrievals for user', async () => {
+            const retrievals = [
+                createRetrievalFixture({ id: 'r1' }),
+                createRetrievalFixture({ id: 'r2', status: 'ready' }),
+            ];
+            mocks.findMany.mockResolvedValue(retrievals);
+
+            const result = await findByUser(db, TEST_USER_ID);
+
+            expect(result).toEqual(retrievals);
+            expect(mocks.findMany).toHaveBeenCalledOnce();
+        });
+
+        it('returns empty array when user has no retrievals', async () => {
+            mocks.findMany.mockResolvedValue([]);
+
+            const result = await findByUser(db, TEST_USER_ID);
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('insert', () => {
+        it('returns inserted retrieval', async () => {
+            const retrieval = createRetrievalFixture();
+            mocks.returning.mockResolvedValue([retrieval]);
+
+            const result = await insert(db, {
+                id: TEST_RETRIEVAL_ID,
+                fileId: TEST_FILE_ID,
+                userId: TEST_USER_ID,
+                tier: 'standard',
+                status: 'pending',
+            });
+
+            expect(result).toEqual(retrieval);
+            expect(mocks.insert).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('insertMany', () => {
+        it('returns inserted retrievals', async () => {
+            const retrievals = [
+                createRetrievalFixture({ id: 'r1', fileId: 'file1' }),
+                createRetrievalFixture({ id: 'r2', fileId: 'file2' }),
+            ];
+            mocks.returning.mockResolvedValue(retrievals);
+
+            const result = await insertMany(db, [
+                {
+                    id: 'r1',
+                    fileId: 'file1',
+                    userId: TEST_USER_ID,
+                    tier: 'standard',
+                    status: 'pending',
+                },
+                {
+                    id: 'r2',
+                    fileId: 'file2',
+                    userId: TEST_USER_ID,
+                    tier: 'standard',
+                    status: 'pending',
+                },
+            ]);
+
+            expect(result).toEqual(retrievals);
+            expect(mocks.insert).toHaveBeenCalledOnce();
+        });
+
+        it('returns empty array when given empty array', async () => {
+            const result = await insertMany(db, []);
+
+            expect(result).toEqual([]);
+            expect(mocks.insert).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('updateStatus', () => {
+        it('returns updated retrieval', async () => {
+            const updated = createRetrievalFixture({
+                status: 'in_progress',
+                initiatedAt: new Date(),
+            });
+            mocks.returning.mockResolvedValue([updated]);
+
+            const result = await updateStatus(
+                db,
+                TEST_RETRIEVAL_ID,
+                'in_progress',
+                { initiatedAt: new Date() }
+            );
+
+            expect(result).toEqual(updated);
+            expect(mocks.update).toHaveBeenCalledOnce();
+            expect(mocks.set).toHaveBeenCalledWith(
+                expect.objectContaining({ status: 'in_progress' })
+            );
+        });
+
+        it('returns undefined when retrieval not found', async () => {
+            mocks.returning.mockResolvedValue([]);
+
+            const result = await updateStatus(db, 'nonexistent', 'failed');
+
+            expect(result).toBeUndefined();
+        });
+
+        it('includes metadata fields when provided', async () => {
+            const now = new Date();
+            const updated = createRetrievalFixture({
+                status: 'failed',
+                failedAt: now,
+                errorMessage: 'AWS error',
+            });
+            mocks.returning.mockResolvedValue([updated]);
+
+            await updateStatus(db, TEST_RETRIEVAL_ID, 'failed', {
+                failedAt: now,
+                errorMessage: 'AWS error',
+            });
+
+            expect(mocks.set).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    status: 'failed',
+                    failedAt: now,
+                    errorMessage: 'AWS error',
+                })
+            );
+        });
+    });
+});

--- a/packages/db/src/repositories/retrievals.ts
+++ b/packages/db/src/repositories/retrievals.ts
@@ -1,0 +1,73 @@
+import { eq, and, inArray } from 'drizzle-orm';
+import type { DB } from '../index';
+import * as schema from '../schema';
+
+export type Retrieval = typeof schema.retrievals.$inferSelect;
+export type NewRetrieval = typeof schema.retrievals.$inferInsert;
+
+// 'ready' included because the restored copy is still available for download
+const ACTIVE_STATUSES: Retrieval['status'][] = [
+    'pending',
+    'in_progress',
+    'ready',
+];
+
+export function findByFileId(
+    db: DB,
+    fileId: string
+): Promise<Retrieval | undefined> {
+    return db.query.retrievals.findFirst({
+        where: and(
+            eq(schema.retrievals.fileId, fileId),
+            inArray(schema.retrievals.status, ACTIVE_STATUSES)
+        ),
+    });
+}
+
+export function findByFileIds(db: DB, fileIds: string[]): Promise<Retrieval[]> {
+    if (fileIds.length === 0) return Promise.resolve([]);
+    return db.query.retrievals.findMany({
+        where: and(
+            inArray(schema.retrievals.fileId, fileIds),
+            inArray(schema.retrievals.status, ACTIVE_STATUSES)
+        ),
+    });
+}
+
+export function findByUser(db: DB, userId: string): Promise<Retrieval[]> {
+    return db.query.retrievals.findMany({
+        where: eq(schema.retrievals.userId, userId),
+    });
+}
+
+export async function insert(db: DB, data: NewRetrieval): Promise<Retrieval> {
+    const [retrieval] = await db
+        .insert(schema.retrievals)
+        .values(data)
+        .returning();
+    return retrieval;
+}
+
+export async function insertMany(
+    db: DB,
+    dataArray: NewRetrieval[]
+): Promise<Retrieval[]> {
+    if (dataArray.length === 0) return [];
+    return db.insert(schema.retrievals).values(dataArray).returning();
+}
+
+export async function updateStatus(
+    db: DB,
+    retrievalId: string,
+    status: Retrieval['status'],
+    metadata?: Partial<
+        Omit<NewRetrieval, 'id' | 'fileId' | 'userId' | 'status'>
+    >
+): Promise<Retrieval | undefined> {
+    const [retrieval] = await db
+        .update(schema.retrievals)
+        .set({ status, ...metadata })
+        .where(eq(schema.retrievals.id, retrievalId))
+        .returning();
+    return retrieval;
+}


### PR DESCRIPTION
## Summary

Implement the Glacier restore and download API for archived files. Users can request retrieval of files (individually or in bulk) with a choice of restore tier (Standard or Bulk), then download via presigned URL when ready.

Closes #20

## Changes

- **Retrievals repository** (`packages/db/src/repositories/retrievals.ts`): `findByFileId`, `findByFileIds`, `findByUser`, `insert`, `insertMany`, `updateStatus` — with active-status filtering for idempotent retrieval lookups
- **Retrieval service** (`apps/web/server/services/retrieval.ts`): `requestRetrieval` (delegates to bulk), `requestBulkRetrieval` (validates ownership, checks Glacier tier, handles idempotency), `getDownloadUrl` (presigned URL with filename)
- **tRPC endpoints**: `files.requestRetrieval`, `files.requestBulkRetrieval`, `files.getDownloadUrl` (protected mutations/query), `retrievals.list` (new router)
- **Storage helpers**: Added `restoreMany` to `lib/storage/glacier.ts` for batch S3 restore calls
- **Fixtures & mocks**: `createRetrievalFixture`, updated `createMockDb` with `retrievals` query, `restoreMany` mock
- **Tests**: 12 repository unit tests + 14 service unit tests covering happy paths, idempotency, validation errors, and edge cases

## Test Plan

- [ ] `pnpm check` passes (lint + build + test)
- [ ] Verify retrieval service tests cover: file not found, not in Glacier tier, active retrieval idempotency, bulk with partial existing retrievals, download URL when not ready
- [ ] Verify repository tests cover: empty array edge cases, status updates with metadata