### PR TITLE
fix(ci): provide client env vars to post-merge smoke tests

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -44,3 +44,8 @@ jobs:
 
             - name: Run smoke tests
               run: pnpm -F web test:e2e:smoke
+              env:
+                  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+                  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+                  NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLIC_KEY }}
+                  NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}


### PR DESCRIPTION
## Summary
- Post-merge smoke tests were failing because `NEXT_PUBLIC_*` client env vars were missing in CI
- Added the 4 required client env vars as GitHub secrets referenced in the workflow

## Test plan
- [ ] Verify post-merge workflow passes after merging

No-Issue: CI fix for missing env vars in smoke tests