### PR TITLE
feat: add S3 multipart upload backend API

### DIFF
--- a/apps/web/lib/storage/index.ts
+++ b/apps/web/lib/storage/index.ts
@@ -1,6 +1,7 @@
 import * as presigned from './presigned';
 import * as glacier from './glacier';
 import * as objects from './objects';
+import * as multipart from './multipart';
 
 /**
  * S3 storage operations for file archival
@@ -25,6 +26,7 @@ export const s3 = {
     presigned,
     glacier,
     objects,
+    multipart,
 } as const;
 
 // Re-export types for convenience

--- a/apps/web/lib/storage/multipart.test.ts
+++ b/apps/web/lib/storage/multipart.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockSend, mockGetSignedUrl } = vi.hoisted(() => ({
+    mockSend: vi.fn(),
+    mockGetSignedUrl: vi.fn(),
+}));
+
+vi.mock('./client', () => ({
+    client: { send: mockSend },
+    bucket: 'test-bucket',
+}));
+
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+    getSignedUrl: mockGetSignedUrl,
+}));
+
+import { create, signParts, complete, abort } from './multipart';
+
+describe('multipart storage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('create', () => {
+        it('returns the upload ID from S3', async () => {
+            mockSend.mockResolvedValue({ UploadId: 'test-upload-id' });
+
+            const result = await create(
+                'user/file/name.zip',
+                'application/zip'
+            );
+
+            expect(result.uploadId).toBe('test-upload-id');
+            expect(mockSend).toHaveBeenCalledOnce();
+        });
+
+        it('throws if S3 does not return an UploadId', async () => {
+            mockSend.mockResolvedValue({});
+
+            await expect(create('key')).rejects.toThrow(
+                'S3 did not return an UploadId'
+            );
+        });
+    });
+
+    describe('signParts', () => {
+        it('generates presigned URLs for each part', async () => {
+            mockGetSignedUrl.mockResolvedValue('https://signed-url.test');
+
+            const urls = await signParts({
+                key: 'user/file/name.zip',
+                uploadId: 'test-upload-id',
+                partCount: 3,
+            });
+
+            expect(urls).toHaveLength(3);
+            expect(mockGetSignedUrl).toHaveBeenCalledTimes(3);
+        });
+
+        it('uses custom expiry when provided', async () => {
+            mockGetSignedUrl.mockResolvedValue('https://signed-url.test');
+
+            await signParts({
+                key: 'key',
+                uploadId: 'uid',
+                partCount: 1,
+                expiresIn: 7200,
+            });
+
+            expect(mockGetSignedUrl).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.anything(),
+                { expiresIn: 7200 }
+            );
+        });
+    });
+
+    describe('complete', () => {
+        it('sends CompleteMultipartUploadCommand with parts', async () => {
+            mockSend.mockResolvedValue({});
+
+            await complete('key', 'uid', [
+                { partNumber: 1, etag: '"abc"' },
+                { partNumber: 2, etag: '"def"' },
+            ]);
+
+            expect(mockSend).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('abort', () => {
+        it('sends AbortMultipartUploadCommand', async () => {
+            mockSend.mockResolvedValue({});
+
+            await abort('key', 'uid');
+
+            expect(mockSend).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/apps/web/lib/storage/multipart.ts
+++ b/apps/web/lib/storage/multipart.ts
@@ -1,0 +1,95 @@
+import {
+    CreateMultipartUploadCommand,
+    UploadPartCommand,
+    CompleteMultipartUploadCommand,
+    AbortMultipartUploadCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { client, bucket } from './client';
+
+const PART_URL_EXPIRY_SECONDS = 3600; // 1 hour for large uploads
+
+interface CreateResult {
+    uploadId: string;
+}
+
+interface SignPartsOptions {
+    key: string;
+    uploadId: string;
+    partCount: number;
+    /** URL expiration in seconds (default: 3600 = 1 hour) */
+    expiresIn?: number;
+}
+
+interface CompletePart {
+    partNumber: number;
+    etag: string;
+}
+
+/** Initiate an S3 multipart upload, returning the upload ID needed for subsequent part operations */
+export async function create(
+    key: string,
+    contentType?: string
+): Promise<CreateResult> {
+    const command = new CreateMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        ContentType: contentType,
+    });
+    const response = await client.send(command);
+
+    if (!response.UploadId) {
+        throw new Error('S3 did not return an UploadId');
+    }
+
+    return { uploadId: response.UploadId };
+}
+
+/** Generate presigned URLs for all parts in a multipart upload (1-indexed) */
+export async function signParts(options: SignPartsOptions): Promise<string[]> {
+    const expiresIn = options.expiresIn ?? PART_URL_EXPIRY_SECONDS;
+
+    const urls = await Promise.all(
+        Array.from({ length: options.partCount }, (_, i) => {
+            const command = new UploadPartCommand({
+                Bucket: bucket,
+                Key: options.key,
+                UploadId: options.uploadId,
+                PartNumber: i + 1,
+            });
+            return getSignedUrl(client, command, { expiresIn });
+        })
+    );
+
+    return urls;
+}
+
+/** Complete a multipart upload — client must provide ETags received from each part PUT */
+export async function complete(
+    key: string,
+    uploadId: string,
+    parts: CompletePart[]
+): Promise<void> {
+    const command = new CompleteMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId,
+        MultipartUpload: {
+            Parts: parts.map((p) => ({
+                PartNumber: p.partNumber,
+                ETag: p.etag,
+            })),
+        },
+    });
+    await client.send(command);
+}
+
+/** Abort a multipart upload, cleaning up any uploaded parts on S3 */
+export async function abort(key: string, uploadId: string): Promise<void> {
+    const command = new AbortMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId,
+    });
+    await client.send(command);
+}

