### PR TITLE
fix(ci): add server env vars to post-merge smoke tests

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -49,3 +49,13 @@ jobs:
                   NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
                   NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLIC_KEY }}
                   NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+                  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+                  SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  AWS_REGION: ${{ secrets.AWS_REGION }}
+                  S3_BUCKET: ${{ secrets.S3_BUCKET }}
+                  SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
+                  STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+                  STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+                  BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}


### PR DESCRIPTION
## Summary
- Post-merge smoke tests hit API routes that trigger server env validation
- Added all 10 server env vars as GitHub secrets referenced in the workflow
- Previous PR (#179) added client vars but server vars were still missing

## Test plan
- [ ] Verify post-merge workflow passes after merging

No-Issue: CI fix for missing env vars in smoke tests