### PR TITLE
feat: add AlertDialog component for confirmation dialogs (#158)

### DIFF
--- a/apps/web/components/dashboard/file-browser.tsx
+++ b/apps/web/components/dashboard/file-browser.tsx
@@ -5,6 +5,15 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogDescription,
+    AlertDialogPopup,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -184,16 +193,8 @@ export function FileBrowser() {
     };
 
     function handleBulkDelete() {
-        // TODO: Replace with AlertDialog component when available
-        const count = selectedFiles.length;
-        if (
-            window.confirm(
-                `Delete ${count} file${count > 1 ? 's' : ''}? This cannot be undone.`
-            )
-        ) {
-            deleteManyMutation.reset();
-            deleteManyMutation.mutate({ ids: selectedFiles });
-        }
+        deleteManyMutation.reset();
+        deleteManyMutation.mutate({ ids: selectedFiles });
     }
 
     function handleBulkRetrieval() {
@@ -275,20 +276,46 @@ export function FileBrowser() {
                                 )}
                                 Retrieve
                             </Button>
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                className="text-destructive hover:text-destructive bg-transparent"
-                                onClick={handleBulkDelete}
-                                disabled={deleteManyMutation.isPending}
-                            >
-                                {deleteManyMutation.isPending ? (
-                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                ) : (
-                                    <Trash2 className="mr-2 h-4 w-4" />
-                                )}
-                                Delete
-                            </Button>
+                            <AlertDialog>
+                                <AlertDialogTrigger
+                                    render={
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="text-destructive hover:text-destructive bg-transparent"
+                                        />
+                                    }
+                                    disabled={deleteManyMutation.isPending}
+                                >
+                                    {deleteManyMutation.isPending ? (
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    ) : (
+                                        <Trash2 className="mr-2 h-4 w-4" />
+                                    )}
+                                    Delete
+                                </AlertDialogTrigger>
+                                <AlertDialogPopup>
+                                    <AlertDialogTitle>
+                                        Delete {selectedFiles.length} file
+                                        {selectedFiles.length > 1 ? 's' : ''}?
+                                    </AlertDialogTitle>
+                                    <AlertDialogDescription>
+                                        This action cannot be undone. The
+                                        selected files will be permanently
+                                        deleted.
+                                    </AlertDialogDescription>
+                                    <div className="flex justify-end gap-2">
+                                        <AlertDialogCancel>
+                                            Cancel
+                                        </AlertDialogCancel>
+                                        <AlertDialogAction
+                                            onClick={handleBulkDelete}
+                                        >
+                                            Delete
+                                        </AlertDialogAction>
+                                    </div>
+                                </AlertDialogPopup>
+                            </AlertDialog>
                         </div>
                     )}
                     {hasRestoringFiles && (

--- a/apps/web/components/ui/alert-dialog.tsx
+++ b/apps/web/components/ui/alert-dialog.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { AlertDialog as AlertDialogPrimitive } from '@base-ui/react/alert-dialog';
+import { type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/cn';
+import { buttonVariants } from '@/components/ui/button';
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+    return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+    return (
+        <AlertDialogPrimitive.Trigger
+            data-slot="alert-dialog-trigger"
+            {...props}
+        />
+    );
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+    return (
+        <AlertDialogPrimitive.Portal
+            data-slot="alert-dialog-portal"
+            {...props}
+        />
+    );
+}
+
+function AlertDialogBackdrop({
+    className,
+    ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+    return (
+        <AlertDialogPrimitive.Backdrop
+            data-slot="alert-dialog-backdrop"
+            className={cn(
+                'data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+                className
+            )}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogPopup({
+    className,
+    children,
+    ...props
+}: AlertDialogPrimitive.Popup.Props) {
+    return (
+        <AlertDialogPortal>
+            <AlertDialogBackdrop />
+            <AlertDialogPrimitive.Popup
+                data-slot="alert-dialog-popup"
+                className={cn(
+                    'bg-background data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:zoom-out-95 data-[open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+                    className
+                )}
+                {...props}
+            >
+                {children}
+            </AlertDialogPrimitive.Popup>
+        </AlertDialogPortal>
+    );
+}
+
+function AlertDialogTitle({
+    className,
+    ...props
+}: AlertDialogPrimitive.Title.Props) {
+    return (
+        <AlertDialogPrimitive.Title
+            data-slot="alert-dialog-title"
+            className={cn('text-lg font-semibold', className)}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogDescription({
+    className,
+    ...props
+}: AlertDialogPrimitive.Description.Props) {
+    return (
+        <AlertDialogPrimitive.Description
+            data-slot="alert-dialog-description"
+            className={cn('text-muted-foreground text-sm', className)}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogAction({
+    className,
+    variant = 'destructive',
+    size,
+    ...props
+}: AlertDialogPrimitive.Close.Props & VariantProps<typeof buttonVariants>) {
+    return (
+        <AlertDialogPrimitive.Close
+            data-slot="alert-dialog-action"
+            className={cn(buttonVariants({ variant, size }), className)}
+            {...props}
+        />
+    );
+}
+
+function AlertDialogCancel({
+    className,
+    ...props
+}: AlertDialogPrimitive.Close.Props) {
+    return (
+        <AlertDialogPrimitive.Close
+            data-slot="alert-dialog-cancel"
+            className={cn(buttonVariants({ variant: 'outline' }), className)}
+            {...props}
+        />
+    );
+}
+
+export {
+    AlertDialog,
+    AlertDialogTrigger,
+    AlertDialogPortal,
+    AlertDialogBackdrop,
+    AlertDialogPopup,
+    AlertDialogTitle,
+    AlertDialogDescription,
+    AlertDialogAction,
+    AlertDialogCancel,
+};


### PR DESCRIPTION
## Summary

Add a reusable AlertDialog compound component built on `@base-ui/react/alert-dialog` and wire it into the FileBrowser to replace `window.confirm()` for bulk file deletion.

Closes #158

## Changes

- Add `AlertDialog` compound component at `components/ui/alert-dialog.tsx` with sub-components: Root, Trigger, Portal, Backdrop, Popup, Title, Description, Action, Cancel
- `AlertDialogAction` accepts a `variant` prop (default `"destructive"`) using existing `buttonVariants`
- `AlertDialogCancel` uses outline button styling
- Centered overlay with zoom-in/zoom-out + fade enter/exit animations
- Replace `window.confirm()` in FileBrowser `handleBulkDelete` with AlertDialog
- Remove TODO comment referencing AlertDialog

## Test Plan

- [ ] Select files in FileBrowser → click Delete → AlertDialog appears with title, description, Cancel/Delete buttons
- [ ] Click Cancel → dialog closes, no files deleted
- [ ] Click Delete → dialog closes, files are deleted
- [ ] Press ESC → dialog closes
- [ ] Clicking backdrop does NOT close dialog (alertdialog behavior)
- [ ] Cancel button receives initial focus
- [ ] `pnpm check` passes (lint + build + test)
- [ ] `pnpm -F web test:e2e:smoke` passes (12/12)