--- a/apps/web/lib/storage/testing.ts
+++ b/apps/web/lib/storage/testing.ts
@@ -48,10 +48,24 @@ const objectsMocks = {
     remove: async (): Promise<void> => {},
 };
 
+const multipartMocks = {
+    create: async (): Promise<{ uploadId: string }> => ({
+        uploadId: 'mock-upload-id',
+    }),
+    signParts: async (options: { partCount: number }): Promise<string[]> =>
+        Array.from(
+            { length: options.partCount },
+            (_, i) => `${MOCK_HOST}/${MOCK_BUCKET}/part-${i + 1}`
+        ),
+    complete: async (): Promise<void> => {},
+    abort: async (): Promise<void> => {},
+};
+
 interface MockS3 {
     presigned: typeof presignedMocks;
     glacier: typeof glacierMocks;
     objects: typeof objectsMocks;
+    multipart: typeof multipartMocks;
 }
 
 /**
@@ -79,6 +93,7 @@ export function createPresignedMocks(): MockS3 {
         presigned: presignedMocks,
         glacier: glacierMocks,
         objects: objectsMocks,
+        multipart: multipartMocks,
     };
 }
 

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -5,7 +5,11 @@ import {
     TEST_USER_ID,
 } from '@nexus/db/testing';
 import { mockS3 } from '@/lib/storage/testing';
-import { NotFoundError, QuotaExceededError } from '@/server/errors';
+import {
+    NotFoundError,
+    QuotaExceededError,
+    InvalidStateError,
+} from '@/server/errors';
 import { fileService } from './files';
 
 vi.mock('@/lib/storage', () => ({
@@ -272,6 +276,163 @@ describe('files service', () => {
                     ])
                 ).rejects.toThrow(NotFoundError);
             });
+        });
+    });
+
+    describe('initiateMultipartUpload', () => {
+        it('returns fileId, uploadId, partUrls, chunkSize, and expiresAt', async () => {
+            mocks.where.mockResolvedValue([{ total: 0 }]);
+            const insertedFile = createFileFixture({ status: 'uploading' });
+            mocks.returning.mockResolvedValue([insertedFile]);
+
+            const result = await fileService.initiateMultipartUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'large-file.zip',
+                    sizeBytes: 50 * 1024 * 1024, // 50MB = 5 parts
+                    mimeType: 'application/zip',
+                }
+            );
+
+            expect(result).toHaveProperty('fileId');
+            expect(result).toHaveProperty('uploadId', 'mock-upload-id');
+            expect(result.partUrls).toHaveLength(5);
+            expect(result.chunkSize).toBe(10 * 1024 * 1024);
+            expect(result.expiresAt).toBeInstanceOf(Date);
+        });
+
+        it('throws QuotaExceededError when storage limit exceeded', async () => {
+            const tenGBMinus1 = 10 * 1024 * 1024 * 1024 - 1;
+            mocks.where.mockResolvedValue([{ total: tenGBMinus1 }]);
+
+            await expect(
+                fileService.initiateMultipartUpload(db, TEST_USER_ID, {
+                    name: 'large-file.zip',
+                    sizeBytes: 2,
+                })
+            ).rejects.toThrow(QuotaExceededError);
+        });
+
+        it('creates file record with status uploading', async () => {
+            mocks.where.mockResolvedValue([{ total: 0 }]);
+            const insertedFile = createFileFixture({ status: 'uploading' });
+            mocks.returning.mockResolvedValue([insertedFile]);
+
+            await fileService.initiateMultipartUpload(db, TEST_USER_ID, {
+                name: 'large-file.zip',
+                sizeBytes: 50 * 1024 * 1024,
+            });
+
+            expect(mocks.insert).toHaveBeenCalledOnce();
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: TEST_USER_ID,
+                    name: 'large-file.zip',
+                    status: 'uploading',
+                })
+            );
+        });
+
+        it('calculates correct part count for exact chunk boundary', async () => {
+            mocks.where.mockResolvedValue([{ total: 0 }]);
+            const insertedFile = createFileFixture({ status: 'uploading' });
+            mocks.returning.mockResolvedValue([insertedFile]);
+
+            const result = await fileService.initiateMultipartUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'exact.bin',
+                    sizeBytes: 20 * 1024 * 1024, // exactly 2 chunks
+                }
+            );
+
+            expect(result.partUrls).toHaveLength(2);
+        });
+    });
+
+    describe('completeMultipartUpload', () => {
+        it('transitions file to available status', async () => {
+            const uploadingFile = createFileFixture({ status: 'uploading' });
+            const availableFile = createFileFixture({ status: 'available' });
+            mocks.findFirst.mockResolvedValue(uploadingFile);
+            mocks.returning.mockResolvedValue([availableFile]);
+
+            const result = await fileService.completeMultipartUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    fileId: uploadingFile.id,
+                    uploadId: 'some-upload-id',
+                    parts: [{ partNumber: 1, etag: '"abc123"' }],
+                }
+            );
+
+            expect(result.file.status).toBe('available');
+            expect(mocks.set).toHaveBeenCalledWith({ status: 'available' });
+        });
+
+        it('throws NotFoundError when file does not exist', async () => {
+            mocks.findFirst.mockResolvedValue(undefined);
+
+            await expect(
+                fileService.completeMultipartUpload(db, TEST_USER_ID, {
+                    fileId: 'nonexistent',
+                    uploadId: 'some-upload-id',
+                    parts: [{ partNumber: 1, etag: '"abc"' }],
+                })
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('throws InvalidStateError when file is not uploading', async () => {
+            const availableFile = createFileFixture({ status: 'available' });
+            mocks.findFirst.mockResolvedValue(availableFile);
+
+            await expect(
+                fileService.completeMultipartUpload(db, TEST_USER_ID, {
+                    fileId: availableFile.id,
+                    uploadId: 'some-upload-id',
+                    parts: [{ partNumber: 1, etag: '"abc"' }],
+                })
+            ).rejects.toThrow(InvalidStateError);
+        });
+    });
+
+    describe('abortMultipartUpload', () => {
+        it('soft-deletes the file record', async () => {
+            const uploadingFile = createFileFixture({ status: 'uploading' });
+            mocks.findFirst.mockResolvedValue(uploadingFile);
+            mocks.returning.mockResolvedValue([
+                { ...uploadingFile, status: 'deleted' },
+            ]);
+
+            await fileService.abortMultipartUpload(
+                db,
+                TEST_USER_ID,
+                uploadingFile.id,
+                'some-upload-id'
+            );
+
+            expect(mocks.set).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    status: 'deleted',
+                    deletedAt: expect.any(Date),
+                })
+            );
+        });
+
+        it('throws NotFoundError when file does not exist', async () => {
+            mocks.findFirst.mockResolvedValue(undefined);
+
+            await expect(
+                fileService.abortMultipartUpload(
+                    db,
+                    TEST_USER_ID,
+                    'nonexistent',
+                    'some-upload-id'
+                )
+            ).rejects.toThrow(NotFoundError);
         });
     });
 });

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -1,12 +1,18 @@
 import type { DB } from '@nexus/db';
 import { createFileRepo, type File } from '@nexus/db/repo/files';
-import { NotFoundError, QuotaExceededError } from '@/server/errors';
+import {
+    NotFoundError,
+    QuotaExceededError,
+    InvalidStateError,
+} from '@/server/errors';
 import { s3 } from '@/lib/storage';
 
 const MAX_STORAGE_BYTES = 10 * 1024 * 1024 * 1024; // 10GB for MVP
 const PRESIGNED_URL_EXPIRY_SECONDS = 900; // 15 minutes
+const MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024; // 10MB
+const MULTIPART_URL_EXPIRY_SECONDS = 3600; // 1 hour
 
-interface InitiateUploadInput {
+interface UploadInput {
     name: string;
     sizeBytes: number;
     mimeType?: string;
@@ -18,6 +24,24 @@ interface InitiateUploadResult {
     expiresAt: Date;
 }
 
+interface InitiateMultipartResult {
+    fileId: string;
+    uploadId: string;
+    partUrls: string[];
+    chunkSize: number;
+    expiresAt: Date;
+}
+
+interface CompleteMultipartInput {
+    fileId: string;
+    uploadId: string;
+    parts: { partNumber: number; etag: string }[];
+}
+
+interface CompleteMultipartResult {
+    file: File;
+}
+
 interface ConfirmUploadResult {
     file: File;
 }
@@ -25,7 +49,7 @@ interface ConfirmUploadResult {
 async function initiateUpload(
     db: DB,
     userId: string,
-    input: InitiateUploadInput
+    input: UploadInput
 ): Promise<InitiateUploadResult> {
     const fileRepo = createFileRepo(db);
     const currentUsage = await fileRepo.sumStorageByUser(userId);
@@ -85,7 +109,102 @@ async function confirmUpload(
     return { file: updated };
 }
 
-// Overload signatures
+async function initiateMultipartUpload(
+    db: DB,
+    userId: string,
+    input: UploadInput
+): Promise<InitiateMultipartResult> {
+    const fileRepo = createFileRepo(db);
+    const currentUsage = await fileRepo.sumStorageByUser(userId);
+    if (currentUsage + input.sizeBytes > MAX_STORAGE_BYTES) {
+        throw new QuotaExceededError('Storage quota exceeded');
+    }
+
+    const fileId = crypto.randomUUID();
+    const s3Key = `${userId}/${fileId}/${input.name}`;
+    const partCount = Math.ceil(input.sizeBytes / MULTIPART_CHUNK_SIZE);
+
+    const { uploadId } = await s3.multipart.create(s3Key, input.mimeType);
+
+    const partUrls = await s3.multipart.signParts({
+        key: s3Key,
+        uploadId,
+        partCount,
+        expiresIn: MULTIPART_URL_EXPIRY_SECONDS,
+    });
+
+    await fileRepo.insert({
+        id: fileId,
+        userId,
+        name: input.name,
+        size: input.sizeBytes,
+        mimeType: input.mimeType ?? null,
+        s3Key,
+        status: 'uploading',
+    });
+
+    const expiresAt = new Date(
+        Date.now() + MULTIPART_URL_EXPIRY_SECONDS * 1000
+    );
+
+    return {
+        fileId,
+        uploadId,
+        partUrls,
+        chunkSize: MULTIPART_CHUNK_SIZE,
+        expiresAt,
+    };
+}
+
+async function completeMultipartUpload(
+    db: DB,
+    userId: string,
+    input: CompleteMultipartInput
+): Promise<CompleteMultipartResult> {
+    const fileRepo = createFileRepo(db);
+    const file = await fileRepo.findByUserAndId(userId, input.fileId);
+    if (!file) {
+        throw new NotFoundError('File', input.fileId);
+    }
+    if (file.status !== 'uploading') {
+        throw new InvalidStateError(
+            `File is not in uploading state: ${file.status}`
+        );
+    }
+
+    await s3.multipart.complete(file.s3Key, input.uploadId, input.parts);
+
+    const updated = await fileRepo.update(input.fileId, {
+        status: 'available',
+    });
+
+    if (!updated) {
+        throw new NotFoundError('File', input.fileId);
+    }
+
+    return { file: updated };
+}
+
+async function abortMultipartUpload(
+    db: DB,
+    userId: string,
+    fileId: string,
+    uploadId: string
+): Promise<void> {
+    const fileRepo = createFileRepo(db);
+    const file = await fileRepo.findByUserAndId(userId, fileId);
+    if (!file) {
+        throw new NotFoundError('File', fileId);
+    }
+
+    await s3.multipart.abort(file.s3Key, uploadId);
+
+    await fileRepo.update(fileId, {
+        status: 'deleted',
+        deletedAt: new Date(),
+    });
+}
+
 function deleteUserFile(db: DB, userId: string, fileId: string): Promise<File>;
 function deleteUserFile(
     db: DB,
@@ -120,5 +239,8 @@ async function deleteUserFile(
 export const fileService = {
     initiateUpload,
     confirmUpload,
+    initiateMultipartUpload,
+    completeMultipartUpload,
+    abortMultipartUpload,
     deleteUserFile,
 } as const;

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -5,6 +5,12 @@ import { fileService } from '@/server/services/files';
 import { retrievalService } from '@/server/services/retrieval';
 import { protectedProcedure, router } from '../init';
 
+const uploadInputSchema = z.object({
+    name: z.string().min(1).max(255),
+    sizeBytes: z.number().positive(),
+    mimeType: z.string().optional(),
+});
+
 export const filesRouter = router({
     list: protectedProcedure
         .input(
@@ -48,13 +54,7 @@ export const filesRouter = router({
         }),
 
     upload: protectedProcedure
-        .input(
-            z.object({
-                name: z.string().min(1).max(255),
-                sizeBytes: z.number().positive(),
-                mimeType: z.string().optional(),
-            })
-        )
+        .input(uploadInputSchema)
         .mutation(({ ctx, input }) => {
             return fileService.initiateUpload(
                 ctx.db,
@@ -134,4 +134,56 @@ export const filesRouter = router({
                 input.fileId
             );
         }),
+
+    multipart: router({
+        init: protectedProcedure
+            .input(uploadInputSchema)
+            .mutation(({ ctx, input }) => {
+                return fileService.initiateMultipartUpload(
+                    ctx.db,
+                    ctx.session.user.id,
+                    input
+                );
+            }),
+
+        complete: protectedProcedure
+            .input(
+                z.object({
+                    fileId: z.string().uuid(),
+                    uploadId: z.string().min(1),
+                    parts: z
+                        .array(
+                            z.object({
+                                partNumber: z.number().int().positive(),
+                                etag: z.string().min(1),
+                            })
+                        )
+                        .min(1)
+                        .max(10000),
+                })
+            )
+            .mutation(({ ctx, input }) => {
+                return fileService.completeMultipartUpload(
+                    ctx.db,
+                    ctx.session.user.id,
+                    input
+                );
+            }),
+
+        abort: protectedProcedure
+            .input(
+                z.object({
+                    fileId: z.string().uuid(),
+                    uploadId: z.string().min(1),
+                })
+            )
+            .mutation(({ ctx, input }) => {
+                return fileService.abortMultipartUpload(
+                    ctx.db,
+                    ctx.session.user.id,
+                    input.fileId,
+                    input.uploadId
+                );
+            }),
+    }),
 });

--- a/docs/infra/aws-manual-setup.md
+++ b/docs/infra/aws-manual-setup.md
@@ -59,6 +59,7 @@ Allows requests from:
 - `https://*.vercel.app`
 
 Methods: GET, PUT, POST, DELETE, HEAD
+Exposed headers: `ETag` (required for multipart uploads — client must read part ETags)
 
 ## IAM Policy
 
@@ -76,7 +77,9 @@ The `nexus-app-dev` user has the following permissions on the bucket:
                 "s3:DeleteObject",
                 "s3:ListBucket",
                 "s3:RestoreObject",
-                "s3:GetObjectAttributes"
+                "s3:GetObjectAttributes",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts"
             ],
             "Resource": [
                 "arn:aws:s3:::nexus-storage-files-dev",


### PR DESCRIPTION
## Summary

Add backend API for S3 multipart uploads, enabling reliable upload of large files (>100MB). New `s3.multipart.*` storage module, service layer functions, and nested tRPC router — all non-breaking alongside the existing single-PUT upload flow.

Closes #27

## Changes

- New `lib/storage/multipart.ts` with `create`, `signParts`, `complete`, `abort` functions
- `s3.multipart.*` namespace exported from storage index
- Service functions: `initiateMultipartUpload`, `completeMultipartUpload`, `abortMultipartUpload` with quota check, state validation, and soft-delete on abort
- Nested tRPC router: `files.multipart.init`, `files.multipart.complete`, `files.multipart.abort`
- Shared `UploadInput` type and `uploadInputSchema` (deduplicated from single-PUT flow)
- Mock `s3.multipart.*` added to `lib/storage/testing.ts`
- Unit tests for multipart storage functions (6 tests) and service functions (9 tests)

## Manual AWS Setup Required

- S3 CORS: expose `ETag` header (needed for client to read part ETags)
- IAM policy: add `s3:AbortMultipartUpload` and `s3:ListMultipartUploadParts`

## Test Plan

- [x] `pnpm check` passes (lint + build + 165 tests)
- [ ] Verify multipart init returns `uploadId`, `partUrls`, `chunkSize`, `expiresAt`
- [ ] Verify complete transitions file to `available`
- [ ] Verify abort soft-deletes file and calls S3 AbortMultipartUpload
- [ ] Verify quota check blocks uploads exceeding 10GB limit