### PR TITLE
fix: use opus for groom skill review agents

### DIFF
--- a/.claude/skills/groom/SKILL.md
+++ b/.claude/skills/groom/SKILL.md
@@ -195,7 +195,7 @@ Before presenting drafts to the user, review them for quality and codebase align
 
 ### For Each Draft:
 
-1. **Spawn three review agents in the same message** (do NOT use `run_in_background` — make all three Task calls in one message so they run concurrently and return results directly). **Use `model: "sonnet"` for all review agents** — do not let them default to haiku:
+1. **Spawn three review agents in the same message** (do NOT use `run_in_background` — make all three Task calls in one message so they run concurrently and return results directly). **Use `model: "opus"` for all review agents** — do not let them default to haiku:
 
     **Issue Quality Review** (subagent_type: "general-purpose"):
     - Review the draft against `.claude/skills/groom/templates/review-criteria.md`


### PR DESCRIPTION
## Summary
- Groom skill's self-review step was defaulting to haiku for the three general-purpose review agents
- Explicitly specify `model: "opus"` to ensure quality reviews

No-Issue: config fix for AI agent model selection