### PR TITLE
docs: add E2E testing decision framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,10 +145,11 @@ docs/
 
 ### Required Reading
 
-| When                             | You MUST read                                               |
-| -------------------------------- | ----------------------------------------------------------- |
-| Before writing any code          | `docs/ai/conventions.md` - naming, structure, code style    |
-| When unfamiliar with the project | `docs/ai/context.md` - data model, architecture, tech stack |
+| When                             | You MUST read                                                         |
+| -------------------------------- | --------------------------------------------------------------------- |
+| Before writing any code          | `docs/ai/conventions.md` - naming, structure, code style              |
+| When unfamiliar with the project | `docs/ai/context.md` - data model, architecture, tech stack           |
+| When writing UI features         | `docs/guides/e2e-testing-guidelines.md` - E2E test decision framework |
 
 ## Git Commits
 

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -23,6 +23,7 @@ Technical documentation, setup guides, and implementation patterns for the Nexus
 - [[background-jobs|Background Jobs Runbook]] - AWS resource ARNs, deployment, and operations
 - [[webhooks|Webhook Handling]] - Webhook handler architecture, idempotency, and testing patterns
 - [[db-subpaths|@nexus/db Subpath Exports]] - Subpath conventions, factory pattern, DB type rationale
+- [[e2e-testing-guidelines|E2E Testing Guidelines]] - When to write Playwright E2E tests vs smoke + unit tests
 
 ## Dataview
 

--- a/docs/guides/e2e-testing-guidelines.md
+++ b/docs/guides/e2e-testing-guidelines.md
@@ -1,0 +1,63 @@
+---
+title: E2E Testing Guidelines
+created: 2026-03-07
+updated: 2026-03-07
+status: active
+tags:
+    - guide
+    - testing
+    - playwright
+    - e2e
+aliases:
+    - E2E Testing Guide
+    - Playwright Guidelines
+---
+
+# E2E Testing Guidelines
+
+Decision framework for when AI agents should write Playwright E2E tests vs rely on smoke tests + unit tests.
+
+## Decision Framework
+
+| Question                                            | If YES          | If NO        |
+| --------------------------------------------------- | --------------- | ------------ |
+| Does the feature have multi-step user interactions? | E2E test        | Smoke + unit |
+| Does it depend on auth guards or role-based access? | E2E test        | Smoke + unit |
+| Does it filter, paginate, or sort server data?      | E2E test        | Smoke + unit |
+| Is it a new page with no interactivity?             | Smoke test only | —            |
+| Is it a pure utility or business logic function?    | Unit test only  | —            |
+
+**Default: smoke test + unit tests.** Only add targeted E2E tests when the interaction complexity makes unit tests fundamentally insufficient.
+
+## When E2E Tests Add Value
+
+Write a Playwright E2E test when the feature involves:
+
+- **Auth guards** — Verifying redirects, role-based access control, protected routes
+- **Data-driven UI** — Filtering, pagination, sorting with real server data
+- **Multi-step flows** — Wizards, multi-step forms, sequential user actions
+- **Interactive state changes** — Retry buttons, status transitions, optimistic updates
+- **Cross-component coordination** — Actions in one component affecting another
+
+**Prior art:** `apps/web/e2e/admin/jobs.spec.ts` — tests auth guards, status filtering, pagination, and retry actions on the admin jobs dashboard.
+
+## When Smoke + Unit Tests Are Sufficient
+
+Don't write E2E tests for:
+
+- **Static pages** — Landing pages, about pages, documentation views
+- **Simple forms** — Single-step forms with basic validation (unit test the schema)
+- **Display-only components** — Cards, lists, dashboards that just render data
+- **Pure logic** — Utilities, formatters, validators (unit test these)
+- **Layout changes** — Header, sidebar, footer updates
+
+Smoke tests already verify these pages render without console errors.
+
+## Writing & Running Tests
+
+See [[../conventions/testing|Testing Conventions]] for test structure patterns, helpers, gotchas, and run commands.
+
+## Related
+
+- [[../conventions/testing|Testing Conventions]] - Smoke test patterns, auth setup, unit test guidance
+- [[../ai/conventions|Code Conventions]] - Project-wide conventions reference


### PR DESCRIPTION
## Summary

Add guidelines for when AI agents should write Playwright E2E tests vs rely on smoke + unit tests. Provides a decision framework table and clear examples of features that warrant each test type.

Closes #166

## Changes

- New `docs/guides/e2e-testing-guidelines.md` with decision framework, "when to" / "when not to" sections, and cross-reference to existing testing conventions
- Added entry to `docs/guides/_index.md`
- Added "When writing UI features" row to CLAUDE.md Required Reading table

## Test Plan

- [x] `pnpm check` passes (lint + build + test)
- [ ] Review guide content aligns with existing patterns in `apps/web/e2e/`
- [ ] Verify no duplication with `docs/conventions/testing.md` (structural details deferred there via cross-reference)