### PR TITLE
feat: add Stripe webhook handler & subscription API

### DIFF
--- a/apps/web/app/api/dev-log/route.test.ts
+++ b/apps/web/app/api/dev-log/route.test.ts
@@ -2,26 +2,17 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import type { LogEvent } from 'pino';
 
-const mockChild = vi.hoisted(() => ({
-    trace: vi.fn(),
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    fatal: vi.fn(),
-}));
-
-// Mock the logger module
-vi.mock('@/server/lib/logger', () => {
-    return {
-        logger: {
-            child: vi.fn(() => mockChild),
-        },
-    };
+const hoisted = await vi.hoisted(async () => {
+    const { createMockLogger } = await import('@/server/lib/logger/testing');
+    return { logger: createMockLogger() };
 });
+
+vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
 
 // Import after mock setup
 import { POST } from './route';
+
+const mockChild = hoisted.logger;
 
 function createLogEvent(overrides: Partial<LogEvent> = {}): LogEvent {
     return {

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -217,13 +217,15 @@ describe('POST /api/webhooks/stripe', () => {
             expect(mocks.insert).not.toHaveBeenCalled();
         });
 
-        it('treats unique-constraint failure on insert as a duplicate', async () => {
+        it('treats Postgres unique-violation on insert as a duplicate', async () => {
             // Concurrent redelivery: the find() race lost, the insert hits the
-            // unique index. Production code should swallow it as a duplicate.
+            // unique index. Production code should swallow code 23505 only.
             mocks.webhookEvents.findFirst.mockResolvedValue(undefined);
-            mocks.returning.mockRejectedValue(
-                new Error('duplicate key value violates unique constraint')
+            const uniqueViolation = Object.assign(
+                new Error('duplicate key value violates unique constraint'),
+                { code: '23505' }
             );
+            mocks.returning.mockRejectedValue(uniqueViolation);
 
             const response = await POST(makeRequest(sampleEvent));
 
@@ -232,6 +234,18 @@ describe('POST /api/webhooks/stripe', () => {
                 received: true,
                 duplicate: true,
             });
+            expect(dispatchWebhookEvent).not.toHaveBeenCalled();
+        });
+
+        it('rethrows non-unique-violation insert errors instead of masking them', async () => {
+            // A schema mismatch or connection drop must NOT be silently
+            // reported as a duplicate — Stripe needs to retry the delivery.
+            mocks.webhookEvents.findFirst.mockResolvedValue(undefined);
+            mocks.returning.mockRejectedValue(new Error('connection refused'));
+
+            await expect(POST(makeRequest(sampleEvent))).rejects.toThrow(
+                'connection refused'
+            );
             expect(dispatchWebhookEvent).not.toHaveBeenCalled();
         });
     });

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type Stripe from 'stripe';
+import { createWebhookEventFixture } from '@nexus/db/testing';
+
+const hoisted = await vi.hoisted(async () => {
+    const { createMockLogger } = await import('@/server/lib/logger/testing');
+    const { createMockStripe } = await import('@/lib/stripe/testing');
+    const { createMockDb } = await import('@nexus/db/testing');
+    return {
+        logger: createMockLogger(),
+        ...createMockStripe(),
+        mockDb: createMockDb(),
+        dispatchWebhookEvent: vi.fn(),
+    };
+});
+
+vi.mock('@/lib/env', () => ({
+    env: {
+        NEXT_PUBLIC_APP_URL: 'https://test.example',
+        STRIPE_SECRET_KEY: 'sk_test',
+    },
+}));
+
+vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
+
+vi.mock('@/lib/stripe', () => ({
+    stripe: hoisted.stripe,
+    stripeClient: hoisted.stripeClient,
+}));
+
+// The route imports `db` directly, not through a factory. We point it at the
+// shared mock db so test setup can drive it via `mocks.webhookEvents.findFirst`.
+vi.mock('@/server/db', () => ({ db: hoisted.mockDb.db }));
+
+vi.mock('@/server/services/subscriptions', () => ({
+    subscriptionService: { dispatchWebhookEvent: hoisted.dispatchWebhookEvent },
+}));
+
+import { POST } from './route';
+
+const constructEvent = hoisted.stripe.webhooks.constructEvent;
+const dispatchWebhookEvent = hoisted.dispatchWebhookEvent;
+const mocks = hoisted.mockDb.mocks;
+
+function makeRequest(
+    body: string | object,
+    headers: Record<string, string> = {}
+): NextRequest {
+    return new NextRequest('http://localhost/api/webhooks/stripe', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...headers },
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+    });
+}
+
+const sampleEvent = {
+    id: 'evt_test_123',
+    type: 'customer.subscription.updated',
+    data: { object: {} },
+} as unknown as Stripe.Event;
+
+describe('POST /api/webhooks/stripe', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Reset shared mock state since vi.clearAllMocks does not reset
+        // mockResolvedValue defaults set in createMockDb (e.g. returning -> []).
+        mocks.returning.mockResolvedValue([]);
+        mocks.webhookEvents.findFirst.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    describe('production mode (signature verification)', () => {
+        beforeEach(() => {
+            vi.stubEnv('NODE_ENV', 'production');
+        });
+
+        it('returns 400 when stripe-signature header is missing', async () => {
+            const response = await POST(makeRequest(sampleEvent));
+
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toEqual({
+                error: 'Missing stripe-signature header',
+            });
+            expect(constructEvent).not.toHaveBeenCalled();
+        });
+
+        it('returns 400 when signature verification fails', async () => {
+            constructEvent.mockImplementation(() => {
+                throw new Error('bad signature');
+            });
+
+            const response = await POST(
+                makeRequest(sampleEvent, { 'stripe-signature': 'sig_bad' })
+            );
+
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toEqual({
+                error: 'Invalid signature',
+            });
+            expect(dispatchWebhookEvent).not.toHaveBeenCalled();
+        });
+
+        it('processes event when signature is valid', async () => {
+            constructEvent.mockReturnValue(sampleEvent);
+            mocks.returning.mockResolvedValue([
+                createWebhookEventFixture({ externalId: sampleEvent.id }),
+            ]);
+
+            const response = await POST(
+                makeRequest(sampleEvent, { 'stripe-signature': 'sig_good' })
+            );
+
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({ received: true });
+            expect(dispatchWebhookEvent).toHaveBeenCalledWith(
+                hoisted.mockDb.db,
+                sampleEvent
+            );
+        });
+    });
+
+    describe('development mode (signature bypass)', () => {
+        beforeEach(() => {
+            vi.stubEnv('NODE_ENV', 'development');
+        });
+
+        it('parses event from raw JSON without signature', async () => {
+            mocks.returning.mockResolvedValue([
+                createWebhookEventFixture({ externalId: sampleEvent.id }),
+            ]);
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            expect(response.status).toBe(200);
+            expect(constructEvent).not.toHaveBeenCalled();
+            expect(dispatchWebhookEvent).toHaveBeenCalledWith(
+                hoisted.mockDb.db,
+                expect.objectContaining({ id: sampleEvent.id })
+            );
+        });
+
+        it('returns 400 on malformed JSON body', async () => {
+            const response = await POST(makeRequest('{ not json'));
+
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toEqual({
+                error: 'Invalid JSON',
+            });
+            expect(dispatchWebhookEvent).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('idempotency', () => {
+        beforeEach(() => {
+            vi.stubEnv('NODE_ENV', 'development');
+        });
+
+        it('skips dispatch when event id already recorded', async () => {
+            mocks.webhookEvents.findFirst.mockResolvedValue(
+                createWebhookEventFixture({
+                    externalId: sampleEvent.id,
+                    status: 'processed',
+                })
+            );
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({
+                received: true,
+                duplicate: true,
+            });
+            expect(dispatchWebhookEvent).not.toHaveBeenCalled();
+            expect(mocks.insert).not.toHaveBeenCalled();
+        });
+
+        it('treats unique-constraint failure on insert as a duplicate', async () => {
+            // Concurrent redelivery: the find() race lost, the insert hits the
+            // unique index. Production code should swallow it as a duplicate.
+            mocks.webhookEvents.findFirst.mockResolvedValue(undefined);
+            mocks.returning.mockRejectedValue(
+                new Error('duplicate key value violates unique constraint')
+            );
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({
+                received: true,
+                duplicate: true,
+            });
+            expect(dispatchWebhookEvent).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('dispatch outcome', () => {
+        beforeEach(() => {
+            vi.stubEnv('NODE_ENV', 'development');
+            mocks.returning.mockResolvedValue([
+                createWebhookEventFixture({ externalId: sampleEvent.id }),
+            ]);
+        });
+
+        it('marks event processed and returns 200 on success', async () => {
+            dispatchWebhookEvent.mockResolvedValue(undefined);
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({ received: true });
+            expect(mocks.update).toHaveBeenCalled();
+            expect(mocks.set).toHaveBeenCalledWith({ status: 'processed' });
+        });
+
+        it('marks event failed with error message on dispatch error', async () => {
+            dispatchWebhookEvent.mockRejectedValue(
+                new Error('downstream exploded')
+            );
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            // Failed events still return 200 — see #201 for the retry-loss tradeoff
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({ received: true });
+            expect(mocks.set).toHaveBeenCalledWith({
+                status: 'failed',
+                error: 'downstream exploded',
+            });
+        });
+
+        it('stringifies non-Error throws when marking failed', async () => {
+            dispatchWebhookEvent.mockRejectedValue('plain string failure');
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            expect(response.status).toBe(200);
+            expect(mocks.set).toHaveBeenCalledWith({
+                status: 'failed',
+                error: 'plain string failure',
+            });
+        });
+    });
+});

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -159,7 +159,7 @@ describe('POST /api/webhooks/stripe', () => {
             vi.stubEnv('NODE_ENV', 'development');
         });
 
-        it('skips dispatch when event id already recorded', async () => {
+        it('skips dispatch when event was already processed', async () => {
             mocks.webhookEvents.findFirst.mockResolvedValue(
                 createWebhookEventFixture({
                     externalId: sampleEvent.id,
@@ -175,6 +175,45 @@ describe('POST /api/webhooks/stripe', () => {
                 duplicate: true,
             });
             expect(dispatchWebhookEvent).not.toHaveBeenCalled();
+            expect(mocks.insert).not.toHaveBeenCalled();
+        });
+
+        it('retries dispatch when prior attempt failed', async () => {
+            // Stripe redelivers a previously-failed event. The original record
+            // exists with status 'failed' — this run should re-dispatch and
+            // promote it to 'processed' on success.
+            const failedRecord = createWebhookEventFixture({
+                externalId: sampleEvent.id,
+                status: 'failed',
+                error: 'previous downstream error',
+            });
+            mocks.webhookEvents.findFirst.mockResolvedValue(failedRecord);
+            dispatchWebhookEvent.mockResolvedValue(undefined);
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({ received: true });
+            expect(dispatchWebhookEvent).toHaveBeenCalled();
+            expect(mocks.insert).not.toHaveBeenCalled();
+            expect(mocks.set).toHaveBeenCalledWith({ status: 'processed' });
+        });
+
+        it('retries dispatch when prior attempt is still in received state', async () => {
+            // Edge case: a prior crash left the row stuck on 'received'.
+            // Stripe's retry should be allowed to drive it to a terminal state.
+            mocks.webhookEvents.findFirst.mockResolvedValue(
+                createWebhookEventFixture({
+                    externalId: sampleEvent.id,
+                    status: 'received',
+                })
+            );
+            dispatchWebhookEvent.mockResolvedValue(undefined);
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            expect(response.status).toBe(200);
+            expect(dispatchWebhookEvent).toHaveBeenCalled();
             expect(mocks.insert).not.toHaveBeenCalled();
         });
 

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -8,6 +8,17 @@ import { subscriptionService } from '@/server/services/subscriptions';
 
 const log = logger.child({ handler: 'stripe-webhook' });
 
+const POSTGRES_UNIQUE_VIOLATION = '23505';
+
+function isUniqueViolation(err: unknown): boolean {
+    return (
+        typeof err === 'object' &&
+        err !== null &&
+        'code' in err &&
+        (err as { code: unknown }).code === POSTGRES_UNIQUE_VIOLATION
+    );
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
     let rawBody: string;
     try {
@@ -71,10 +82,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
                 eventType: event.type,
                 payload: event as unknown as Record<string, unknown>,
             });
-        } catch {
-            // Unique constraint violation from concurrent redelivery
-            log.debug({ eventId: event.id }, 'Concurrent duplicate skipped');
-            return NextResponse.json({ received: true, duplicate: true });
+        } catch (err) {
+            // Only swallow Postgres unique-violation (23505) — that's a
+            // concurrent redelivery race. Anything else (schema mismatch,
+            // connection drop, etc.) is a real failure and must surface.
+            if (isUniqueViolation(err)) {
+                log.debug(
+                    { eventId: event.id },
+                    'Concurrent duplicate skipped'
+                );
+                return NextResponse.json({
+                    received: true,
+                    duplicate: true,
+                });
+            }
+            throw err;
         }
     }
 

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -6,8 +6,11 @@ import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { stripe } from '@/lib/stripe';
 import { PLAN_LIMITS, type PlanTier } from '@/server/services/constants';
+import { subscriptionStatusEnum } from '@nexus/db/schema';
 
 const log = logger.child({ handler: 'stripe-webhook' });
+
+const VALID_STATUSES = new Set<string>(subscriptionStatusEnum.enumValues);
 
 /** Stripe uses expandable fields (string | object | null) — normalize to the ID string. */
 function resolveStripeId(
@@ -15,6 +18,23 @@ function resolveStripeId(
 ): string | undefined {
     if (!field) return undefined;
     return typeof field === 'string' ? field : field.id;
+}
+
+type SubscriptionStatus = (typeof subscriptionStatusEnum.enumValues)[number];
+
+/** Map Stripe status to our DB enum, falling back to existing value for unknown statuses. */
+function mapStripeStatus(
+    stripeStatus: string,
+    fallback: SubscriptionStatus
+): SubscriptionStatus {
+    if (VALID_STATUSES.has(stripeStatus)) {
+        return stripeStatus as SubscriptionStatus;
+    }
+    log.warn(
+        { stripeStatus },
+        'Unknown Stripe subscription status, using fallback'
+    );
+    return fallback;
 }
 
 function resolveTierFromSubscription(
@@ -55,7 +75,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             );
         }
     } else {
-        event = JSON.parse(rawBody) as Stripe.Event;
+        try {
+            event = JSON.parse(rawBody) as Stripe.Event;
+        } catch {
+            return NextResponse.json(
+                { error: 'Invalid JSON' },
+                { status: 400 }
+            );
+        }
     }
 
     const webhookRepo = createWebhookRepo(db);
@@ -70,12 +97,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         return NextResponse.json({ received: true, duplicate: true });
     }
 
-    const webhookEvent = await webhookRepo.insert({
-        source: 'stripe',
-        externalId: event.id,
-        eventType: event.type,
-        payload: event as unknown as Record<string, unknown>,
-    });
+    let webhookEvent;
+    try {
+        webhookEvent = await webhookRepo.insert({
+            source: 'stripe',
+            externalId: event.id,
+            eventType: event.type,
+            payload: event as unknown as Record<string, unknown>,
+        });
+    } catch {
+        // Unique constraint violation from concurrent redelivery
+        log.debug({ eventId: event.id }, 'Concurrent duplicate skipped');
+        return NextResponse.json({ received: true, duplicate: true });
+    }
 
     const start = Date.now();
     log.info({ eventId: event.id, eventType: event.type }, 'Webhook received');
@@ -206,7 +240,7 @@ async function handleSubscriptionUpsert(
         ...existing,
         stripeSubscriptionId: sub.id,
         planTier: tier,
-        status: sub.status as typeof existing.status,
+        status: mapStripeStatus(sub.status, existing.status),
         storageLimit,
         currentPeriodStart: periodStart,
         currentPeriodEnd: periodEnd,

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,52 +1,12 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import type Stripe from 'stripe';
 import { createWebhookRepo } from '@nexus/db/repo/webhooks';
-import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { stripe } from '@/lib/stripe';
-import { PLAN_LIMITS, type PlanTier } from '@/server/services/constants';
-import { subscriptionStatusEnum } from '@nexus/db/schema';
+import { subscriptionService } from '@/server/services/subscriptions';
 
 const log = logger.child({ handler: 'stripe-webhook' });
-
-const VALID_STATUSES = new Set<string>(subscriptionStatusEnum.enumValues);
-
-/** Stripe uses expandable fields (string | object | null) — normalize to the ID string. */
-function resolveStripeId(
-    field: string | { id: string } | null | undefined
-): string | undefined {
-    if (!field) return undefined;
-    return typeof field === 'string' ? field : field.id;
-}
-
-type SubscriptionStatus = (typeof subscriptionStatusEnum.enumValues)[number];
-
-/** Map Stripe status to our DB enum, falling back to existing value for unknown statuses. */
-function mapStripeStatus(
-    stripeStatus: string,
-    fallback: SubscriptionStatus
-): SubscriptionStatus {
-    if (VALID_STATUSES.has(stripeStatus)) {
-        return stripeStatus as SubscriptionStatus;
-    }
-    log.warn(
-        { stripeStatus },
-        'Unknown Stripe subscription status, using fallback'
-    );
-    return fallback;
-}
-
-function resolveTierFromSubscription(
-    sub: Stripe.Subscription
-): PlanTier | null {
-    const item = sub.items.data[0];
-    if (!item) return null;
-    const product = item.price.product as Stripe.Product | string;
-    const metadata =
-        typeof product === 'string' ? null : (product.metadata ?? null);
-    return (metadata?.tier as PlanTier) ?? null;
-}
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
     let rawBody: string;
@@ -115,7 +75,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     log.info({ eventId: event.id, eventType: event.type }, 'Webhook received');
 
     try {
-        await dispatch(event);
+        await subscriptionService.dispatchWebhookEvent(db, event);
 
         await webhookRepo.update(webhookEvent.id, { status: 'processed' });
 
@@ -142,162 +102,4 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         return NextResponse.json({ received: true });
     }
-}
-
-async function dispatch(event: Stripe.Event): Promise<void> {
-    switch (event.type) {
-        case 'checkout.session.completed':
-            await handleCheckoutCompleted(
-                event.data.object as Stripe.Checkout.Session
-            );
-            break;
-        case 'customer.subscription.created':
-        case 'customer.subscription.updated':
-            await handleSubscriptionUpsert(
-                event.data.object as Stripe.Subscription
-            );
-            break;
-        case 'customer.subscription.deleted':
-            await handleSubscriptionDeleted(
-                event.data.object as Stripe.Subscription
-            );
-            break;
-        case 'invoice.payment_failed':
-            await handlePaymentFailed(event.data.object as Stripe.Invoice);
-            break;
-        default:
-            log.debug({ eventType: event.type }, 'Unhandled event type');
-    }
-}
-
-async function handleCheckoutCompleted(
-    session: Stripe.Checkout.Session
-): Promise<void> {
-    if (session.mode !== 'subscription') return;
-
-    const customerId = resolveStripeId(session.customer);
-    const subscriptionId = resolveStripeId(session.subscription);
-
-    if (!customerId || !subscriptionId) {
-        log.warn(
-            { sessionId: session.id },
-            'Checkout session missing customer or subscription'
-        );
-        return;
-    }
-
-    const repo = createSubscriptionRepo(db);
-    const sub = await repo.findByStripeCustomerId(customerId);
-    if (!sub) {
-        log.warn(
-            { customerId, sessionId: session.id },
-            'No subscription record for customer'
-        );
-        return;
-    }
-
-    // subscription.created will fill in plan details; this just links the IDs
-    await repo.upsertFromWebhook({
-        ...sub,
-        stripeSubscriptionId: subscriptionId,
-    });
-
-    log.info(
-        { customerId, subscriptionId },
-        'Linked Stripe subscription from checkout'
-    );
-}
-
-async function handleSubscriptionUpsert(
-    sub: Stripe.Subscription
-): Promise<void> {
-    const customerId = resolveStripeId(sub.customer);
-    if (!customerId) return;
-
-    const repo = createSubscriptionRepo(db);
-    const existing = await repo.findByStripeCustomerId(customerId);
-    if (!existing) {
-        log.warn(
-            { customerId, stripeSubscriptionId: sub.id },
-            'No local record for subscription upsert'
-        );
-        return;
-    }
-
-    const tier = resolveTierFromSubscription(sub) ?? existing.planTier;
-    const storageLimit = PLAN_LIMITS[tier as PlanTier] ?? existing.storageLimit;
-
-    // In API version 2026-02-25.clover, period fields moved from Subscription to its items
-    const firstItem = sub.items.data[0];
-    const periodStart = firstItem
-        ? new Date(firstItem.current_period_start * 1000)
-        : existing.currentPeriodStart;
-    const periodEnd = firstItem
-        ? new Date(firstItem.current_period_end * 1000)
-        : existing.currentPeriodEnd;
-
-    await repo.upsertFromWebhook({
-        ...existing,
-        stripeSubscriptionId: sub.id,
-        planTier: tier,
-        status: mapStripeStatus(sub.status, existing.status),
-        storageLimit,
-        currentPeriodStart: periodStart,
-        currentPeriodEnd: periodEnd,
-        cancelAtPeriodEnd: sub.cancel_at_period_end,
-        trialEnd: sub.trial_end ? new Date(sub.trial_end * 1000) : null,
-    });
-
-    log.info(
-        { customerId, tier, status: sub.status },
-        'Subscription synced from webhook'
-    );
-}
-
-async function handleSubscriptionDeleted(
-    sub: Stripe.Subscription
-): Promise<void> {
-    const customerId = resolveStripeId(sub.customer);
-    if (!customerId) return;
-
-    const repo = createSubscriptionRepo(db);
-    const existing = await repo.findByStripeCustomerId(customerId);
-    if (!existing) {
-        log.warn({ customerId }, 'No local record for subscription deletion');
-        return;
-    }
-
-    await repo.upsertFromWebhook({
-        ...existing,
-        status: 'canceled',
-        cancelAtPeriodEnd: false,
-    });
-
-    log.info({ customerId }, 'Subscription marked as canceled');
-}
-
-async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
-    const customerId = resolveStripeId(invoice.customer);
-
-    if (!customerId) {
-        log.warn({ invoiceId: invoice.id }, 'Invoice missing customer');
-        return;
-    }
-
-    const repo = createSubscriptionRepo(db);
-    const existing = await repo.findByStripeCustomerId(customerId);
-    if (!existing) {
-        log.warn({ customerId }, 'No local record for payment failure');
-        return;
-    }
-
-    await repo.upsertFromWebhook({
-        ...existing,
-        status: 'past_due',
-    });
-
-    log.info(
-        { customerId, invoiceId: invoice.id },
-        'Subscription marked past_due'
-    );
 }

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import type Stripe from 'stripe';
-import { createWebhookRepo } from '@nexus/db/repo/webhooks';
+import { createWebhookRepo, type WebhookEvent } from '@nexus/db/repo/webhooks';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { stripe } from '@/lib/stripe';
@@ -47,28 +47,35 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const webhookRepo = createWebhookRepo(db);
 
-    // Stripe may redeliver events during outages
+    // Stripe may redeliver events during outages, or retry after a prior
+    // failure. Only `processed` short-circuits — `failed` and `received` rows
+    // fall through so the dispatch can re-run and recover.
     const existing = await webhookRepo.find('stripe', event.id);
-    if (existing) {
-        log.debug(
-            { eventId: event.id, duplicate: true },
-            'Duplicate webhook event skipped'
-        );
+    if (existing?.status === 'processed') {
+        log.debug({ eventId: event.id }, 'Webhook already processed, skipping');
         return NextResponse.json({ received: true, duplicate: true });
     }
 
-    let webhookEvent;
-    try {
-        webhookEvent = await webhookRepo.insert({
-            source: 'stripe',
-            externalId: event.id,
-            eventType: event.type,
-            payload: event as unknown as Record<string, unknown>,
-        });
-    } catch {
-        // Unique constraint violation from concurrent redelivery
-        log.debug({ eventId: event.id }, 'Concurrent duplicate skipped');
-        return NextResponse.json({ received: true, duplicate: true });
+    let webhookEvent: WebhookEvent;
+    if (existing) {
+        webhookEvent = existing;
+        log.info(
+            { eventId: event.id, prevStatus: existing.status },
+            'Retrying webhook event'
+        );
+    } else {
+        try {
+            webhookEvent = await webhookRepo.insert({
+                source: 'stripe',
+                externalId: event.id,
+                eventType: event.type,
+                payload: event as unknown as Record<string, unknown>,
+            });
+        } catch {
+            // Unique constraint violation from concurrent redelivery
+            log.debug({ eventId: event.id }, 'Concurrent duplicate skipped');
+            return NextResponse.json({ received: true, duplicate: true });
+        }
     }
 
     const start = Date.now();

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,269 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import type Stripe from 'stripe';
+import { createWebhookRepo } from '@nexus/db/repo/webhooks';
+import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
+import { db } from '@/server/db';
+import { logger } from '@/server/lib/logger';
+import { stripe } from '@/lib/stripe';
+import { PLAN_LIMITS, type PlanTier } from '@/server/services/constants';
+
+const log = logger.child({ handler: 'stripe-webhook' });
+
+/** Stripe uses expandable fields (string | object | null) — normalize to the ID string. */
+function resolveStripeId(
+    field: string | { id: string } | null | undefined
+): string | undefined {
+    if (!field) return undefined;
+    return typeof field === 'string' ? field : field.id;
+}
+
+function resolveTierFromSubscription(
+    sub: Stripe.Subscription
+): PlanTier | null {
+    const item = sub.items.data[0];
+    if (!item) return null;
+    const product = item.price.product as Stripe.Product | string;
+    const metadata =
+        typeof product === 'string' ? null : (product.metadata ?? null);
+    return (metadata?.tier as PlanTier) ?? null;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+    let rawBody: string;
+    try {
+        rawBody = await request.text();
+    } catch {
+        return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+    }
+
+    let event: Stripe.Event;
+    if (process.env.NODE_ENV !== 'development') {
+        const signature = request.headers.get('stripe-signature');
+        if (!signature) {
+            return NextResponse.json(
+                { error: 'Missing stripe-signature header' },
+                { status: 400 }
+            );
+        }
+        try {
+            event = stripe.webhooks.constructEvent(rawBody, signature);
+        } catch (err) {
+            log.warn({ err }, 'Stripe signature verification failed');
+            return NextResponse.json(
+                { error: 'Invalid signature' },
+                { status: 400 }
+            );
+        }
+    } else {
+        event = JSON.parse(rawBody) as Stripe.Event;
+    }
+
+    const webhookRepo = createWebhookRepo(db);
+
+    // Stripe may redeliver events during outages
+    const existing = await webhookRepo.find('stripe', event.id);
+    if (existing) {
+        log.debug(
+            { eventId: event.id, duplicate: true },
+            'Duplicate webhook event skipped'
+        );
+        return NextResponse.json({ received: true, duplicate: true });
+    }
+
+    const webhookEvent = await webhookRepo.insert({
+        source: 'stripe',
+        externalId: event.id,
+        eventType: event.type,
+        payload: event as unknown as Record<string, unknown>,
+    });
+
+    const start = Date.now();
+    log.info({ eventId: event.id, eventType: event.type }, 'Webhook received');
+
+    try {
+        await dispatch(event);
+
+        await webhookRepo.update(webhookEvent.id, { status: 'processed' });
+
+        log.info(
+            {
+                eventId: event.id,
+                eventType: event.type,
+                durationMs: Date.now() - start,
+            },
+            'Webhook processed'
+        );
+
+        return NextResponse.json({ received: true });
+    } catch (error) {
+        log.error(
+            { err: error, eventId: event.id, eventType: event.type },
+            'Webhook processing failed'
+        );
+
+        await webhookRepo.update(webhookEvent.id, {
+            status: 'failed',
+            error: error instanceof Error ? error.message : String(error),
+        });
+
+        return NextResponse.json({ received: true });
+    }
+}
+
+async function dispatch(event: Stripe.Event): Promise<void> {
+    switch (event.type) {
+        case 'checkout.session.completed':
+            await handleCheckoutCompleted(
+                event.data.object as Stripe.Checkout.Session
+            );
+            break;
+        case 'customer.subscription.created':
+        case 'customer.subscription.updated':
+            await handleSubscriptionUpsert(
+                event.data.object as Stripe.Subscription
+            );
+            break;
+        case 'customer.subscription.deleted':
+            await handleSubscriptionDeleted(
+                event.data.object as Stripe.Subscription
+            );
+            break;
+        case 'invoice.payment_failed':
+            await handlePaymentFailed(event.data.object as Stripe.Invoice);
+            break;
+        default:
+            log.debug({ eventType: event.type }, 'Unhandled event type');
+    }
+}
+
+async function handleCheckoutCompleted(
+    session: Stripe.Checkout.Session
+): Promise<void> {
+    if (session.mode !== 'subscription') return;
+
+    const customerId = resolveStripeId(session.customer);
+    const subscriptionId = resolveStripeId(session.subscription);
+
+    if (!customerId || !subscriptionId) {
+        log.warn(
+            { sessionId: session.id },
+            'Checkout session missing customer or subscription'
+        );
+        return;
+    }
+
+    const repo = createSubscriptionRepo(db);
+    const sub = await repo.findByStripeCustomerId(customerId);
+    if (!sub) {
+        log.warn(
+            { customerId, sessionId: session.id },
+            'No subscription record for customer'
+        );
+        return;
+    }
+
+    // subscription.created will fill in plan details; this just links the IDs
+    await repo.upsertFromWebhook({
+        ...sub,
+        stripeSubscriptionId: subscriptionId,
+    });
+
+    log.info(
+        { customerId, subscriptionId },
+        'Linked Stripe subscription from checkout'
+    );
+}
+
+async function handleSubscriptionUpsert(
+    sub: Stripe.Subscription
+): Promise<void> {
+    const customerId = resolveStripeId(sub.customer);
+    if (!customerId) return;
+
+    const repo = createSubscriptionRepo(db);
+    const existing = await repo.findByStripeCustomerId(customerId);
+    if (!existing) {
+        log.warn(
+            { customerId, stripeSubscriptionId: sub.id },
+            'No local record for subscription upsert'
+        );
+        return;
+    }
+
+    const tier = resolveTierFromSubscription(sub) ?? existing.planTier;
+    const storageLimit = PLAN_LIMITS[tier as PlanTier] ?? existing.storageLimit;
+
+    // In API version 2026-02-25.clover, period fields moved from Subscription to its items
+    const firstItem = sub.items.data[0];
+    const periodStart = firstItem
+        ? new Date(firstItem.current_period_start * 1000)
+        : existing.currentPeriodStart;
+    const periodEnd = firstItem
+        ? new Date(firstItem.current_period_end * 1000)
+        : existing.currentPeriodEnd;
+
+    await repo.upsertFromWebhook({
+        ...existing,
+        stripeSubscriptionId: sub.id,
+        planTier: tier,
+        status: sub.status as typeof existing.status,
+        storageLimit,
+        currentPeriodStart: periodStart,
+        currentPeriodEnd: periodEnd,
+        cancelAtPeriodEnd: sub.cancel_at_period_end,
+        trialEnd: sub.trial_end ? new Date(sub.trial_end * 1000) : null,
+    });
+
+    log.info(
+        { customerId, tier, status: sub.status },
+        'Subscription synced from webhook'
+    );
+}
+
+async function handleSubscriptionDeleted(
+    sub: Stripe.Subscription
+): Promise<void> {
+    const customerId = resolveStripeId(sub.customer);
+    if (!customerId) return;
+
+    const repo = createSubscriptionRepo(db);
+    const existing = await repo.findByStripeCustomerId(customerId);
+    if (!existing) {
+        log.warn({ customerId }, 'No local record for subscription deletion');
+        return;
+    }
+
+    await repo.upsertFromWebhook({
+        ...existing,
+        status: 'canceled',
+        cancelAtPeriodEnd: false,
+    });
+
+    log.info({ customerId }, 'Subscription marked as canceled');
+}
+
+async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
+    const customerId = resolveStripeId(invoice.customer);
+
+    if (!customerId) {
+        log.warn({ invoiceId: invoice.id }, 'Invoice missing customer');
+        return;
+    }
+
+    const repo = createSubscriptionRepo(db);
+    const existing = await repo.findByStripeCustomerId(customerId);
+    if (!existing) {
+        log.warn({ customerId }, 'No local record for payment failure');
+        return;
+    }
+
+    await repo.upsertFromWebhook({
+        ...existing,
+        status: 'past_due',
+    });
+
+    log.info(
+        { customerId, invoiceId: invoice.id },
+        'Subscription marked past_due'
+    );
+}

--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -2,6 +2,10 @@ import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import * as schema from '@nexus/db/schema';
 import { db } from '@/server/db';
+import { subscriptionService } from '@/server/services/subscriptions';
+import { logger } from '@/server/lib/logger';
+
+const log = logger.child({ module: 'auth' });
 
 export const auth = betterAuth({
     database: drizzleAdapter(db, {
@@ -20,6 +24,27 @@ export const auth = betterAuth({
             role: {
                 type: 'string',
                 input: false,
+            },
+        },
+    },
+    databaseHooks: {
+        user: {
+            create: {
+                after: async (user) => {
+                    try {
+                        await subscriptionService.provisionTrialSubscription(
+                            db,
+                            user.id,
+                            user.email,
+                            user.name
+                        );
+                    } catch (err) {
+                        log.error(
+                            { err, userId: user.id },
+                            'Failed to provision trial subscription on signup'
+                        );
+                    }
+                },
             },
         },
     },

--- a/apps/web/lib/stripe/client.ts
+++ b/apps/web/lib/stripe/client.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import Stripe from 'stripe';
 import { env } from '@/lib/env';
 

--- a/apps/web/lib/stripe/index.ts
+++ b/apps/web/lib/stripe/index.ts
@@ -1,5 +1,6 @@
 import * as webhooks from './webhooks';
 import * as checkout from './checkout';
+import * as prices from './prices';
 
 /**
  * Stripe payment processing operations
@@ -16,11 +17,15 @@ import * as checkout from './checkout';
  *
  * // Create billing portal session
  * const portal = await stripe.checkout.createBillingPortalSession(customerId, returnUrl);
+ *
+ * // Resolve price by metadata
+ * const priceId = await stripe.prices.resolvePriceId('pro', 'month');
  * ```
  */
 export const stripe = {
     webhooks,
     checkout,
+    prices,
 } as const;
 
 // Re-export the client for direct SDK access

--- a/apps/web/lib/stripe/index.ts
+++ b/apps/web/lib/stripe/index.ts
@@ -2,26 +2,7 @@ import * as webhooks from './webhooks';
 import * as checkout from './checkout';
 import * as prices from './prices';
 
-/**
- * Stripe payment processing operations
- *
- * @example
- * ```typescript
- * import { stripe } from '@/lib/stripe';
- *
- * // Verify webhook signature
- * const event = stripe.webhooks.constructEvent(rawBody, signature);
- *
- * // Create checkout session
- * const session = await stripe.checkout.createCheckoutSession({ ... });
- *
- * // Create billing portal session
- * const portal = await stripe.checkout.createBillingPortalSession(customerId, returnUrl);
- *
- * // Resolve price by metadata
- * const priceId = await stripe.prices.resolvePriceId('pro', 'month');
- * ```
- */
+/** Namespace facade so consumers import a single entry point instead of individual modules. */
 export const stripe = {
     webhooks,
     checkout,

--- a/apps/web/lib/stripe/prices.ts
+++ b/apps/web/lib/stripe/prices.ts
@@ -1,12 +1,24 @@
 import type Stripe from 'stripe';
-import type { CheckoutTier, BillingInterval } from './types';
+import {
+    CHECKOUT_TIERS,
+    type CheckoutTier,
+    type BillingInterval,
+} from './types';
 import { stripeClient } from './client';
 
-/** Avoids repeated Stripe API calls; populated once per process, keyed by tier:interval. */
-let priceCache: Map<string, string> | null = null;
+// Cache the in-flight promise (not just the resolved Map) so concurrent first
+// callers share a single Stripe pagination instead of stampeding.
+let pricesPromise: Promise<Map<string, string>> | null = null;
 
 function cacheKey(tier: CheckoutTier, interval: BillingInterval): string {
     return `${tier}:${interval}`;
+}
+
+function isCheckoutTier(value: string | undefined): value is CheckoutTier {
+    return (
+        value !== undefined &&
+        (CHECKOUT_TIERS as readonly string[]).includes(value)
+    );
 }
 
 async function loadPrices(): Promise<Map<string, string>> {
@@ -26,12 +38,13 @@ async function loadPrices(): Promise<Map<string, string>> {
 
         for (const price of page.data) {
             const product = price.product as Stripe.Product;
-            const tier = product.metadata?.tier as CheckoutTier | undefined;
-            const interval = price.recurring?.interval as
-                | BillingInterval
-                | undefined;
+            const tier = product.metadata?.tier;
+            const interval = price.recurring?.interval;
 
-            if (tier && interval) {
+            if (
+                isCheckoutTier(tier) &&
+                (interval === 'month' || interval === 'year')
+            ) {
                 cache.set(cacheKey(tier, interval), price.id);
             }
         }
@@ -50,11 +63,16 @@ export async function resolvePriceId(
     tier: CheckoutTier,
     interval: BillingInterval
 ): Promise<string> {
-    if (!priceCache) {
-        priceCache = await loadPrices();
+    if (!pricesPromise) {
+        pricesPromise = loadPrices().catch((err) => {
+            // Don't pin a rejected promise — let the next call retry.
+            pricesPromise = null;
+            throw err;
+        });
     }
 
-    const priceId = priceCache.get(cacheKey(tier, interval));
+    const cache = await pricesPromise;
+    const priceId = cache.get(cacheKey(tier, interval));
     if (!priceId) {
         throw new Error(
             `No Stripe price found for tier="${tier}" interval="${interval}". ` +
@@ -63,9 +81,4 @@ export async function resolvePriceId(
     }
 
     return priceId;
-}
-
-/** Call after adding or changing prices in the Stripe Dashboard. */
-export function invalidatePriceCache(): void {
-    priceCache = null;
 }

--- a/apps/web/lib/stripe/prices.ts
+++ b/apps/web/lib/stripe/prices.ts
@@ -1,8 +1,5 @@
 import type Stripe from 'stripe';
-import type {
-    CheckoutTier,
-    BillingInterval,
-} from '@/server/services/constants';
+import type { CheckoutTier, BillingInterval } from './types';
 import { stripeClient } from './client';
 
 /** Avoids repeated Stripe API calls; populated once per process, keyed by tier:interval. */

--- a/apps/web/lib/stripe/prices.ts
+++ b/apps/web/lib/stripe/prices.ts
@@ -1,0 +1,74 @@
+import type Stripe from 'stripe';
+import type {
+    CheckoutTier,
+    BillingInterval,
+} from '@/server/services/constants';
+import { stripeClient } from './client';
+
+/** Avoids repeated Stripe API calls; populated once per process, keyed by tier:interval. */
+let priceCache: Map<string, string> | null = null;
+
+function cacheKey(tier: CheckoutTier, interval: BillingInterval): string {
+    return `${tier}:${interval}`;
+}
+
+async function loadPrices(): Promise<Map<string, string>> {
+    const cache = new Map<string, string>();
+    let hasMore = true;
+    let startingAfter: string | undefined;
+
+    while (hasMore) {
+        const params: Stripe.PriceListParams = {
+            active: true,
+            limit: 100,
+            expand: ['data.product'],
+            ...(startingAfter ? { starting_after: startingAfter } : {}),
+        };
+
+        const page = await stripeClient.prices.list(params);
+
+        for (const price of page.data) {
+            const product = price.product as Stripe.Product;
+            const tier = product.metadata?.tier as CheckoutTier | undefined;
+            const interval = price.recurring?.interval as
+                | BillingInterval
+                | undefined;
+
+            if (tier && interval) {
+                cache.set(cacheKey(tier, interval), price.id);
+            }
+        }
+
+        hasMore = page.has_more;
+        if (page.data.length > 0) {
+            startingAfter = page.data[page.data.length - 1].id;
+        }
+    }
+
+    return cache;
+}
+
+/** Uses product metadata instead of hardcoded IDs so the same code works across Stripe environments. */
+export async function resolvePriceId(
+    tier: CheckoutTier,
+    interval: BillingInterval
+): Promise<string> {
+    if (!priceCache) {
+        priceCache = await loadPrices();
+    }
+
+    const priceId = priceCache.get(cacheKey(tier, interval));
+    if (!priceId) {
+        throw new Error(
+            `No Stripe price found for tier="${tier}" interval="${interval}". ` +
+                'Ensure products and prices are configured with correct metadata in the Stripe Dashboard.'
+        );
+    }
+
+    return priceId;
+}
+
+/** Call after adding or changing prices in the Stripe Dashboard. */
+export function invalidatePriceCache(): void {
+    priceCache = null;
+}

--- a/apps/web/lib/stripe/testing.ts
+++ b/apps/web/lib/stripe/testing.ts
@@ -1,0 +1,68 @@
+import { vi, type Mock } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMock = Mock<any>;
+
+export interface MockStripeClient {
+    customers: { create: AnyMock };
+    products: { retrieve: AnyMock };
+    prices: { list: AnyMock };
+    checkout: { sessions: { create: AnyMock } };
+    billingPortal: { sessions: { create: AnyMock } };
+    webhooks: { constructEvent: AnyMock };
+}
+
+export interface MockStripeNamespace {
+    webhooks: { constructEvent: AnyMock };
+    checkout: {
+        createCheckoutSession: AnyMock;
+        createBillingPortalSession: AnyMock;
+    };
+    prices: { resolvePriceId: AnyMock };
+}
+
+export interface MockStripe {
+    stripe: MockStripeNamespace;
+    stripeClient: MockStripeClient;
+}
+
+/**
+ * Creates a vitest stub for the `@/lib/stripe` module — both the `stripe`
+ * namespace facade and the raw `stripeClient` SDK. Every method is `vi.fn()`
+ * so individual tests can override behavior with `.mockResolvedValue(...)`
+ * or `.mockRejectedValue(...)`.
+ *
+ * Wire it through `vi.hoisted` with a dynamic import — `vi.hoisted` runs
+ * before static imports, so this file must be loaded asynchronously:
+ *
+ * ```ts
+ * const hoisted = await vi.hoisted(async () => {
+ *     const { createMockStripe } = await import('@/lib/stripe/testing');
+ *     return createMockStripe();
+ * });
+ * vi.mock('@/lib/stripe', () => ({
+ *     stripe: hoisted.stripe,
+ *     stripeClient: hoisted.stripeClient,
+ * }));
+ * ```
+ */
+export function createMockStripe(): MockStripe {
+    return {
+        stripe: {
+            webhooks: { constructEvent: vi.fn() },
+            checkout: {
+                createCheckoutSession: vi.fn(),
+                createBillingPortalSession: vi.fn(),
+            },
+            prices: { resolvePriceId: vi.fn() },
+        },
+        stripeClient: {
+            customers: { create: vi.fn() },
+            products: { retrieve: vi.fn() },
+            prices: { list: vi.fn() },
+            checkout: { sessions: { create: vi.fn() } },
+            billingPortal: { sessions: { create: vi.fn() } },
+            webhooks: { constructEvent: vi.fn() },
+        },
+    };
+}

--- a/apps/web/lib/stripe/types.ts
+++ b/apps/web/lib/stripe/types.ts
@@ -1,0 +1,6 @@
+import type { PlanTier } from '@nexus/db/plans';
+
+/** Tiers available for user-facing checkout (excludes enterprise). */
+export type CheckoutTier = Exclude<PlanTier, 'enterprise'>;
+
+export type BillingInterval = 'month' | 'year';

--- a/apps/web/lib/stripe/types.ts
+++ b/apps/web/lib/stripe/types.ts
@@ -1,6 +1,9 @@
 import type { PlanTier } from '@nexus/db/plans';
 
+export const CHECKOUT_TIERS = ['starter', 'pro', 'max'] as const;
+export const BILLING_INTERVALS = ['month', 'year'] as const;
+
 /** Tiers available for user-facing checkout (excludes enterprise). */
 export type CheckoutTier = Exclude<PlanTier, 'enterprise'>;
 
-export type BillingInterval = 'month' | 'year';
+export type BillingInterval = (typeof BILLING_INTERVALS)[number];

--- a/apps/web/lib/stripe/types.ts
+++ b/apps/web/lib/stripe/types.ts
@@ -1,15 +1,21 @@
 import { planTierEnum } from '@nexus/db/schema';
 import type { PlanTier } from '@nexus/db/plans';
 
-/** Tiers available for user-facing checkout (excludes enterprise). */
-export type CheckoutTier = Exclude<PlanTier, 'enterprise'>;
-
 export const BILLING_INTERVALS = ['month', 'year'] as const;
 
 export type BillingInterval = (typeof BILLING_INTERVALS)[number];
 
+// Single source of truth for which tiers are sales-only and excluded from
+// self-serve checkout. Both the runtime list and the type derive from this.
+const NON_CHECKOUT_TIERS = ['enterprise'] as const;
+type NonCheckoutTier = (typeof NON_CHECKOUT_TIERS)[number];
+
+/** Tiers available for user-facing checkout (excludes sales-driven tiers). */
+export type CheckoutTier = Exclude<PlanTier, NonCheckoutTier>;
+
 // Derived from planTierEnum so adding a tier to the DB schema flows through
-// to checkout validation automatically. Sales-driven enterprise is excluded.
+// to checkout validation automatically.
 export const CHECKOUT_TIERS = planTierEnum.enumValues.filter(
-    (t): t is CheckoutTier => t !== 'enterprise'
+    (t): t is CheckoutTier =>
+        !(NON_CHECKOUT_TIERS as readonly string[]).includes(t)
 );

--- a/apps/web/lib/stripe/types.ts
+++ b/apps/web/lib/stripe/types.ts
@@ -1,9 +1,15 @@
+import { planTierEnum } from '@nexus/db/schema';
 import type { PlanTier } from '@nexus/db/plans';
-
-export const CHECKOUT_TIERS = ['starter', 'pro', 'max'] as const;
-export const BILLING_INTERVALS = ['month', 'year'] as const;
 
 /** Tiers available for user-facing checkout (excludes enterprise). */
 export type CheckoutTier = Exclude<PlanTier, 'enterprise'>;
 
+export const BILLING_INTERVALS = ['month', 'year'] as const;
+
 export type BillingInterval = (typeof BILLING_INTERVALS)[number];
+
+// Derived from planTierEnum so adding a tier to the DB schema flows through
+// to checkout validation automatically. Sales-driven enterprise is excluded.
+export const CHECKOUT_TIERS = planTierEnum.enumValues.filter(
+    (t): t is CheckoutTier => t !== 'enterprise'
+);

--- a/apps/web/server/errors.ts
+++ b/apps/web/server/errors.ts
@@ -42,6 +42,13 @@ export class QuotaExceededError extends DomainError {
     }
 }
 
+/** Trial subscription has expired. */
+export class TrialExpiredError extends DomainError {
+    constructor(message = 'Trial has expired') {
+        super(message, 'FORBIDDEN');
+    }
+}
+
 /** Type guard to check for DomainError (handles cross-module instanceof issues). */
 export function isDomainError(error: unknown): error is DomainError {
     return (

--- a/apps/web/server/lib/logger/testing.ts
+++ b/apps/web/server/lib/logger/testing.ts
@@ -1,0 +1,45 @@
+import { vi, type Mock } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMock = Mock<any>;
+
+export interface MockLogger {
+    trace: AnyMock;
+    debug: AnyMock;
+    info: AnyMock;
+    warn: AnyMock;
+    error: AnyMock;
+    fatal: AnyMock;
+    /** Returns the same logger instance so chained `.child()` calls work transparently. */
+    child: AnyMock;
+}
+
+/**
+ * Vitest stub for `@/server/lib/logger`'s `logger` export. `child(...)` returns
+ * the same instance so production code that does `logger.child({...}).info(...)`
+ * routes through the same spies.
+ *
+ * Wire it through `vi.hoisted` with a dynamic import — `vi.hoisted` runs before
+ * static imports, so this file must be loaded asynchronously inside the block:
+ *
+ * ```ts
+ * const hoisted = await vi.hoisted(async () => {
+ *     const { createMockLogger } = await import('@/server/lib/logger/testing');
+ *     return { logger: createMockLogger() };
+ * });
+ * vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
+ * ```
+ */
+export function createMockLogger(): MockLogger {
+    const logger: MockLogger = {
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        child: vi.fn(),
+    };
+    logger.child.mockReturnValue(logger);
+    return logger;
+}

--- a/apps/web/server/services/constants.ts
+++ b/apps/web/server/services/constants.ts
@@ -1,8 +1,5 @@
 export { PLAN_LIMITS, type PlanTier } from '@nexus/db/plans';
 export type { CheckoutTier, BillingInterval } from '@/lib/stripe/types';
 
-/** Default storage quota (10 GB) applied when no subscription overrides it. */
-export const DEFAULT_STORAGE_LIMIT_BYTES = 10 * 1024 * 1024 * 1024;
-
 /** Trial duration in days. */
 export const TRIAL_DURATION_DAYS = 30;

--- a/apps/web/server/services/constants.ts
+++ b/apps/web/server/services/constants.ts
@@ -1,14 +1,8 @@
-import type { PlanTier } from '@nexus/db/plans';
-
 export { PLAN_LIMITS, type PlanTier } from '@nexus/db/plans';
+export type { CheckoutTier, BillingInterval } from '@/lib/stripe/types';
 
 /** Default storage quota (10 GB) applied when no subscription overrides it. */
 export const DEFAULT_STORAGE_LIMIT_BYTES = 10 * 1024 * 1024 * 1024;
 
 /** Trial duration in days. */
 export const TRIAL_DURATION_DAYS = 30;
-
-/** Tiers available for user-facing checkout (excludes enterprise). */
-export type CheckoutTier = Exclude<PlanTier, 'enterprise'>;
-
-export type BillingInterval = 'month' | 'year';

--- a/apps/web/server/services/constants.ts
+++ b/apps/web/server/services/constants.ts
@@ -1,2 +1,14 @@
+import type { PlanTier } from '@nexus/db/plans';
+
+export { PLAN_LIMITS, type PlanTier } from '@nexus/db/plans';
+
 /** Default storage quota (10 GB) applied when no subscription overrides it. */
 export const DEFAULT_STORAGE_LIMIT_BYTES = 10 * 1024 * 1024 * 1024;
+
+/** Trial duration in days. */
+export const TRIAL_DURATION_DAYS = 30;
+
+/** Tiers available for user-facing checkout (excludes enterprise). */
+export type CheckoutTier = Exclude<PlanTier, 'enterprise'>;
+
+export type BillingInterval = 'month' | 'year';

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -134,7 +134,7 @@ describe('files service', () => {
 
         it('uses subscription storageLimit instead of starter default', async () => {
             // Pro subscription with 100 GB limit — user is already at 50 GB
-            mocks.findFirst.mockResolvedValue(
+            mocks.subscriptions.findFirst.mockResolvedValue(
                 createSubscriptionFixture({
                     planTier: 'pro',
                     status: 'active',
@@ -154,7 +154,7 @@ describe('files service', () => {
         });
 
         it('throws QuotaExceededError when over subscription limit', async () => {
-            mocks.findFirst.mockResolvedValue(
+            mocks.subscriptions.findFirst.mockResolvedValue(
                 createSubscriptionFixture({
                     planTier: 'pro',
                     status: 'active',
@@ -174,7 +174,7 @@ describe('files service', () => {
 
         it('allows upload during active trial within quota', async () => {
             const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // +7 days
-            mocks.findFirst.mockResolvedValue(
+            mocks.subscriptions.findFirst.mockResolvedValue(
                 createSubscriptionFixture({
                     status: 'trialing',
                     trialEnd: future,
@@ -193,7 +193,7 @@ describe('files service', () => {
 
         it('throws TrialExpiredError when trial has ended', async () => {
             const past = new Date(Date.now() - 24 * 60 * 60 * 1000); // -1 day
-            mocks.findFirst.mockResolvedValue(
+            mocks.subscriptions.findFirst.mockResolvedValue(
                 createSubscriptionFixture({
                     status: 'trialing',
                     trialEnd: past,
@@ -212,7 +212,7 @@ describe('files service', () => {
         it('prefers TrialExpiredError over QuotaExceededError when both apply', async () => {
             // Expired trial AND over quota — trial check must run first
             const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
-            mocks.findFirst.mockResolvedValue(
+            mocks.subscriptions.findFirst.mockResolvedValue(
                 createSubscriptionFixture({
                     status: 'trialing',
                     trialEnd: past,
@@ -232,7 +232,7 @@ describe('files service', () => {
         it('ignores trialEnd when status is not trialing', async () => {
             // Active sub with a stale trialEnd in the past — should not throw
             const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
-            mocks.findFirst.mockResolvedValue(
+            mocks.subscriptions.findFirst.mockResolvedValue(
                 createSubscriptionFixture({
                     status: 'active',
                     trialEnd: past,
@@ -254,7 +254,7 @@ describe('files service', () => {
         it('returns file with status available', async () => {
             const uploadingFile = createFileFixture({ status: 'uploading' });
             const availableFile = createFileFixture({ status: 'available' });
-            mocks.findFirst.mockResolvedValue(uploadingFile);
+            mocks.files.findFirst.mockResolvedValue(uploadingFile);
             mocks.returning.mockResolvedValue([availableFile]);
 
             const result = await fileService.confirmUpload(
@@ -268,7 +268,7 @@ describe('files service', () => {
         });
 
         it('throws NotFoundError when file does not exist', async () => {
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.files.findFirst.mockResolvedValue(undefined);
 
             await expect(
                 fileService.confirmUpload(db, TEST_USER_ID, 'nonexistent-id')
@@ -277,7 +277,7 @@ describe('files service', () => {
 
         it('throws NotFoundError when file belongs to different user', async () => {
             // findUserFile returns undefined when user doesn't own file
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.files.findFirst.mockResolvedValue(undefined);
 
             await expect(
                 fileService.confirmUpload(db, 'different-user', 'some-file-id')
@@ -480,7 +480,7 @@ describe('files service', () => {
         it('transitions file to available status', async () => {
             const uploadingFile = createFileFixture({ status: 'uploading' });
             const availableFile = createFileFixture({ status: 'available' });
-            mocks.findFirst.mockResolvedValue(uploadingFile);
+            mocks.files.findFirst.mockResolvedValue(uploadingFile);
             mocks.returning.mockResolvedValue([availableFile]);
 
             const result = await fileService.completeMultipartUpload(
@@ -498,7 +498,7 @@ describe('files service', () => {
         });
 
         it('throws NotFoundError when file does not exist', async () => {
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.files.findFirst.mockResolvedValue(undefined);
 
             await expect(
                 fileService.completeMultipartUpload(db, TEST_USER_ID, {
@@ -511,7 +511,7 @@ describe('files service', () => {
 
         it('throws InvalidStateError when file is not uploading', async () => {
             const availableFile = createFileFixture({ status: 'available' });
-            mocks.findFirst.mockResolvedValue(availableFile);
+            mocks.files.findFirst.mockResolvedValue(availableFile);
 
             await expect(
                 fileService.completeMultipartUpload(db, TEST_USER_ID, {
@@ -526,7 +526,7 @@ describe('files service', () => {
     describe('abortMultipartUpload', () => {
         it('soft-deletes the file record', async () => {
             const uploadingFile = createFileFixture({ status: 'uploading' });
-            mocks.findFirst.mockResolvedValue(uploadingFile);
+            mocks.files.findFirst.mockResolvedValue(uploadingFile);
             mocks.returning.mockResolvedValue([
                 { ...uploadingFile, status: 'deleted' },
             ]);
@@ -547,7 +547,7 @@ describe('files service', () => {
         });
 
         it('throws NotFoundError when file does not exist', async () => {
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.files.findFirst.mockResolvedValue(undefined);
 
             await expect(
                 fileService.abortMultipartUpload(

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 import {
     createMockDb,
     createFileFixture,
+    createSubscriptionFixture,
     TEST_USER_ID,
 } from '@nexus/db/testing';
 import { mockS3 } from '@/lib/storage/testing';
@@ -9,6 +10,7 @@ import {
     NotFoundError,
     QuotaExceededError,
     InvalidStateError,
+    TrialExpiredError,
 } from '@/server/errors';
 import { fileService } from './files';
 
@@ -123,6 +125,128 @@ describe('files service', () => {
                     ),
                 })
             );
+        });
+    });
+
+    describe('quota enforcement with subscription', () => {
+        const oneGB = 1024 ** 3;
+        const hundredGB = 100 * 1024 ** 3;
+
+        it('uses subscription storageLimit instead of starter default', async () => {
+            // Pro subscription with 100 GB limit — user is already at 50 GB
+            mocks.findFirst.mockResolvedValue(
+                createSubscriptionFixture({
+                    planTier: 'pro',
+                    status: 'active',
+                    storageLimit: hundredGB,
+                })
+            );
+            mocks.where.mockResolvedValue([{ total: 50 * oneGB }]);
+            mocks.returning.mockResolvedValue([createFileFixture()]);
+
+            // 40 GB upload would exceed starter (10 GB) but fits in pro (100 GB)
+            const result = await fileService.initiateUpload(db, TEST_USER_ID, {
+                name: 'big.bin',
+                sizeBytes: 40 * oneGB,
+            });
+
+            expect(result).toHaveProperty('fileId');
+        });
+
+        it('throws QuotaExceededError when over subscription limit', async () => {
+            mocks.findFirst.mockResolvedValue(
+                createSubscriptionFixture({
+                    planTier: 'pro',
+                    status: 'active',
+                    storageLimit: hundredGB,
+                })
+            );
+            // At 99 GB, a 2 GB upload would exceed the 100 GB limit
+            mocks.where.mockResolvedValue([{ total: 99 * oneGB }]);
+
+            await expect(
+                fileService.initiateUpload(db, TEST_USER_ID, {
+                    name: 'overflow.bin',
+                    sizeBytes: 2 * oneGB,
+                })
+            ).rejects.toThrow(QuotaExceededError);
+        });
+
+        it('allows upload during active trial within quota', async () => {
+            const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // +7 days
+            mocks.findFirst.mockResolvedValue(
+                createSubscriptionFixture({
+                    status: 'trialing',
+                    trialEnd: future,
+                })
+            );
+            mocks.where.mockResolvedValue([{ total: 0 }]);
+            mocks.returning.mockResolvedValue([createFileFixture()]);
+
+            const result = await fileService.initiateUpload(db, TEST_USER_ID, {
+                name: 'trial.pdf',
+                sizeBytes: 1024,
+            });
+
+            expect(result).toHaveProperty('fileId');
+        });
+
+        it('throws TrialExpiredError when trial has ended', async () => {
+            const past = new Date(Date.now() - 24 * 60 * 60 * 1000); // -1 day
+            mocks.findFirst.mockResolvedValue(
+                createSubscriptionFixture({
+                    status: 'trialing',
+                    trialEnd: past,
+                })
+            );
+            mocks.where.mockResolvedValue([{ total: 0 }]);
+
+            await expect(
+                fileService.initiateUpload(db, TEST_USER_ID, {
+                    name: 'expired.pdf',
+                    sizeBytes: 1024,
+                })
+            ).rejects.toThrow(TrialExpiredError);
+        });
+
+        it('prefers TrialExpiredError over QuotaExceededError when both apply', async () => {
+            // Expired trial AND over quota — trial check must run first
+            const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
+            mocks.findFirst.mockResolvedValue(
+                createSubscriptionFixture({
+                    status: 'trialing',
+                    trialEnd: past,
+                    storageLimit: oneGB,
+                })
+            );
+            mocks.where.mockResolvedValue([{ total: oneGB }]); // already at quota
+
+            await expect(
+                fileService.initiateUpload(db, TEST_USER_ID, {
+                    name: 'double-fail.pdf',
+                    sizeBytes: 1024,
+                })
+            ).rejects.toThrow(TrialExpiredError);
+        });
+
+        it('ignores trialEnd when status is not trialing', async () => {
+            // Active sub with a stale trialEnd in the past — should not throw
+            const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
+            mocks.findFirst.mockResolvedValue(
+                createSubscriptionFixture({
+                    status: 'active',
+                    trialEnd: past,
+                })
+            );
+            mocks.where.mockResolvedValue([{ total: 0 }]);
+            mocks.returning.mockResolvedValue([createFileFixture()]);
+
+            const result = await fileService.initiateUpload(db, TEST_USER_ID, {
+                name: 'active.pdf',
+                sizeBytes: 1024,
+            });
+
+            expect(result).toHaveProperty('fileId');
         });
     });
 

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -6,7 +6,7 @@ import {
     InvalidStateError,
 } from '@/server/errors';
 import { s3 } from '@/lib/storage';
-import { DEFAULT_STORAGE_LIMIT_BYTES } from './constants';
+import { PLAN_LIMITS } from './constants';
 
 const PRESIGNED_URL_EXPIRY_SECONDS = 900; // 15 minutes
 const MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024; // 10MB
@@ -53,7 +53,7 @@ async function initiateUpload(
 ): Promise<InitiateUploadResult> {
     const fileRepo = createFileRepo(db);
     const currentUsage = await fileRepo.sumStorageByUser(userId);
-    if (currentUsage + input.sizeBytes > DEFAULT_STORAGE_LIMIT_BYTES) {
+    if (currentUsage + input.sizeBytes > PLAN_LIMITS.starter) {
         throw new QuotaExceededError('Storage quota exceeded');
     }
 
@@ -116,7 +116,7 @@ async function initiateMultipartUpload(
 ): Promise<InitiateMultipartResult> {
     const fileRepo = createFileRepo(db);
     const currentUsage = await fileRepo.sumStorageByUser(userId);
-    if (currentUsage + input.sizeBytes > DEFAULT_STORAGE_LIMIT_BYTES) {
+    if (currentUsage + input.sizeBytes > PLAN_LIMITS.starter) {
         throw new QuotaExceededError('Storage quota exceeded');
     }
 

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -1,9 +1,11 @@
 import type { DB } from '@nexus/db';
 import { createFileRepo, type File } from '@nexus/db/repo/files';
+import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
 import {
     NotFoundError,
     QuotaExceededError,
     InvalidStateError,
+    TrialExpiredError,
 } from '@/server/errors';
 import { s3 } from '@/lib/storage';
 import { PLAN_LIMITS } from './constants';
@@ -46,17 +48,41 @@ interface ConfirmUploadResult {
     file: File;
 }
 
+async function assertWithinQuota(
+    db: DB,
+    userId: string,
+    additionalBytes: number
+): Promise<void> {
+    const fileRepo = createFileRepo(db);
+    const subscriptionRepo = createSubscriptionRepo(db);
+
+    const [currentUsage, sub] = await Promise.all([
+        fileRepo.sumStorageByUser(userId),
+        subscriptionRepo.findByUserId(userId),
+    ]);
+
+    if (
+        sub?.status === 'trialing' &&
+        sub.trialEnd &&
+        sub.trialEnd < new Date()
+    ) {
+        throw new TrialExpiredError();
+    }
+
+    const quotaBytes = sub?.storageLimit ?? PLAN_LIMITS.starter;
+    if (currentUsage + additionalBytes > quotaBytes) {
+        throw new QuotaExceededError('Storage quota exceeded');
+    }
+}
+
 async function initiateUpload(
     db: DB,
     userId: string,
     input: UploadInput
 ): Promise<InitiateUploadResult> {
-    const fileRepo = createFileRepo(db);
-    const currentUsage = await fileRepo.sumStorageByUser(userId);
-    if (currentUsage + input.sizeBytes > PLAN_LIMITS.starter) {
-        throw new QuotaExceededError('Storage quota exceeded');
-    }
+    await assertWithinQuota(db, userId, input.sizeBytes);
 
+    const fileRepo = createFileRepo(db);
     const fileId = crypto.randomUUID();
     const s3Key = `${userId}/${fileId}/${input.name}`;
 
@@ -114,12 +140,9 @@ async function initiateMultipartUpload(
     userId: string,
     input: UploadInput
 ): Promise<InitiateMultipartResult> {
-    const fileRepo = createFileRepo(db);
-    const currentUsage = await fileRepo.sumStorageByUser(userId);
-    if (currentUsage + input.sizeBytes > PLAN_LIMITS.starter) {
-        throw new QuotaExceededError('Storage quota exceeded');
-    }
+    await assertWithinQuota(db, userId, input.sizeBytes);
 
+    const fileRepo = createFileRepo(db);
     const fileId = crypto.randomUUID();
     const s3Key = `${userId}/${fileId}/${input.name}`;
     const partCount = Math.ceil(input.sizeBytes / MULTIPART_CHUNK_SIZE);

--- a/apps/web/server/services/retrieval.test.ts
+++ b/apps/web/server/services/retrieval.test.ts
@@ -32,9 +32,8 @@ describe('retrieval service', () => {
 
             // requestRetrieval delegates to requestBulkRetrieval:
             // findUserFiles -> findByFileIds -> s3.glacier.restoreMany -> insertMany
-            mocks.findMany
-                .mockResolvedValueOnce([file]) // findUserFiles
-                .mockResolvedValueOnce([]); // findByFileIds (no existing)
+            mocks.files.findMany.mockResolvedValue([file]);
+            mocks.retrievals.findMany.mockResolvedValue([]);
             mocks.returning.mockResolvedValue([retrieval]);
 
             const result = await retrievalService.requestRetrieval(
@@ -52,9 +51,8 @@ describe('retrieval service', () => {
             const file = createFileFixture({ storageTier: 'deep_archive' });
             const retrieval = createRetrievalFixture({ tier: 'bulk' });
 
-            mocks.findMany
-                .mockResolvedValueOnce([file])
-                .mockResolvedValueOnce([]);
+            mocks.files.findMany.mockResolvedValue([file]);
+            mocks.retrievals.findMany.mockResolvedValue([]);
             mocks.returning.mockResolvedValue([retrieval]);
 
             const result = await retrievalService.requestRetrieval(
@@ -71,9 +69,8 @@ describe('retrieval service', () => {
             const file = createFileFixture({ storageTier: 'glacier' });
             const existing = createRetrievalFixture({ status: 'pending' });
 
-            mocks.findMany
-                .mockResolvedValueOnce([file]) // findUserFiles
-                .mockResolvedValueOnce([existing]); // findByFileIds returns active retrieval
+            mocks.files.findMany.mockResolvedValue([file]);
+            mocks.retrievals.findMany.mockResolvedValue([existing]);
 
             const result = await retrievalService.requestRetrieval(
                 db,
@@ -86,7 +83,7 @@ describe('retrieval service', () => {
         });
 
         it('throws NotFoundError when file does not exist', async () => {
-            mocks.findMany.mockResolvedValueOnce([]); // findUserFiles returns empty
+            mocks.files.findMany.mockResolvedValue([]);
 
             await expect(
                 retrievalService.requestRetrieval(
@@ -100,9 +97,8 @@ describe('retrieval service', () => {
         it('throws InvalidStateError when file is not in Glacier tier', async () => {
             const file = createFileFixture({ storageTier: 'standard' });
 
-            mocks.findMany
-                .mockResolvedValueOnce([file]) // findUserFiles
-                .mockResolvedValueOnce([]); // findByFileIds (no existing)
+            mocks.files.findMany.mockResolvedValue([file]);
+            mocks.retrievals.findMany.mockResolvedValue([]);
 
             await expect(
                 retrievalService.requestRetrieval(
@@ -133,9 +129,8 @@ describe('retrieval service', () => {
                 createRetrievalFixture({ id: 'r2', fileId: 'file2' }),
             ];
 
-            mocks.findMany
-                .mockResolvedValueOnce(files) // findUserFiles
-                .mockResolvedValueOnce([]); // findByFileIds (no existing)
+            mocks.files.findMany.mockResolvedValue(files);
+            mocks.retrievals.findMany.mockResolvedValue([]);
             mocks.returning.mockResolvedValue(newRetrievals);
 
             const result = await retrievalService.requestBulkRetrieval(
@@ -172,9 +167,8 @@ describe('retrieval service', () => {
                 fileId: 'file2',
             });
 
-            mocks.findMany
-                .mockResolvedValueOnce(files) // findUserFiles
-                .mockResolvedValueOnce([existingRetrieval]); // findByFileIds
+            mocks.files.findMany.mockResolvedValue(files);
+            mocks.retrievals.findMany.mockResolvedValue([existingRetrieval]);
             mocks.returning.mockResolvedValue([newRetrieval]);
 
             const result = await retrievalService.requestBulkRetrieval(
@@ -188,7 +182,7 @@ describe('retrieval service', () => {
 
         it('throws NotFoundError when any file is missing', async () => {
             const files = [createFileFixture({ id: 'file1' })];
-            mocks.findMany.mockResolvedValueOnce(files);
+            mocks.files.findMany.mockResolvedValue(files);
 
             await expect(
                 retrievalService.requestBulkRetrieval(db, TEST_USER_ID, [
@@ -210,9 +204,8 @@ describe('retrieval service', () => {
                 }),
             ];
 
-            mocks.findMany
-                .mockResolvedValueOnce(files) // findUserFiles
-                .mockResolvedValueOnce([]); // findByFileIds (no existing)
+            mocks.files.findMany.mockResolvedValue(files);
+            mocks.retrievals.findMany.mockResolvedValue([]);
 
             await expect(
                 retrievalService.requestBulkRetrieval(db, TEST_USER_ID, [
@@ -232,9 +225,8 @@ describe('retrieval service', () => {
                 status: 'ready',
             });
 
-            mocks.findMany
-                .mockResolvedValueOnce(files) // findUserFiles
-                .mockResolvedValueOnce([existingRetrieval]); // findByFileIds
+            mocks.files.findMany.mockResolvedValue(files);
+            mocks.retrievals.findMany.mockResolvedValue([existingRetrieval]);
 
             const result = await retrievalService.requestBulkRetrieval(
                 db,
@@ -252,9 +244,8 @@ describe('retrieval service', () => {
             const file = createFileFixture();
             const retrieval = createRetrievalFixture({ status: 'ready' });
 
-            mocks.findFirst
-                .mockResolvedValueOnce(file) // findUserFile
-                .mockResolvedValueOnce(retrieval); // findByFileId
+            mocks.files.findFirst.mockResolvedValue(file);
+            mocks.retrievals.findFirst.mockResolvedValue(retrieval);
 
             const result = await retrievalService.getDownloadUrl(
                 db,
@@ -269,7 +260,7 @@ describe('retrieval service', () => {
         });
 
         it('throws NotFoundError when file does not exist', async () => {
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.files.findFirst.mockResolvedValue(undefined);
 
             await expect(
                 retrievalService.getDownloadUrl(db, TEST_USER_ID, 'nonexistent')
@@ -279,9 +270,8 @@ describe('retrieval service', () => {
         it('throws InvalidStateError when no retrieval exists', async () => {
             const file = createFileFixture();
 
-            mocks.findFirst
-                .mockResolvedValueOnce(file) // findUserFile
-                .mockResolvedValueOnce(undefined); // findByFileId (no retrieval)
+            mocks.files.findFirst.mockResolvedValue(file);
+            mocks.retrievals.findFirst.mockResolvedValue(undefined);
 
             await expect(
                 retrievalService.getDownloadUrl(db, TEST_USER_ID, TEST_FILE_ID)
@@ -292,9 +282,8 @@ describe('retrieval service', () => {
             const file = createFileFixture();
             const retrieval = createRetrievalFixture({ status: 'pending' });
 
-            mocks.findFirst
-                .mockResolvedValueOnce(file) // findUserFile
-                .mockResolvedValueOnce(retrieval); // findByFileId
+            mocks.files.findFirst.mockResolvedValue(file);
+            mocks.retrievals.findFirst.mockResolvedValue(retrieval);
 
             await expect(
                 retrievalService.getDownloadUrl(db, TEST_USER_ID, TEST_FILE_ID)

--- a/apps/web/server/services/storage.ts
+++ b/apps/web/server/services/storage.ts
@@ -1,19 +1,18 @@
 import type { DB } from '@nexus/db';
-import { type planTierEnum } from '@nexus/db/schema';
 import {
     createFileRepo,
     type StorageByCategory,
     type DailyUploadVolume,
 } from '@nexus/db/repo/files';
 import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
-import { DEFAULT_STORAGE_LIMIT_BYTES } from './constants';
+import { PLAN_LIMITS, type PlanTier } from './constants';
 
 interface StorageUsage {
     usedBytes: number;
     quotaBytes: number;
     percentage: number;
     fileCount: number;
-    planTier: (typeof planTierEnum.enumValues)[number];
+    planTier: PlanTier;
 }
 
 async function getUsage(db: DB, userId: string): Promise<StorageUsage> {
@@ -26,7 +25,7 @@ async function getUsage(db: DB, userId: string): Promise<StorageUsage> {
         subscriptionRepo.findByUserId(userId),
     ]);
 
-    const quotaBytes = sub?.storageLimit ?? DEFAULT_STORAGE_LIMIT_BYTES;
+    const quotaBytes = sub?.storageLimit ?? PLAN_LIMITS.starter;
     const percentage = quotaBytes > 0 ? (usedBytes / quotaBytes) * 100 : 0;
 
     return {

--- a/apps/web/server/services/subscriptions.test.ts
+++ b/apps/web/server/services/subscriptions.test.ts
@@ -56,25 +56,54 @@ interface SubscriptionEventOpts {
     periodEnd?: number;
     /** When true, omit `items.data` entirely (used for the deleted handler which doesn't need them). */
     noItems?: boolean;
+    /**
+     * Items prepended before the main plan item — use to simulate add-ons or
+     * non-plan items appearing at index 0, exercising findPlanItem's selector.
+     */
+    prependItems?: Array<{
+        productMetadata?: Record<string, string>;
+        periodStart?: number;
+        periodEnd?: number;
+    }>;
+}
+
+function makeSubscriptionItem(opts: {
+    productMetadata?: Record<string, string>;
+    periodStart?: number;
+    periodEnd?: number;
+    productId?: string;
+}) {
+    return {
+        current_period_start: opts.periodStart ?? 1_700_000_000,
+        current_period_end: opts.periodEnd ?? 1_702_000_000,
+        price: {
+            product: {
+                id: opts.productId ?? 'prod_test',
+                metadata: opts.productMetadata ?? {},
+            },
+        },
+    };
 }
 
 function makeSubscriptionEvent(opts: SubscriptionEventOpts = {}): Stripe.Event {
-    const product = opts.unexpandedProductId ?? {
+    const mainProduct = opts.unexpandedProductId ?? {
         id: 'prod_test',
         metadata: opts.productMetadata ?? {},
     };
 
+    const mainItem = {
+        current_period_start: opts.periodStart ?? 1_700_000_000,
+        current_period_end: opts.periodEnd ?? 1_702_000_000,
+        price: { product: mainProduct },
+    };
+
+    const prepended = (opts.prependItems ?? []).map((extra, idx) =>
+        makeSubscriptionItem({ ...extra, productId: `prod_extra_${idx}` })
+    );
+
     const items = opts.noItems
         ? { data: [] }
-        : {
-              data: [
-                  {
-                      current_period_start: opts.periodStart ?? 1_700_000_000,
-                      current_period_end: opts.periodEnd ?? 1_702_000_000,
-                      price: { product },
-                  },
-              ],
-          };
+        : { data: [...prepended, mainItem] };
 
     const subscription = {
         id: opts.stripeSubId ?? 'sub_stripe_test',
@@ -276,6 +305,41 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
 
             expect(mocks.values).toHaveBeenCalledWith(
                 expect.objectContaining({
+                    currentPeriodStart: new Date(1_700_000_000 * 1000),
+                    currentPeriodEnd: new Date(1_702_000_000 * 1000),
+                })
+            );
+        });
+
+        it('selects plan item from multi-item subscription regardless of order', async () => {
+            // A metered add-on at index 0, with the real plan item second.
+            // The old `items.data[0]` selector would have used the add-on's
+            // empty metadata + cycle. findPlanItem must pick the tiered item.
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({ planTier: 'starter' })
+            );
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionEvent({
+                    prependItems: [
+                        {
+                            // add-on with no tier metadata, different cycle
+                            productMetadata: {},
+                            periodStart: 1_500_000_000,
+                            periodEnd: 1_500_500_000,
+                        },
+                    ],
+                    productMetadata: { tier: 'pro' },
+                    periodStart: 1_700_000_000,
+                    periodEnd: 1_702_000_000,
+                })
+            );
+
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    planTier: 'pro',
+                    storageLimit: PLAN_LIMITS.pro,
                     currentPeriodStart: new Date(1_700_000_000 * 1000),
                     currentPeriodEnd: new Date(1_702_000_000 * 1000),
                 })

--- a/apps/web/server/services/subscriptions.test.ts
+++ b/apps/web/server/services/subscriptions.test.ts
@@ -6,26 +6,12 @@ import {
     TEST_STRIPE_CUSTOMER_ID,
 } from '@nexus/db/testing';
 
-// vi.mock factories are hoisted above regular code, so any variables they
-// reference must be declared via vi.hoisted(). This block owns the shared
-// mocks that tests later reach into.
-const hoisted = vi.hoisted(() => {
-    const loggerStub = {
-        info: vi.fn(),
-        error: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn(),
-        child: vi.fn(),
-    };
-    loggerStub.child.mockReturnValue(loggerStub);
-
-    return {
-        loggerStub,
-        productsRetrieve: vi.fn(),
-    };
+const hoisted = await vi.hoisted(async () => {
+    const { createMockLogger } = await import('@/server/lib/logger/testing');
+    const { createMockStripe } = await import('@/lib/stripe/testing');
+    return { logger: createMockLogger(), ...createMockStripe() };
 });
 
-// Env: stub so the service module can be imported without .env.local loaded
 vi.mock('@/lib/env', () => ({
     env: {
         NEXT_PUBLIC_APP_URL: 'https://test.example',
@@ -33,29 +19,86 @@ vi.mock('@/lib/env', () => ({
     },
 }));
 
-vi.mock('@/server/lib/logger', () => ({ logger: hoisted.loggerStub }));
+vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
 
-// Stripe SDK: mocked so the service can import without hitting the network.
-// Individual tests override `productsRetrieve` when they need to assert behavior.
 vi.mock('@/lib/stripe', () => ({
-    stripe: {
-        webhooks: {},
-        checkout: {
-            createCheckoutSession: vi.fn(),
-            createBillingPortalSession: vi.fn(),
-        },
-        prices: { resolvePriceId: vi.fn() },
-    },
-    stripeClient: {
-        customers: { create: vi.fn() },
-        products: { retrieve: hoisted.productsRetrieve },
-    },
+    stripe: hoisted.stripe,
+    stripeClient: hoisted.stripeClient,
 }));
-
-const { productsRetrieve } = hoisted;
 
 import { subscriptionService } from './subscriptions';
 import { PLAN_LIMITS } from './constants';
+
+const productsRetrieve = hoisted.stripeClient.products.retrieve;
+
+/** Wraps an arbitrary object in a Stripe.Event envelope, centralizing the cast. */
+function makeStripeEvent<T>(type: string, object: T): Stripe.Event {
+    return {
+        id: 'evt_test',
+        type,
+        data: { object },
+    } as unknown as Stripe.Event;
+}
+
+interface SubscriptionEventOpts {
+    type?:
+        | 'customer.subscription.created'
+        | 'customer.subscription.updated'
+        | 'customer.subscription.deleted';
+    customerId?: string;
+    stripeSubId?: string;
+    status?: string;
+    cancelAtPeriodEnd?: boolean;
+    /** When set, the price.product is the ID string (unexpanded). Otherwise an object with `productMetadata`. */
+    unexpandedProductId?: string;
+    productMetadata?: Record<string, string>;
+    periodStart?: number;
+    periodEnd?: number;
+    /** When true, omit `items.data` entirely (used for the deleted handler which doesn't need them). */
+    noItems?: boolean;
+}
+
+function makeSubscriptionEvent(opts: SubscriptionEventOpts = {}): Stripe.Event {
+    const product = opts.unexpandedProductId ?? {
+        id: 'prod_test',
+        metadata: opts.productMetadata ?? {},
+    };
+
+    const items = opts.noItems
+        ? { data: [] }
+        : {
+              data: [
+                  {
+                      current_period_start: opts.periodStart ?? 1_700_000_000,
+                      current_period_end: opts.periodEnd ?? 1_702_000_000,
+                      price: { product },
+                  },
+              ],
+          };
+
+    const subscription = {
+        id: opts.stripeSubId ?? 'sub_stripe_test',
+        customer: opts.customerId ?? TEST_STRIPE_CUSTOMER_ID,
+        status: opts.status ?? 'active',
+        cancel_at_period_end: opts.cancelAtPeriodEnd ?? false,
+        trial_end: null,
+        items,
+    };
+
+    return makeStripeEvent(
+        opts.type ?? 'customer.subscription.updated',
+        subscription
+    );
+}
+
+function makePaymentFailedEvent(
+    customerId: string | null = TEST_STRIPE_CUSTOMER_ID
+): Stripe.Event {
+    return makeStripeEvent('invoice.payment_failed', {
+        id: 'in_test',
+        customer: customerId,
+    });
+}
 
 describe('subscriptionService.dispatchWebhookEvent', () => {
     let db: ReturnType<typeof createMockDb>['db'];
@@ -68,61 +111,44 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         mocks = mockDb.mocks;
     });
 
-    // ─── invoice.payment_failed ────────────────────────────────────────
-
     describe('invoice.payment_failed', () => {
-        function makePaymentFailedEvent(customerId: string): Stripe.Event {
-            return {
-                id: 'evt_test',
-                type: 'invoice.payment_failed',
-                data: {
-                    object: {
-                        id: 'in_test',
-                        customer: customerId,
-                    } as unknown as Stripe.Invoice,
-                },
-            } as unknown as Stripe.Event;
-        }
-
         it('transitions active subscription to past_due', async () => {
-            const existing = createSubscriptionFixture({ status: 'active' });
-            mocks.findFirst.mockResolvedValue(existing);
-            mocks.returning.mockResolvedValue([
-                { ...existing, status: 'past_due' },
-            ]);
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({ status: 'active' })
+            );
 
             await subscriptionService.dispatchWebhookEvent(
                 db,
-                makePaymentFailedEvent(TEST_STRIPE_CUSTOMER_ID)
+                makePaymentFailedEvent()
             );
 
-            // The upsert's .values(...) receives the full row to write
             expect(mocks.values).toHaveBeenCalledWith(
                 expect.objectContaining({ status: 'past_due' })
             );
         });
 
         it('does not regress from canceled status', async () => {
-            const existing = createSubscriptionFixture({ status: 'canceled' });
-            mocks.findFirst.mockResolvedValue(existing);
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({ status: 'canceled' })
+            );
 
             await subscriptionService.dispatchWebhookEvent(
                 db,
-                makePaymentFailedEvent(TEST_STRIPE_CUSTOMER_ID)
+                makePaymentFailedEvent()
             );
 
-            // Terminal status guard: no write at all
             expect(mocks.insert).not.toHaveBeenCalled();
             expect(mocks.values).not.toHaveBeenCalled();
         });
 
         it('does not regress from unpaid status', async () => {
-            const existing = createSubscriptionFixture({ status: 'unpaid' });
-            mocks.findFirst.mockResolvedValue(existing);
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({ status: 'unpaid' })
+            );
 
             await subscriptionService.dispatchWebhookEvent(
                 db,
-                makePaymentFailedEvent(TEST_STRIPE_CUSTOMER_ID)
+                makePaymentFailedEvent()
             );
 
             expect(mocks.insert).not.toHaveBeenCalled();
@@ -130,97 +156,40 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         });
 
         it('no-ops when no local subscription exists', async () => {
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.subscriptions.findFirst.mockResolvedValue(undefined);
 
-            await expect(
-                subscriptionService.dispatchWebhookEvent(
-                    db,
-                    makePaymentFailedEvent(TEST_STRIPE_CUSTOMER_ID)
-                )
-            ).resolves.toBeUndefined();
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makePaymentFailedEvent()
+            );
 
             expect(mocks.insert).not.toHaveBeenCalled();
+            expect(mocks.values).not.toHaveBeenCalled();
         });
 
         it('no-ops when invoice has no customer', async () => {
-            const event = {
-                id: 'evt_test',
-                type: 'invoice.payment_failed',
-                data: {
-                    object: {
-                        id: 'in_test',
-                        customer: null,
-                    } as unknown as Stripe.Invoice,
-                },
-            } as unknown as Stripe.Event;
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makePaymentFailedEvent(null)
+            );
 
-            await subscriptionService.dispatchWebhookEvent(db, event);
-
-            expect(mocks.findFirst).not.toHaveBeenCalled();
+            expect(mocks.subscriptions.findFirst).not.toHaveBeenCalled();
             expect(mocks.insert).not.toHaveBeenCalled();
         });
     });
 
-    // ─── customer.subscription.updated ─────────────────────────────────
-
     describe('customer.subscription.updated', () => {
-        /**
-         * Builds a Stripe.Subscription with a pre-expanded product object so
-         * the handler never hits `stripeClient.products.retrieve`. Each test
-         * can override product metadata to exercise tier-resolution branches.
-         */
-        function makeSubscriptionUpsertEvent(opts: {
-            stripeSubId?: string;
-            customerId?: string;
-            status?: string;
-            productMetadata?: Record<string, string>;
-            periodStart?: number;
-            periodEnd?: number;
-        }): Stripe.Event {
-            const item = {
-                current_period_start: opts.periodStart ?? 1_700_000_000,
-                current_period_end: opts.periodEnd ?? 1_702_000_000,
-                price: {
-                    product: {
-                        id: 'prod_test',
-                        metadata: opts.productMetadata ?? {},
-                    },
-                },
-            };
-
-            const subscription = {
-                id: opts.stripeSubId ?? 'sub_stripe_test',
-                customer: opts.customerId ?? TEST_STRIPE_CUSTOMER_ID,
-                status: opts.status ?? 'active',
-                cancel_at_period_end: false,
-                trial_end: null,
-                items: { data: [item] },
-            };
-
-            return {
-                id: 'evt_test',
-                type: 'customer.subscription.updated',
-                data: {
-                    object: subscription as unknown as Stripe.Subscription,
-                },
-            } as unknown as Stripe.Event;
-        }
-
         it('updates tier and storage limit from product metadata', async () => {
-            const existing = createSubscriptionFixture({
-                planTier: 'starter',
-                storageLimit: PLAN_LIMITS.starter,
-            });
-            mocks.findFirst.mockResolvedValue(existing);
-            mocks.returning.mockResolvedValue([
-                { ...existing, planTier: 'pro' },
-            ]);
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({
+                    planTier: 'starter',
+                    storageLimit: PLAN_LIMITS.starter,
+                })
+            );
 
             await subscriptionService.dispatchWebhookEvent(
                 db,
-                makeSubscriptionUpsertEvent({
-                    productMetadata: { tier: 'pro' },
-                })
+                makeSubscriptionEvent({ productMetadata: { tier: 'pro' } })
             );
 
             expect(mocks.values).toHaveBeenCalledWith(
@@ -235,16 +204,16 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         it('preserves existing tier when Stripe product has no tier metadata', async () => {
             // Regression guard: a Stripe config mistake (missing metadata)
             // must not silently downgrade an existing pro subscription.
-            const existing = createSubscriptionFixture({
-                planTier: 'pro',
-                storageLimit: PLAN_LIMITS.pro,
-            });
-            mocks.findFirst.mockResolvedValue(existing);
-            mocks.returning.mockResolvedValue([existing]);
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({
+                    planTier: 'pro',
+                    storageLimit: PLAN_LIMITS.pro,
+                })
+            );
 
             await subscriptionService.dispatchWebhookEvent(
                 db,
-                makeSubscriptionUpsertEvent({ productMetadata: {} })
+                makeSubscriptionEvent({ productMetadata: {} })
             );
 
             expect(mocks.values).toHaveBeenCalledWith(
@@ -256,13 +225,13 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         });
 
         it('maps Stripe status to DB enum', async () => {
-            const existing = createSubscriptionFixture({ status: 'active' });
-            mocks.findFirst.mockResolvedValue(existing);
-            mocks.returning.mockResolvedValue([existing]);
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({ status: 'active' })
+            );
 
             await subscriptionService.dispatchWebhookEvent(
                 db,
-                makeSubscriptionUpsertEvent({
+                makeSubscriptionEvent({
                     status: 'past_due',
                     productMetadata: { tier: 'starter' },
                 })
@@ -274,13 +243,13 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         });
 
         it('falls back to existing status on unknown Stripe status', async () => {
-            const existing = createSubscriptionFixture({ status: 'active' });
-            mocks.findFirst.mockResolvedValue(existing);
-            mocks.returning.mockResolvedValue([existing]);
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({ status: 'active' })
+            );
 
             await subscriptionService.dispatchWebhookEvent(
                 db,
-                makeSubscriptionUpsertEvent({
+                makeSubscriptionEvent({
                     status: 'some_future_stripe_status',
                     productMetadata: { tier: 'starter' },
                 })
@@ -292,13 +261,13 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         });
 
         it('reads period dates from subscription items (post-2026-02-25)', async () => {
-            const existing = createSubscriptionFixture();
-            mocks.findFirst.mockResolvedValue(existing);
-            mocks.returning.mockResolvedValue([existing]);
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture()
+            );
 
             await subscriptionService.dispatchWebhookEvent(
                 db,
-                makeSubscriptionUpsertEvent({
+                makeSubscriptionEvent({
                     productMetadata: { tier: 'starter' },
                     periodStart: 1_700_000_000,
                     periodEnd: 1_702_000_000,
@@ -314,53 +283,31 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         });
 
         it('no-ops when no local subscription exists', async () => {
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.subscriptions.findFirst.mockResolvedValue(undefined);
 
             await subscriptionService.dispatchWebhookEvent(
                 db,
-                makeSubscriptionUpsertEvent({
-                    productMetadata: { tier: 'pro' },
-                })
+                makeSubscriptionEvent({ productMetadata: { tier: 'pro' } })
             );
 
             expect(mocks.insert).not.toHaveBeenCalled();
+            expect(mocks.values).not.toHaveBeenCalled();
+            expect(productsRetrieve).not.toHaveBeenCalled();
         });
 
         it('retrieves product from Stripe when not expanded', async () => {
-            const existing = createSubscriptionFixture({ planTier: 'starter' });
-            mocks.findFirst.mockResolvedValue(existing);
-            mocks.returning.mockResolvedValue([existing]);
-
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({ planTier: 'starter' })
+            );
             productsRetrieve.mockResolvedValue({
                 id: 'prod_test',
                 metadata: { tier: 'max' },
             });
 
-            // Unexpanded product: just the ID string, not the full object
-            const event = {
-                id: 'evt_test',
-                type: 'customer.subscription.updated',
-                data: {
-                    object: {
-                        id: 'sub_stripe_test',
-                        customer: TEST_STRIPE_CUSTOMER_ID,
-                        status: 'active',
-                        cancel_at_period_end: false,
-                        trial_end: null,
-                        items: {
-                            data: [
-                                {
-                                    current_period_start: 1_700_000_000,
-                                    current_period_end: 1_702_000_000,
-                                    price: { product: 'prod_test' },
-                                },
-                            ],
-                        },
-                    } as unknown as Stripe.Subscription,
-                },
-            } as unknown as Stripe.Event;
-
-            await subscriptionService.dispatchWebhookEvent(db, event);
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionEvent({ unexpandedProductId: 'prod_test' })
+            );
 
             expect(productsRetrieve).toHaveBeenCalledWith('prod_test');
             expect(mocks.values).toHaveBeenCalledWith(
@@ -372,36 +319,15 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         });
 
         it('preserves existing tier when product retrieval fails', async () => {
-            const existing = createSubscriptionFixture({ planTier: 'pro' });
-            mocks.findFirst.mockResolvedValue(existing);
-            mocks.returning.mockResolvedValue([existing]);
-
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({ planTier: 'pro' })
+            );
             productsRetrieve.mockRejectedValue(new Error('stripe api error'));
 
-            const event = {
-                id: 'evt_test',
-                type: 'customer.subscription.updated',
-                data: {
-                    object: {
-                        id: 'sub_stripe_test',
-                        customer: TEST_STRIPE_CUSTOMER_ID,
-                        status: 'active',
-                        cancel_at_period_end: false,
-                        trial_end: null,
-                        items: {
-                            data: [
-                                {
-                                    current_period_start: 1_700_000_000,
-                                    current_period_end: 1_702_000_000,
-                                    price: { product: 'prod_test' },
-                                },
-                            ],
-                        },
-                    } as unknown as Stripe.Subscription,
-                },
-            } as unknown as Stripe.Event;
-
-            await subscriptionService.dispatchWebhookEvent(db, event);
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionEvent({ unexpandedProductId: 'prod_test' })
+            );
 
             expect(mocks.values).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -412,32 +338,22 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         });
     });
 
-    // ─── customer.subscription.deleted ─────────────────────────────────
-
     describe('customer.subscription.deleted', () => {
         it('marks subscription as canceled', async () => {
-            const existing = createSubscriptionFixture({
-                status: 'active',
-                cancelAtPeriodEnd: true,
-            });
-            mocks.findFirst.mockResolvedValue(existing);
-            mocks.returning.mockResolvedValue([
-                { ...existing, status: 'canceled' },
-            ]);
+            mocks.subscriptions.findFirst.mockResolvedValue(
+                createSubscriptionFixture({
+                    status: 'active',
+                    cancelAtPeriodEnd: true,
+                })
+            );
 
-            const event = {
-                id: 'evt_test',
-                type: 'customer.subscription.deleted',
-                data: {
-                    object: {
-                        id: 'sub_stripe_test',
-                        customer: TEST_STRIPE_CUSTOMER_ID,
-                        items: { data: [] },
-                    } as unknown as Stripe.Subscription,
-                },
-            } as unknown as Stripe.Event;
-
-            await subscriptionService.dispatchWebhookEvent(db, event);
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionEvent({
+                    type: 'customer.subscription.deleted',
+                    noItems: true,
+                })
+            );
 
             expect(mocks.values).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -448,20 +364,13 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         });
     });
 
-    // ─── unhandled events ──────────────────────────────────────────────
-
     it('ignores unhandled event types without error', async () => {
-        const event = {
-            id: 'evt_test',
-            type: 'some.other.event',
-            data: { object: {} },
-        } as unknown as Stripe.Event;
+        await subscriptionService.dispatchWebhookEvent(
+            db,
+            makeStripeEvent('some.other.event', {})
+        );
 
-        await expect(
-            subscriptionService.dispatchWebhookEvent(db, event)
-        ).resolves.toBeUndefined();
-
-        expect(mocks.findFirst).not.toHaveBeenCalled();
+        expect(mocks.subscriptions.findFirst).not.toHaveBeenCalled();
         expect(mocks.insert).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/server/services/subscriptions.test.ts
+++ b/apps/web/server/services/subscriptions.test.ts
@@ -1,0 +1,467 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import type Stripe from 'stripe';
+import {
+    createMockDb,
+    createSubscriptionFixture,
+    TEST_STRIPE_CUSTOMER_ID,
+} from '@nexus/db/testing';
+
+// vi.mock factories are hoisted above regular code, so any variables they
+// reference must be declared via vi.hoisted(). This block owns the shared
+// mocks that tests later reach into.
+const hoisted = vi.hoisted(() => {
+    const loggerStub = {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        child: vi.fn(),
+    };
+    loggerStub.child.mockReturnValue(loggerStub);
+
+    return {
+        loggerStub,
+        productsRetrieve: vi.fn(),
+    };
+});
+
+// Env: stub so the service module can be imported without .env.local loaded
+vi.mock('@/lib/env', () => ({
+    env: {
+        NEXT_PUBLIC_APP_URL: 'https://test.example',
+        STRIPE_SECRET_KEY: 'sk_test',
+    },
+}));
+
+vi.mock('@/server/lib/logger', () => ({ logger: hoisted.loggerStub }));
+
+// Stripe SDK: mocked so the service can import without hitting the network.
+// Individual tests override `productsRetrieve` when they need to assert behavior.
+vi.mock('@/lib/stripe', () => ({
+    stripe: {
+        webhooks: {},
+        checkout: {
+            createCheckoutSession: vi.fn(),
+            createBillingPortalSession: vi.fn(),
+        },
+        prices: { resolvePriceId: vi.fn() },
+    },
+    stripeClient: {
+        customers: { create: vi.fn() },
+        products: { retrieve: hoisted.productsRetrieve },
+    },
+}));
+
+const { productsRetrieve } = hoisted;
+
+import { subscriptionService } from './subscriptions';
+import { PLAN_LIMITS } from './constants';
+
+describe('subscriptionService.dispatchWebhookEvent', () => {
+    let db: ReturnType<typeof createMockDb>['db'];
+    let mocks: ReturnType<typeof createMockDb>['mocks'];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+    });
+
+    // ─── invoice.payment_failed ────────────────────────────────────────
+
+    describe('invoice.payment_failed', () => {
+        function makePaymentFailedEvent(customerId: string): Stripe.Event {
+            return {
+                id: 'evt_test',
+                type: 'invoice.payment_failed',
+                data: {
+                    object: {
+                        id: 'in_test',
+                        customer: customerId,
+                    } as unknown as Stripe.Invoice,
+                },
+            } as unknown as Stripe.Event;
+        }
+
+        it('transitions active subscription to past_due', async () => {
+            const existing = createSubscriptionFixture({ status: 'active' });
+            mocks.findFirst.mockResolvedValue(existing);
+            mocks.returning.mockResolvedValue([
+                { ...existing, status: 'past_due' },
+            ]);
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makePaymentFailedEvent(TEST_STRIPE_CUSTOMER_ID)
+            );
+
+            // The upsert's .values(...) receives the full row to write
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({ status: 'past_due' })
+            );
+        });
+
+        it('does not regress from canceled status', async () => {
+            const existing = createSubscriptionFixture({ status: 'canceled' });
+            mocks.findFirst.mockResolvedValue(existing);
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makePaymentFailedEvent(TEST_STRIPE_CUSTOMER_ID)
+            );
+
+            // Terminal status guard: no write at all
+            expect(mocks.insert).not.toHaveBeenCalled();
+            expect(mocks.values).not.toHaveBeenCalled();
+        });
+
+        it('does not regress from unpaid status', async () => {
+            const existing = createSubscriptionFixture({ status: 'unpaid' });
+            mocks.findFirst.mockResolvedValue(existing);
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makePaymentFailedEvent(TEST_STRIPE_CUSTOMER_ID)
+            );
+
+            expect(mocks.insert).not.toHaveBeenCalled();
+            expect(mocks.values).not.toHaveBeenCalled();
+        });
+
+        it('no-ops when no local subscription exists', async () => {
+            mocks.findFirst.mockResolvedValue(undefined);
+
+            await expect(
+                subscriptionService.dispatchWebhookEvent(
+                    db,
+                    makePaymentFailedEvent(TEST_STRIPE_CUSTOMER_ID)
+                )
+            ).resolves.toBeUndefined();
+
+            expect(mocks.insert).not.toHaveBeenCalled();
+        });
+
+        it('no-ops when invoice has no customer', async () => {
+            const event = {
+                id: 'evt_test',
+                type: 'invoice.payment_failed',
+                data: {
+                    object: {
+                        id: 'in_test',
+                        customer: null,
+                    } as unknown as Stripe.Invoice,
+                },
+            } as unknown as Stripe.Event;
+
+            await subscriptionService.dispatchWebhookEvent(db, event);
+
+            expect(mocks.findFirst).not.toHaveBeenCalled();
+            expect(mocks.insert).not.toHaveBeenCalled();
+        });
+    });
+
+    // ─── customer.subscription.updated ─────────────────────────────────
+
+    describe('customer.subscription.updated', () => {
+        /**
+         * Builds a Stripe.Subscription with a pre-expanded product object so
+         * the handler never hits `stripeClient.products.retrieve`. Each test
+         * can override product metadata to exercise tier-resolution branches.
+         */
+        function makeSubscriptionUpsertEvent(opts: {
+            stripeSubId?: string;
+            customerId?: string;
+            status?: string;
+            productMetadata?: Record<string, string>;
+            periodStart?: number;
+            periodEnd?: number;
+        }): Stripe.Event {
+            const item = {
+                current_period_start: opts.periodStart ?? 1_700_000_000,
+                current_period_end: opts.periodEnd ?? 1_702_000_000,
+                price: {
+                    product: {
+                        id: 'prod_test',
+                        metadata: opts.productMetadata ?? {},
+                    },
+                },
+            };
+
+            const subscription = {
+                id: opts.stripeSubId ?? 'sub_stripe_test',
+                customer: opts.customerId ?? TEST_STRIPE_CUSTOMER_ID,
+                status: opts.status ?? 'active',
+                cancel_at_period_end: false,
+                trial_end: null,
+                items: { data: [item] },
+            };
+
+            return {
+                id: 'evt_test',
+                type: 'customer.subscription.updated',
+                data: {
+                    object: subscription as unknown as Stripe.Subscription,
+                },
+            } as unknown as Stripe.Event;
+        }
+
+        it('updates tier and storage limit from product metadata', async () => {
+            const existing = createSubscriptionFixture({
+                planTier: 'starter',
+                storageLimit: PLAN_LIMITS.starter,
+            });
+            mocks.findFirst.mockResolvedValue(existing);
+            mocks.returning.mockResolvedValue([
+                { ...existing, planTier: 'pro' },
+            ]);
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionUpsertEvent({
+                    productMetadata: { tier: 'pro' },
+                })
+            );
+
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    planTier: 'pro',
+                    storageLimit: PLAN_LIMITS.pro,
+                    status: 'active',
+                })
+            );
+        });
+
+        it('preserves existing tier when Stripe product has no tier metadata', async () => {
+            // Regression guard: a Stripe config mistake (missing metadata)
+            // must not silently downgrade an existing pro subscription.
+            const existing = createSubscriptionFixture({
+                planTier: 'pro',
+                storageLimit: PLAN_LIMITS.pro,
+            });
+            mocks.findFirst.mockResolvedValue(existing);
+            mocks.returning.mockResolvedValue([existing]);
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionUpsertEvent({ productMetadata: {} })
+            );
+
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    planTier: 'pro',
+                    storageLimit: PLAN_LIMITS.pro,
+                })
+            );
+        });
+
+        it('maps Stripe status to DB enum', async () => {
+            const existing = createSubscriptionFixture({ status: 'active' });
+            mocks.findFirst.mockResolvedValue(existing);
+            mocks.returning.mockResolvedValue([existing]);
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionUpsertEvent({
+                    status: 'past_due',
+                    productMetadata: { tier: 'starter' },
+                })
+            );
+
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({ status: 'past_due' })
+            );
+        });
+
+        it('falls back to existing status on unknown Stripe status', async () => {
+            const existing = createSubscriptionFixture({ status: 'active' });
+            mocks.findFirst.mockResolvedValue(existing);
+            mocks.returning.mockResolvedValue([existing]);
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionUpsertEvent({
+                    status: 'some_future_stripe_status',
+                    productMetadata: { tier: 'starter' },
+                })
+            );
+
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({ status: 'active' })
+            );
+        });
+
+        it('reads period dates from subscription items (post-2026-02-25)', async () => {
+            const existing = createSubscriptionFixture();
+            mocks.findFirst.mockResolvedValue(existing);
+            mocks.returning.mockResolvedValue([existing]);
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionUpsertEvent({
+                    productMetadata: { tier: 'starter' },
+                    periodStart: 1_700_000_000,
+                    periodEnd: 1_702_000_000,
+                })
+            );
+
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    currentPeriodStart: new Date(1_700_000_000 * 1000),
+                    currentPeriodEnd: new Date(1_702_000_000 * 1000),
+                })
+            );
+        });
+
+        it('no-ops when no local subscription exists', async () => {
+            mocks.findFirst.mockResolvedValue(undefined);
+
+            await subscriptionService.dispatchWebhookEvent(
+                db,
+                makeSubscriptionUpsertEvent({
+                    productMetadata: { tier: 'pro' },
+                })
+            );
+
+            expect(mocks.insert).not.toHaveBeenCalled();
+        });
+
+        it('retrieves product from Stripe when not expanded', async () => {
+            const existing = createSubscriptionFixture({ planTier: 'starter' });
+            mocks.findFirst.mockResolvedValue(existing);
+            mocks.returning.mockResolvedValue([existing]);
+
+            productsRetrieve.mockResolvedValue({
+                id: 'prod_test',
+                metadata: { tier: 'max' },
+            });
+
+            // Unexpanded product: just the ID string, not the full object
+            const event = {
+                id: 'evt_test',
+                type: 'customer.subscription.updated',
+                data: {
+                    object: {
+                        id: 'sub_stripe_test',
+                        customer: TEST_STRIPE_CUSTOMER_ID,
+                        status: 'active',
+                        cancel_at_period_end: false,
+                        trial_end: null,
+                        items: {
+                            data: [
+                                {
+                                    current_period_start: 1_700_000_000,
+                                    current_period_end: 1_702_000_000,
+                                    price: { product: 'prod_test' },
+                                },
+                            ],
+                        },
+                    } as unknown as Stripe.Subscription,
+                },
+            } as unknown as Stripe.Event;
+
+            await subscriptionService.dispatchWebhookEvent(db, event);
+
+            expect(productsRetrieve).toHaveBeenCalledWith('prod_test');
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    planTier: 'max',
+                    storageLimit: PLAN_LIMITS.max,
+                })
+            );
+        });
+
+        it('preserves existing tier when product retrieval fails', async () => {
+            const existing = createSubscriptionFixture({ planTier: 'pro' });
+            mocks.findFirst.mockResolvedValue(existing);
+            mocks.returning.mockResolvedValue([existing]);
+
+            productsRetrieve.mockRejectedValue(new Error('stripe api error'));
+
+            const event = {
+                id: 'evt_test',
+                type: 'customer.subscription.updated',
+                data: {
+                    object: {
+                        id: 'sub_stripe_test',
+                        customer: TEST_STRIPE_CUSTOMER_ID,
+                        status: 'active',
+                        cancel_at_period_end: false,
+                        trial_end: null,
+                        items: {
+                            data: [
+                                {
+                                    current_period_start: 1_700_000_000,
+                                    current_period_end: 1_702_000_000,
+                                    price: { product: 'prod_test' },
+                                },
+                            ],
+                        },
+                    } as unknown as Stripe.Subscription,
+                },
+            } as unknown as Stripe.Event;
+
+            await subscriptionService.dispatchWebhookEvent(db, event);
+
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    planTier: 'pro',
+                    storageLimit: PLAN_LIMITS.pro,
+                })
+            );
+        });
+    });
+
+    // ─── customer.subscription.deleted ─────────────────────────────────
+
+    describe('customer.subscription.deleted', () => {
+        it('marks subscription as canceled', async () => {
+            const existing = createSubscriptionFixture({
+                status: 'active',
+                cancelAtPeriodEnd: true,
+            });
+            mocks.findFirst.mockResolvedValue(existing);
+            mocks.returning.mockResolvedValue([
+                { ...existing, status: 'canceled' },
+            ]);
+
+            const event = {
+                id: 'evt_test',
+                type: 'customer.subscription.deleted',
+                data: {
+                    object: {
+                        id: 'sub_stripe_test',
+                        customer: TEST_STRIPE_CUSTOMER_ID,
+                        items: { data: [] },
+                    } as unknown as Stripe.Subscription,
+                },
+            } as unknown as Stripe.Event;
+
+            await subscriptionService.dispatchWebhookEvent(db, event);
+
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    status: 'canceled',
+                    cancelAtPeriodEnd: false,
+                })
+            );
+        });
+    });
+
+    // ─── unhandled events ──────────────────────────────────────────────
+
+    it('ignores unhandled event types without error', async () => {
+        const event = {
+            id: 'evt_test',
+            type: 'some.other.event',
+            data: { object: {} },
+        } as unknown as Stripe.Event;
+
+        await expect(
+            subscriptionService.dispatchWebhookEvent(db, event)
+        ).resolves.toBeUndefined();
+
+        expect(mocks.findFirst).not.toHaveBeenCalled();
+        expect(mocks.insert).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -51,15 +51,30 @@ function mapStripeStatus(
     return fallback;
 }
 
-function resolveTierFromSubscription(
+async function resolveTierFromSubscription(
     sub: Stripe.Subscription
-): PlanTier | null {
+): Promise<PlanTier | null> {
     const item = sub.items.data[0];
     if (!item) return null;
-    const product = item.price.product as Stripe.Product | string;
-    const metadata =
-        typeof product === 'string' ? null : (product.metadata ?? null);
-    return (metadata?.tier as PlanTier) ?? null;
+
+    const rawProduct = item.price.product;
+    let product: Stripe.Product;
+
+    if (typeof rawProduct === 'string') {
+        try {
+            product = await stripeClient.products.retrieve(rawProduct);
+        } catch (err) {
+            log.warn(
+                { productId: rawProduct, err },
+                'Failed to retrieve product from Stripe'
+            );
+            return null;
+        }
+    } else {
+        product = rawProduct as Stripe.Product;
+    }
+
+    return (product.metadata?.tier as PlanTier) ?? null;
 }
 
 // ─── tRPC-facing service methods ────────────────────────────────────────
@@ -125,6 +140,19 @@ async function createPortalSession(
     return { url: session.url };
 }
 
+/**
+ * Provisions a local-only trial: creates a Stripe Customer but no Stripe
+ * Subscription. The trial is tracked via `trialEnd` in the local DB.
+ *
+ * There is currently no automatic expiry transition — when `trialEnd` passes,
+ * the row stays `status: 'trialing'`. Enforcement is soft: the upload quota
+ * check in `files.ts` (`assertWithinQuota`) rejects uploads for expired trials.
+ *
+ * Future options for proper lifecycle handling:
+ *   1. Cron job to transition expired trials to `canceled`
+ *   2. Real Stripe Subscription with `trial_period_days` so Stripe manages expiry
+ *   3. Middleware in `protectedProcedure` that checks trial status on every request
+ */
 async function provisionTrialSubscription(
     db: DB,
     userId: string,
@@ -215,7 +243,7 @@ async function handleSubscriptionUpsert(
         return;
     }
 
-    const tier = resolveTierFromSubscription(sub) ?? existing.planTier;
+    const tier = (await resolveTierFromSubscription(sub)) ?? existing.planTier;
     const storageLimit = PLAN_LIMITS[tier] ?? existing.storageLimit;
 
     // In API version 2026-02-25.clover, period fields moved from Subscription to its items

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -1,10 +1,11 @@
 import type Stripe from 'stripe';
+import { addDays } from 'date-fns';
 import type { DB } from '@nexus/db';
 import {
     createSubscriptionRepo,
     type Subscription,
 } from '@nexus/db/repo/subscriptions';
-import { subscriptionStatusEnum } from '@nexus/db/schema';
+import { planTierEnum, subscriptionStatusEnum } from '@nexus/db/schema';
 import { env } from '@/lib/env';
 import { stripe, stripeClient } from '@/lib/stripe';
 import { NotFoundError, InvalidStateError } from '@/server/errors';
@@ -20,6 +21,7 @@ import {
 const log = logger.child({ service: 'subscriptions' });
 
 const VALID_STATUSES = new Set<string>(subscriptionStatusEnum.enumValues);
+const VALID_TIERS = new Set<string>(planTierEnum.enumValues);
 
 type SubscriptionStatus = (typeof subscriptionStatusEnum.enumValues)[number];
 
@@ -83,12 +85,9 @@ function findPlanItem(
     return planItems[0] ?? sub.items.data[0];
 }
 
-async function resolveTierFromSubscription(
-    sub: Stripe.Subscription
+async function resolveTierFromItem(
+    item: Stripe.SubscriptionItem
 ): Promise<PlanTier | null> {
-    const item = findPlanItem(sub);
-    if (!item) return null;
-
     const rawProduct = item.price.product;
     let product: Stripe.Product;
 
@@ -102,11 +101,22 @@ async function resolveTierFromSubscription(
             );
             return null;
         }
+    } else if ('deleted' in rawProduct && rawProduct.deleted) {
+        return null;
     } else {
-        product = rawProduct as Stripe.Product;
+        product = rawProduct;
     }
 
-    return (product.metadata?.tier as PlanTier) ?? null;
+    const tier = product.metadata?.tier;
+    if (!tier) return null;
+    if (!VALID_TIERS.has(tier)) {
+        log.warn(
+            { productId: product.id, tier },
+            'Stripe product metadata.tier does not match any DB plan tier'
+        );
+        return null;
+    }
+    return tier as PlanTier;
 }
 
 // ─── tRPC-facing service methods ────────────────────────────────────────
@@ -174,16 +184,8 @@ async function createPortalSession(
 
 /**
  * Provisions a local-only trial: creates a Stripe Customer but no Stripe
- * Subscription. The trial is tracked via `trialEnd` in the local DB.
- *
- * There is currently no automatic expiry transition — when `trialEnd` passes,
- * the row stays `status: 'trialing'`. Enforcement is soft: the upload quota
- * check in `files.ts` (`assertWithinQuota`) rejects uploads for expired trials.
- *
- * Future options for proper lifecycle handling:
- *   1. Cron job to transition expired trials to `canceled`
- *   2. Real Stripe Subscription with `trial_period_days` so Stripe manages expiry
- *   3. Middleware in `protectedProcedure` that checks trial status on every request
+ * Subscription. Expiry is enforced soft by `assertWithinQuota` in files.ts —
+ * the row stays `status: 'trialing'` until a real subscription replaces it.
  */
 async function provisionTrialSubscription(
     db: DB,
@@ -197,8 +199,7 @@ async function provisionTrialSubscription(
         metadata: { userId },
     });
 
-    const trialEnd = new Date();
-    trialEnd.setDate(trialEnd.getDate() + TRIAL_DURATION_DAYS);
+    const trialEnd = addDays(new Date(), TRIAL_DURATION_DAYS);
 
     const repo = createSubscriptionRepo(db);
     await repo.insert({
@@ -275,12 +276,14 @@ async function handleSubscriptionUpsert(
         return;
     }
 
-    const tier = (await resolveTierFromSubscription(sub)) ?? existing.planTier;
-    const storageLimit = PLAN_LIMITS[tier] ?? existing.storageLimit;
-
-    // In API version 2026-02-25.clover, period fields moved from Subscription to its items.
-    // Read from the plan item (not the first add-on) so add-ons with different cycles don't override.
+    // Period fields live on subscription items (Stripe API 2026-02-25.clover);
+    // pick the plan item once and reuse it for both tier and period extraction.
     const planItem = findPlanItem(sub);
+    const tier =
+        (planItem ? await resolveTierFromItem(planItem) : null) ??
+        existing.planTier;
+    const storageLimit = PLAN_LIMITS[tier];
+
     const periodStart = planItem
         ? new Date(planItem.current_period_start * 1000)
         : existing.currentPeriodStart;

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -1,19 +1,68 @@
+import type Stripe from 'stripe';
 import type { DB } from '@nexus/db';
 import {
     createSubscriptionRepo,
     type Subscription,
 } from '@nexus/db/repo/subscriptions';
+import { subscriptionStatusEnum } from '@nexus/db/schema';
 import { env } from '@/lib/env';
 import { stripe, stripeClient } from '@/lib/stripe';
+import { NotFoundError, InvalidStateError } from '@/server/errors';
 import { logger } from '@/server/lib/logger';
 import {
     PLAN_LIMITS,
     TRIAL_DURATION_DAYS,
+    type PlanTier,
     type CheckoutTier,
     type BillingInterval,
 } from './constants';
 
 const log = logger.child({ service: 'subscriptions' });
+
+const VALID_STATUSES = new Set<string>(subscriptionStatusEnum.enumValues);
+
+type SubscriptionStatus = (typeof subscriptionStatusEnum.enumValues)[number];
+
+// Terminal or severe statuses that should not be overwritten by past_due
+const TERMINAL_STATUSES = new Set<SubscriptionStatus>(['canceled', 'unpaid']);
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+/** Stripe uses expandable fields (string | object | null) — normalize to the ID string. */
+function resolveStripeId(
+    field: string | { id: string } | null | undefined
+): string | undefined {
+    if (!field) return undefined;
+    return typeof field === 'string' ? field : field.id;
+}
+
+/** Map Stripe status to our DB enum, falling back to existing value for unknown statuses. */
+function mapStripeStatus(
+    stripeStatus: string,
+    fallback: SubscriptionStatus
+): SubscriptionStatus {
+    if (VALID_STATUSES.has(stripeStatus)) {
+        return stripeStatus as SubscriptionStatus;
+    }
+    log.warn(
+        { stripeStatus },
+        'Unknown Stripe subscription status, using fallback'
+    );
+    return fallback;
+}
+
+function resolveTierFromSubscription(
+    sub: Stripe.Subscription
+): PlanTier | null {
+    const item = sub.items.data[0];
+    if (!item) return null;
+    const product = item.price.product as Stripe.Product | string;
+    const metadata =
+        typeof product === 'string' ? null : (product.metadata ?? null);
+    return (metadata?.tier as PlanTier) ?? null;
+}
+
+// ─── tRPC-facing service methods ────────────────────────────────────────
 
 async function getCurrentSubscription(
     db: DB,
@@ -33,7 +82,7 @@ async function createCheckoutSession(
     const sub = await repo.findByUserId(userId);
 
     if (!sub) {
-        throw new Error('No subscription record found for user');
+        throw new NotFoundError('Subscription');
     }
 
     const priceId = await stripe.prices.resolvePriceId(tier, interval);
@@ -46,7 +95,7 @@ async function createCheckoutSession(
     });
 
     if (!session.url) {
-        throw new Error('Stripe did not return a checkout URL');
+        throw new InvalidStateError('Stripe did not return a checkout URL');
     }
 
     log.info(
@@ -65,7 +114,7 @@ async function createPortalSession(
     const sub = await repo.findByUserId(userId);
 
     if (!sub) {
-        throw new Error('No subscription record found for user');
+        throw new NotFoundError('Subscription');
     }
 
     const session = await stripe.checkout.createBillingPortalSession(
@@ -108,9 +157,191 @@ async function provisionTrialSubscription(
     );
 }
 
+// ─── Webhook event handlers ─────────────────────────────────────────────
+
+async function handleCheckoutCompleted(
+    db: DB,
+    session: Stripe.Checkout.Session
+): Promise<void> {
+    if (session.mode !== 'subscription') return;
+
+    const customerId = resolveStripeId(session.customer);
+    const subscriptionId = resolveStripeId(session.subscription);
+
+    if (!customerId || !subscriptionId) {
+        log.warn(
+            { sessionId: session.id },
+            'Checkout session missing customer or subscription'
+        );
+        return;
+    }
+
+    const repo = createSubscriptionRepo(db);
+    const sub = await repo.findByStripeCustomerId(customerId);
+    if (!sub) {
+        log.warn(
+            { customerId, sessionId: session.id },
+            'No subscription record for customer'
+        );
+        return;
+    }
+
+    // subscription.created will fill in plan details; this just links the IDs
+    await repo.upsertFromWebhook({
+        ...sub,
+        stripeSubscriptionId: subscriptionId,
+    });
+
+    log.info(
+        { customerId, subscriptionId },
+        'Linked Stripe subscription from checkout'
+    );
+}
+
+async function handleSubscriptionUpsert(
+    db: DB,
+    sub: Stripe.Subscription
+): Promise<void> {
+    const customerId = resolveStripeId(sub.customer);
+    if (!customerId) return;
+
+    const repo = createSubscriptionRepo(db);
+    const existing = await repo.findByStripeCustomerId(customerId);
+    if (!existing) {
+        log.warn(
+            { customerId, stripeSubscriptionId: sub.id },
+            'No local record for subscription upsert'
+        );
+        return;
+    }
+
+    const tier = resolveTierFromSubscription(sub) ?? existing.planTier;
+    const storageLimit = PLAN_LIMITS[tier] ?? existing.storageLimit;
+
+    // In API version 2026-02-25.clover, period fields moved from Subscription to its items
+    const firstItem = sub.items.data[0];
+    const periodStart = firstItem
+        ? new Date(firstItem.current_period_start * 1000)
+        : existing.currentPeriodStart;
+    const periodEnd = firstItem
+        ? new Date(firstItem.current_period_end * 1000)
+        : existing.currentPeriodEnd;
+
+    await repo.upsertFromWebhook({
+        ...existing,
+        stripeSubscriptionId: sub.id,
+        planTier: tier,
+        status: mapStripeStatus(sub.status, existing.status),
+        storageLimit,
+        currentPeriodStart: periodStart,
+        currentPeriodEnd: periodEnd,
+        cancelAtPeriodEnd: sub.cancel_at_period_end,
+        trialEnd: sub.trial_end ? new Date(sub.trial_end * 1000) : null,
+    });
+
+    log.info(
+        { customerId, tier, status: sub.status },
+        'Subscription synced from webhook'
+    );
+}
+
+async function handleSubscriptionDeleted(
+    db: DB,
+    sub: Stripe.Subscription
+): Promise<void> {
+    const customerId = resolveStripeId(sub.customer);
+    if (!customerId) return;
+
+    const repo = createSubscriptionRepo(db);
+    const existing = await repo.findByStripeCustomerId(customerId);
+    if (!existing) {
+        log.warn({ customerId }, 'No local record for subscription deletion');
+        return;
+    }
+
+    await repo.upsertFromWebhook({
+        ...existing,
+        status: 'canceled',
+        cancelAtPeriodEnd: false,
+    });
+
+    log.info({ customerId }, 'Subscription marked as canceled');
+}
+
+async function handlePaymentFailed(
+    db: DB,
+    invoice: Stripe.Invoice
+): Promise<void> {
+    const customerId = resolveStripeId(invoice.customer);
+
+    if (!customerId) {
+        log.warn({ invoiceId: invoice.id }, 'Invoice missing customer');
+        return;
+    }
+
+    const repo = createSubscriptionRepo(db);
+    const existing = await repo.findByStripeCustomerId(customerId);
+    if (!existing) {
+        log.warn({ customerId }, 'No local record for payment failure');
+        return;
+    }
+
+    // Don't regress from a more severe status if events arrive out of order
+    if (TERMINAL_STATUSES.has(existing.status)) {
+        log.debug(
+            { customerId, currentStatus: existing.status },
+            'Skipping past_due — subscription already in terminal status'
+        );
+        return;
+    }
+
+    await repo.upsertFromWebhook({
+        ...existing,
+        status: 'past_due',
+    });
+
+    log.info(
+        { customerId, invoiceId: invoice.id },
+        'Subscription marked past_due'
+    );
+}
+
+async function dispatchWebhookEvent(
+    db: DB,
+    event: Stripe.Event
+): Promise<void> {
+    switch (event.type) {
+        case 'checkout.session.completed':
+            await handleCheckoutCompleted(
+                db,
+                event.data.object as Stripe.Checkout.Session
+            );
+            break;
+        case 'customer.subscription.created':
+        case 'customer.subscription.updated':
+            await handleSubscriptionUpsert(
+                db,
+                event.data.object as Stripe.Subscription
+            );
+            break;
+        case 'customer.subscription.deleted':
+            await handleSubscriptionDeleted(
+                db,
+                event.data.object as Stripe.Subscription
+            );
+            break;
+        case 'invoice.payment_failed':
+            await handlePaymentFailed(db, event.data.object as Stripe.Invoice);
+            break;
+        default:
+            log.debug({ eventType: event.type }, 'Unhandled event type');
+    }
+}
+
 export const subscriptionService = {
     getCurrentSubscription,
     createCheckoutSession,
     createPortalSession,
     provisionTrialSubscription,
+    dispatchWebhookEvent,
 } as const;

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -1,0 +1,116 @@
+import type { DB } from '@nexus/db';
+import {
+    createSubscriptionRepo,
+    type Subscription,
+} from '@nexus/db/repo/subscriptions';
+import { env } from '@/lib/env';
+import { stripe, stripeClient } from '@/lib/stripe';
+import { logger } from '@/server/lib/logger';
+import {
+    PLAN_LIMITS,
+    TRIAL_DURATION_DAYS,
+    type CheckoutTier,
+    type BillingInterval,
+} from './constants';
+
+const log = logger.child({ service: 'subscriptions' });
+
+async function getCurrentSubscription(
+    db: DB,
+    userId: string
+): Promise<Subscription | undefined> {
+    const repo = createSubscriptionRepo(db);
+    return repo.findByUserId(userId);
+}
+
+async function createCheckoutSession(
+    db: DB,
+    userId: string,
+    tier: CheckoutTier,
+    interval: BillingInterval
+): Promise<{ url: string }> {
+    const repo = createSubscriptionRepo(db);
+    const sub = await repo.findByUserId(userId);
+
+    if (!sub) {
+        throw new Error('No subscription record found for user');
+    }
+
+    const priceId = await stripe.prices.resolvePriceId(tier, interval);
+
+    const session = await stripe.checkout.createCheckoutSession({
+        customerId: sub.stripeCustomerId,
+        priceId,
+        successUrl: `${env.NEXT_PUBLIC_APP_URL}/settings?checkout=success`,
+        cancelUrl: `${env.NEXT_PUBLIC_APP_URL}/settings?checkout=canceled`,
+    });
+
+    if (!session.url) {
+        throw new Error('Stripe did not return a checkout URL');
+    }
+
+    log.info(
+        { userId, tier, interval, sessionId: session.id },
+        'Checkout session created'
+    );
+
+    return { url: session.url };
+}
+
+async function createPortalSession(
+    db: DB,
+    userId: string
+): Promise<{ url: string }> {
+    const repo = createSubscriptionRepo(db);
+    const sub = await repo.findByUserId(userId);
+
+    if (!sub) {
+        throw new Error('No subscription record found for user');
+    }
+
+    const session = await stripe.checkout.createBillingPortalSession(
+        sub.stripeCustomerId,
+        `${env.NEXT_PUBLIC_APP_URL}/settings`
+    );
+
+    return { url: session.url };
+}
+
+async function provisionTrialSubscription(
+    db: DB,
+    userId: string,
+    email: string,
+    name?: string
+): Promise<void> {
+    const customer = await stripeClient.customers.create({
+        email,
+        name: name ?? undefined,
+        metadata: { userId },
+    });
+
+    const trialEnd = new Date();
+    trialEnd.setDate(trialEnd.getDate() + TRIAL_DURATION_DAYS);
+
+    const repo = createSubscriptionRepo(db);
+    await repo.insert({
+        id: crypto.randomUUID(),
+        userId,
+        stripeCustomerId: customer.id,
+        planTier: 'starter',
+        status: 'trialing',
+        storageLimit: PLAN_LIMITS.starter,
+        trialEnd,
+    });
+
+    log.info(
+        { userId, stripeCustomerId: customer.id },
+        'Trial subscription provisioned'
+    );
+}
+
+export const subscriptionService = {
+    getCurrentSubscription,
+    createCheckoutSession,
+    createPortalSession,
+    provisionTrialSubscription,
+} as const;

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -51,10 +51,42 @@ function mapStripeStatus(
     return fallback;
 }
 
+/**
+ * Returns the subscription item that represents the plan (vs. add-ons).
+ *
+ * Stripe doesn't guarantee item ordering, and a single subscription may carry
+ * a base plan plus metered add-ons. We identify the plan by looking for an
+ * expanded product carrying `metadata.tier`. When products aren't expanded
+ * (or none have tier metadata), fall back to the first item — preserving the
+ * old behavior for the common single-item case.
+ */
+function findPlanItem(
+    sub: Stripe.Subscription
+): Stripe.SubscriptionItem | undefined {
+    const planItems = sub.items.data.filter((item) => {
+        const product = item.price.product;
+        return (
+            typeof product === 'object' &&
+            product !== null &&
+            !('deleted' in product && product.deleted) &&
+            !!product.metadata?.tier
+        );
+    });
+
+    if (planItems.length > 1) {
+        log.warn(
+            { stripeSubId: sub.id, count: planItems.length },
+            'Multiple plan items found in subscription, using first'
+        );
+    }
+
+    return planItems[0] ?? sub.items.data[0];
+}
+
 async function resolveTierFromSubscription(
     sub: Stripe.Subscription
 ): Promise<PlanTier | null> {
-    const item = sub.items.data[0];
+    const item = findPlanItem(sub);
     if (!item) return null;
 
     const rawProduct = item.price.product;
@@ -246,13 +278,14 @@ async function handleSubscriptionUpsert(
     const tier = (await resolveTierFromSubscription(sub)) ?? existing.planTier;
     const storageLimit = PLAN_LIMITS[tier] ?? existing.storageLimit;
 
-    // In API version 2026-02-25.clover, period fields moved from Subscription to its items
-    const firstItem = sub.items.data[0];
-    const periodStart = firstItem
-        ? new Date(firstItem.current_period_start * 1000)
+    // In API version 2026-02-25.clover, period fields moved from Subscription to its items.
+    // Read from the plan item (not the first add-on) so add-ons with different cycles don't override.
+    const planItem = findPlanItem(sub);
+    const periodStart = planItem
+        ? new Date(planItem.current_period_start * 1000)
         : existing.currentPeriodStart;
-    const periodEnd = firstItem
-        ? new Date(firstItem.current_period_end * 1000)
+    const periodEnd = planItem
+        ? new Date(planItem.current_period_end * 1000)
         : existing.currentPeriodEnd;
 
     await repo.upsertFromWebhook({

--- a/apps/web/server/trpc/middleware/logging.test.ts
+++ b/apps/web/server/trpc/middleware/logging.test.ts
@@ -2,22 +2,20 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-// Mock the logger module so we can control errorVerbosity per test
-const mockLogger = {
-    errorVerbosity: 'full' as 'minimal' | 'standard' | 'full',
-};
+// Mutable holder so individual tests can swap errorVerbosity
+const config = { errorVerbosity: 'full' as 'minimal' | 'standard' | 'full' };
+
+const hoisted = await vi.hoisted(async () => {
+    const { createMockLogger } = await import('@/server/lib/logger/testing');
+    return { logger: createMockLogger() };
+});
 
 vi.mock('@/server/lib/logger', () => ({
     get errorVerbosity() {
-        return mockLogger.errorVerbosity;
+        return config.errorVerbosity;
     },
     isDev: true,
-    logger: {
-        info: vi.fn(),
-        error: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn(),
-    },
+    logger: hoisted.logger,
 }));
 
 import {
@@ -28,7 +26,7 @@ import {
 } from './logging';
 
 beforeEach(() => {
-    mockLogger.errorVerbosity = 'full';
+    config.errorVerbosity = 'full';
 });
 
 /** Create a real ZodError by parsing invalid data. */
@@ -243,7 +241,7 @@ describe('formatError', () => {
 
     describe('standard verbosity', () => {
         beforeEach(() => {
-            mockLogger.errorVerbosity = 'standard';
+            config.errorVerbosity = 'standard';
         });
 
         it('includes message but no stack or cause', () => {
@@ -264,7 +262,7 @@ describe('formatError', () => {
 
     describe('minimal verbosity', () => {
         beforeEach(() => {
-            mockLogger.errorVerbosity = 'minimal';
+            config.errorVerbosity = 'minimal';
         });
 
         it('includes only code', () => {

--- a/apps/web/server/trpc/router.ts
+++ b/apps/web/server/trpc/router.ts
@@ -5,6 +5,7 @@ import { debugRouter } from './routers/debug';
 import { filesRouter } from './routers/files';
 import { retrievalsRouter } from './routers/retrievals';
 import { storageRouter } from './routers/storage';
+import { subscriptionsRouter } from './routers/subscriptions';
 
 export const appRouter = router({
     admin: adminRouter,
@@ -13,6 +14,7 @@ export const appRouter = router({
     files: filesRouter,
     retrievals: retrievalsRouter,
     storage: storageRouter,
+    subscriptions: subscriptionsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/server/trpc/routers/subscriptions.ts
+++ b/apps/web/server/trpc/routers/subscriptions.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { subscriptionService } from '@/server/services/subscriptions';
+import { protectedProcedure, router } from '../init';
+
+export const subscriptionsRouter = router({
+    current: protectedProcedure.query(({ ctx }) => {
+        return subscriptionService.getCurrentSubscription(
+            ctx.db,
+            ctx.session.user.id
+        );
+    }),
+
+    createCheckoutSession: protectedProcedure
+        .input(
+            z.object({
+                tier: z.enum(['starter', 'pro', 'max']),
+                interval: z.enum(['month', 'year']),
+            })
+        )
+        .mutation(({ ctx, input }) => {
+            return subscriptionService.createCheckoutSession(
+                ctx.db,
+                ctx.session.user.id,
+                input.tier,
+                input.interval
+            );
+        }),
+
+    createPortalSession: protectedProcedure.mutation(({ ctx }) => {
+        return subscriptionService.createPortalSession(
+            ctx.db,
+            ctx.session.user.id
+        );
+    }),
+});

--- a/apps/web/server/trpc/routers/subscriptions.ts
+++ b/apps/web/server/trpc/routers/subscriptions.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { CHECKOUT_TIERS, BILLING_INTERVALS } from '@/lib/stripe/types';
 import { subscriptionService } from '@/server/services/subscriptions';
 import { protectedProcedure, router } from '../init';
 
@@ -13,8 +14,8 @@ export const subscriptionsRouter = router({
     createCheckoutSession: protectedProcedure
         .input(
             z.object({
-                tier: z.enum(['starter', 'pro', 'max']),
-                interval: z.enum(['month', 'year']),
+                tier: z.enum(CHECKOUT_TIERS),
+                interval: z.enum(BILLING_INTERVALS),
             })
         )
         .mutation(({ ctx, input }) => {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -32,6 +32,10 @@
             "import": "./src/repositories/webhooks.ts",
             "types": "./src/repositories/webhooks.ts"
         },
+        "./plans": {
+            "import": "./src/plans.ts",
+            "types": "./src/plans.ts"
+        },
         "./testing": {
             "import": "./src/testing.ts",
             "types": "./src/testing.ts"

--- a/packages/db/src/plans.ts
+++ b/packages/db/src/plans.ts
@@ -1,0 +1,11 @@
+import type { planTierEnum } from './schema/subscriptions';
+
+export type PlanTier = (typeof planTierEnum.enumValues)[number];
+
+/** Storage limits by plan tier in bytes. */
+export const PLAN_LIMITS: Record<PlanTier, number> = {
+    starter: 10 * 1024 ** 3, //    10 GB
+    pro: 100 * 1024 ** 3, //   100 GB
+    max: 1024 * 1024 ** 3, // 1,024 GB (1 TB)
+    enterprise: 10 * 1024 ** 4, //  10 TB
+};

--- a/packages/db/src/repositories/files.test.ts
+++ b/packages/db/src/repositories/files.test.ts
@@ -21,16 +21,16 @@ describe('files repository', () => {
     describe('findById', () => {
         it('returns file when found', async () => {
             const file = createFileFixture();
-            mocks.findFirst.mockResolvedValue(file);
+            mocks.files.findFirst.mockResolvedValue(file);
 
             const result = await repo.findById(TEST_FILE_ID);
 
             expect(result).toEqual(file);
-            expect(mocks.findFirst).toHaveBeenCalledOnce();
+            expect(mocks.files.findFirst).toHaveBeenCalledOnce();
         });
 
         it('returns undefined when not found', async () => {
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.files.findFirst.mockResolvedValue(undefined);
 
             const result = await repo.findById('nonexistent');
 
@@ -41,7 +41,7 @@ describe('files repository', () => {
     describe('findByUserAndId', () => {
         it('returns file when user owns it', async () => {
             const file = createFileFixture();
-            mocks.findFirst.mockResolvedValue(file);
+            mocks.files.findFirst.mockResolvedValue(file);
 
             const result = await repo.findByUserAndId(
                 TEST_USER_ID,
@@ -49,11 +49,11 @@ describe('files repository', () => {
             );
 
             expect(result).toEqual(file);
-            expect(mocks.findFirst).toHaveBeenCalledOnce();
+            expect(mocks.files.findFirst).toHaveBeenCalledOnce();
         });
 
         it('returns undefined when user does not own file', async () => {
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.files.findFirst.mockResolvedValue(undefined);
 
             const result = await repo.findByUserAndId(
                 'other_user',
@@ -70,7 +70,7 @@ describe('files repository', () => {
                 createFileFixture({ id: 'file1' }),
                 createFileFixture({ id: 'file2' }),
             ];
-            mocks.findMany.mockResolvedValue(files);
+            mocks.files.findMany.mockResolvedValue(files);
 
             const result = await repo.findManyByUserAndIds(TEST_USER_ID, [
                 'file1',
@@ -78,19 +78,19 @@ describe('files repository', () => {
             ]);
 
             expect(result).toEqual(files);
-            expect(mocks.findMany).toHaveBeenCalledOnce();
+            expect(mocks.files.findMany).toHaveBeenCalledOnce();
         });
 
         it('returns empty array when given empty ids', async () => {
             const result = await repo.findManyByUserAndIds(TEST_USER_ID, []);
 
             expect(result).toEqual([]);
-            expect(mocks.findMany).not.toHaveBeenCalled();
+            expect(mocks.files.findMany).not.toHaveBeenCalled();
         });
 
         it('returns only files that exist and are owned by user', async () => {
             const files = [createFileFixture({ id: 'file1' })];
-            mocks.findMany.mockResolvedValue(files);
+            mocks.files.findMany.mockResolvedValue(files);
 
             const result = await repo.findManyByUserAndIds(TEST_USER_ID, [
                 'file1',
@@ -107,7 +107,7 @@ describe('files repository', () => {
                 createFileFixture({ id: 'file1' }),
                 createFileFixture({ id: 'file2' }),
             ];
-            mocks.findMany.mockResolvedValue(files);
+            mocks.files.findMany.mockResolvedValue(files);
 
             const result = await repo.findByUser(TEST_USER_ID);
 
@@ -116,11 +116,11 @@ describe('files repository', () => {
         });
 
         it('uses default pagination (limit: 50, offset: 0)', async () => {
-            mocks.findMany.mockResolvedValue([]);
+            mocks.files.findMany.mockResolvedValue([]);
 
             await repo.findByUser(TEST_USER_ID);
 
-            expect(mocks.findMany).toHaveBeenCalledWith(
+            expect(mocks.files.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     limit: 50,
                     offset: 0,
@@ -129,11 +129,11 @@ describe('files repository', () => {
         });
 
         it('respects custom pagination options', async () => {
-            mocks.findMany.mockResolvedValue([]);
+            mocks.files.findMany.mockResolvedValue([]);
 
             await repo.findByUser(TEST_USER_ID, { limit: 10, offset: 20 });
 
-            expect(mocks.findMany).toHaveBeenCalledWith(
+            expect(mocks.files.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     limit: 10,
                     offset: 20,
@@ -142,7 +142,7 @@ describe('files repository', () => {
         });
 
         it('returns empty array when user has no files', async () => {
-            mocks.findMany.mockResolvedValue([]);
+            mocks.files.findMany.mockResolvedValue([]);
 
             const result = await repo.findByUser(TEST_USER_ID);
 
@@ -150,7 +150,7 @@ describe('files repository', () => {
         });
 
         it('respects includeHidden option', async () => {
-            mocks.findMany.mockResolvedValue([]);
+            mocks.files.findMany.mockResolvedValue([]);
 
             await repo.findByUser(TEST_USER_ID, {
                 limit: 50,
@@ -159,7 +159,7 @@ describe('files repository', () => {
             });
 
             // When includeHidden is true, the where clause should only filter by userId
-            expect(mocks.findMany).toHaveBeenCalledOnce();
+            expect(mocks.files.findMany).toHaveBeenCalledOnce();
         });
     });
 

--- a/packages/db/src/repositories/fixtures.ts
+++ b/packages/db/src/repositories/fixtures.ts
@@ -3,6 +3,7 @@ import type { File, NewFile } from './files';
 import type { Job, NewJob } from './jobs';
 import type { Retrieval } from './retrievals';
 import type { Subscription } from './subscriptions';
+import type { WebhookEvent } from './webhooks';
 
 export const TEST_USER_ID = 'user_test123';
 export const TEST_FILE_ID = 'file_test456';
@@ -11,6 +12,7 @@ export const TEST_JOB_ID = 'job_test101';
 export const TEST_RETRIEVAL_ID = 'retrieval_test202';
 export const TEST_SUBSCRIPTION_ID = 'sub_test303';
 export const TEST_STRIPE_CUSTOMER_ID = 'cus_test303';
+export const TEST_WEBHOOK_EVENT_ID = 'wh_test404';
 
 export type User = typeof schema.user.$inferSelect;
 export type StorageUsage = typeof schema.storageUsage.$inferSelect;
@@ -120,6 +122,24 @@ export function createSubscriptionFixture(
         currentPeriodEnd: null,
         cancelAtPeriodEnd: false,
         trialEnd: null,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+    };
+}
+
+export function createWebhookEventFixture(
+    overrides: Partial<WebhookEvent> = {}
+): WebhookEvent {
+    const now = new Date();
+    return {
+        id: TEST_WEBHOOK_EVENT_ID,
+        source: 'stripe',
+        externalId: 'evt_test',
+        eventType: 'customer.subscription.updated',
+        payload: {},
+        status: 'received',
+        error: null,
         createdAt: now,
         updatedAt: now,
         ...overrides,

--- a/packages/db/src/repositories/fixtures.ts
+++ b/packages/db/src/repositories/fixtures.ts
@@ -2,12 +2,15 @@ import * as schema from '../schema';
 import type { File, NewFile } from './files';
 import type { Job, NewJob } from './jobs';
 import type { Retrieval } from './retrievals';
+import type { Subscription } from './subscriptions';
 
 export const TEST_USER_ID = 'user_test123';
 export const TEST_FILE_ID = 'file_test456';
 export const TEST_STORAGE_USAGE_ID = 'storage_test789';
 export const TEST_JOB_ID = 'job_test101';
 export const TEST_RETRIEVAL_ID = 'retrieval_test202';
+export const TEST_SUBSCRIPTION_ID = 'sub_test303';
+export const TEST_STRIPE_CUSTOMER_ID = 'cus_test303';
 
 export type User = typeof schema.user.$inferSelect;
 export type StorageUsage = typeof schema.storageUsage.$inferSelect;
@@ -97,6 +100,28 @@ export function createNewJobFixture(overrides: Partial<NewJob> = {}): NewJob {
     return {
         type: 'delete-account',
         payload: { userId: TEST_USER_ID },
+        ...overrides,
+    };
+}
+
+export function createSubscriptionFixture(
+    overrides: Partial<Subscription> = {}
+): Subscription {
+    const now = new Date();
+    return {
+        id: TEST_SUBSCRIPTION_ID,
+        userId: TEST_USER_ID,
+        stripeCustomerId: TEST_STRIPE_CUSTOMER_ID,
+        stripeSubscriptionId: null,
+        planTier: 'starter',
+        status: 'active',
+        storageLimit: 10 * 1024 ** 3, // 10 GB
+        currentPeriodStart: null,
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+        trialEnd: null,
+        createdAt: now,
+        updatedAt: now,
         ...overrides,
     };
 }

--- a/packages/db/src/repositories/jobs.test.ts
+++ b/packages/db/src/repositories/jobs.test.ts
@@ -19,7 +19,7 @@ describe('jobs repository', () => {
                 createJobFixture({ id: 'job1' }),
                 createJobFixture({ id: 'job2' }),
             ];
-            mocks.findMany.mockResolvedValue(jobs);
+            mocks.backgroundJobs.findMany.mockResolvedValue(jobs);
             mocks.where.mockResolvedValue([{ count: 2 }]);
 
             const result = await repo.findMany();
@@ -29,12 +29,12 @@ describe('jobs repository', () => {
         });
 
         it('uses default pagination (limit: 50, offset: 0)', async () => {
-            mocks.findMany.mockResolvedValue([]);
+            mocks.backgroundJobs.findMany.mockResolvedValue([]);
             mocks.where.mockResolvedValue([{ count: 0 }]);
 
             await repo.findMany();
 
-            expect(mocks.findMany).toHaveBeenCalledWith(
+            expect(mocks.backgroundJobs.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     limit: 50,
                     offset: 0,
@@ -43,12 +43,12 @@ describe('jobs repository', () => {
         });
 
         it('respects custom pagination options', async () => {
-            mocks.findMany.mockResolvedValue([]);
+            mocks.backgroundJobs.findMany.mockResolvedValue([]);
             mocks.where.mockResolvedValue([{ count: 0 }]);
 
             await repo.findMany({ limit: 10, offset: 20 });
 
-            expect(mocks.findMany).toHaveBeenCalledWith(
+            expect(mocks.backgroundJobs.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     limit: 10,
                     offset: 20,
@@ -57,7 +57,7 @@ describe('jobs repository', () => {
         });
 
         it('returns empty result when no jobs exist', async () => {
-            mocks.findMany.mockResolvedValue([]);
+            mocks.backgroundJobs.findMany.mockResolvedValue([]);
             mocks.where.mockResolvedValue([{ count: 0 }]);
 
             const result = await repo.findMany();
@@ -67,12 +67,12 @@ describe('jobs repository', () => {
         });
 
         it('filters by status when provided', async () => {
-            mocks.findMany.mockResolvedValue([]);
+            mocks.backgroundJobs.findMany.mockResolvedValue([]);
             mocks.where.mockResolvedValue([{ count: 0 }]);
 
             await repo.findMany({ limit: 50, offset: 0, status: 'failed' });
 
-            expect(mocks.findMany).toHaveBeenCalledWith(
+            expect(mocks.backgroundJobs.findMany).toHaveBeenCalledWith(
                 expect.objectContaining({
                     where: expect.anything(),
                 })

--- a/packages/db/src/repositories/mocks.ts
+++ b/packages/db/src/repositories/mocks.ts
@@ -11,7 +11,8 @@ export function createMockDb() {
     const groupBy: AnyMock = vi.fn();
     const where: AnyMock = vi.fn(() => ({ returning, groupBy }));
     const set: AnyMock = vi.fn(() => ({ where }));
-    const values: AnyMock = vi.fn(() => ({ returning }));
+    const onConflictDoUpdate: AnyMock = vi.fn(() => ({ returning }));
+    const values: AnyMock = vi.fn(() => ({ returning, onConflictDoUpdate }));
     const from: AnyMock = vi.fn(() => ({ where, groupBy }));
     const select: AnyMock = vi.fn(() => ({ from }));
     const insert: AnyMock = vi.fn(() => ({ values }));
@@ -44,6 +45,7 @@ export function createMockDb() {
             where,
             insert,
             values,
+            onConflictDoUpdate,
             update,
             set,
             delete: deleteFn,

--- a/packages/db/src/repositories/mocks.ts
+++ b/packages/db/src/repositories/mocks.ts
@@ -4,10 +4,20 @@ import type { Connection } from '../connection';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyMock = Mock<any>;
 
+interface QueryMock {
+    findFirst: AnyMock;
+    findMany: AnyMock;
+}
+
+function createQueryMock(): QueryMock {
+    return { findFirst: vi.fn(), findMany: vi.fn() };
+}
+
 export function createMockDb() {
-    const findFirst: AnyMock = vi.fn();
-    const findMany: AnyMock = vi.fn();
-    const returning: AnyMock = vi.fn();
+    // Default to [] so destructuring `const [row] = await ...returning()` doesn't
+    // explode in tests that don't care about the returned row. Tests that need a
+    // specific value override with `mocks.returning.mockResolvedValue([row])`.
+    const returning: AnyMock = vi.fn().mockResolvedValue([]);
     const groupBy: AnyMock = vi.fn();
     const where: AnyMock = vi.fn(() => ({ returning, groupBy }));
     const set: AnyMock = vi.fn(() => ({ where }));
@@ -19,13 +29,19 @@ export function createMockDb() {
     const update: AnyMock = vi.fn(() => ({ set }));
     const deleteFn: AnyMock = vi.fn(() => ({ where }));
 
+    const files = createQueryMock();
+    const backgroundJobs = createQueryMock();
+    const retrievals = createQueryMock();
+    const subscriptions = createQueryMock();
+    const webhookEvents = createQueryMock();
+
     const db = {
         query: {
-            files: { findFirst, findMany },
-            backgroundJobs: { findFirst, findMany },
-            retrievals: { findFirst, findMany },
-            subscriptions: { findFirst, findMany },
-            webhookEvents: { findFirst, findMany },
+            files,
+            backgroundJobs,
+            retrievals,
+            subscriptions,
+            webhookEvents,
         },
         select,
         insert,
@@ -38,8 +54,7 @@ export function createMockDb() {
     return {
         db,
         mocks: {
-            findFirst,
-            findMany,
+            // Insert/update/delete pipeline mocks
             select,
             from,
             where,
@@ -51,6 +66,12 @@ export function createMockDb() {
             delete: deleteFn,
             returning,
             groupBy,
+            // Per-table query mocks (db.query.<table>.findFirst/findMany)
+            files,
+            backgroundJobs,
+            retrievals,
+            subscriptions,
+            webhookEvents,
         },
     };
 }

--- a/packages/db/src/repositories/mocks.ts
+++ b/packages/db/src/repositories/mocks.ts
@@ -23,6 +23,7 @@ export function createMockDb() {
             files: { findFirst, findMany },
             backgroundJobs: { findFirst, findMany },
             retrievals: { findFirst, findMany },
+            subscriptions: { findFirst, findMany },
             webhookEvents: { findFirst, findMany },
         },
         select,

--- a/packages/db/src/repositories/retrievals.test.ts
+++ b/packages/db/src/repositories/retrievals.test.ts
@@ -21,16 +21,16 @@ describe('retrievals repository', () => {
     describe('findByFileId', () => {
         it('returns active retrieval when found', async () => {
             const retrieval = createRetrievalFixture();
-            mocks.findFirst.mockResolvedValue(retrieval);
+            mocks.retrievals.findFirst.mockResolvedValue(retrieval);
 
             const result = await repo.findByFileId(TEST_FILE_ID);
 
             expect(result).toEqual(retrieval);
-            expect(mocks.findFirst).toHaveBeenCalledOnce();
+            expect(mocks.retrievals.findFirst).toHaveBeenCalledOnce();
         });
 
         it('returns undefined when no active retrieval exists', async () => {
-            mocks.findFirst.mockResolvedValue(undefined);
+            mocks.retrievals.findFirst.mockResolvedValue(undefined);
 
             const result = await repo.findByFileId('nonexistent');
 
@@ -44,19 +44,19 @@ describe('retrievals repository', () => {
                 createRetrievalFixture({ id: 'r1', fileId: 'file1' }),
                 createRetrievalFixture({ id: 'r2', fileId: 'file2' }),
             ];
-            mocks.findMany.mockResolvedValue(retrievals);
+            mocks.retrievals.findMany.mockResolvedValue(retrievals);
 
             const result = await repo.findByFileIds(['file1', 'file2']);
 
             expect(result).toEqual(retrievals);
-            expect(mocks.findMany).toHaveBeenCalledOnce();
+            expect(mocks.retrievals.findMany).toHaveBeenCalledOnce();
         });
 
         it('returns empty array when given empty ids', async () => {
             const result = await repo.findByFileIds([]);
 
             expect(result).toEqual([]);
-            expect(mocks.findMany).not.toHaveBeenCalled();
+            expect(mocks.retrievals.findMany).not.toHaveBeenCalled();
         });
     });
 
@@ -66,16 +66,16 @@ describe('retrievals repository', () => {
                 createRetrievalFixture({ id: 'r1' }),
                 createRetrievalFixture({ id: 'r2', status: 'ready' }),
             ];
-            mocks.findMany.mockResolvedValue(retrievals);
+            mocks.retrievals.findMany.mockResolvedValue(retrievals);
 
             const result = await repo.findByUser(TEST_USER_ID);
 
             expect(result).toEqual(retrievals);
-            expect(mocks.findMany).toHaveBeenCalledOnce();
+            expect(mocks.retrievals.findMany).toHaveBeenCalledOnce();
         });
 
         it('returns empty array when user has no retrievals', async () => {
-            mocks.findMany.mockResolvedValue([]);
+            mocks.retrievals.findMany.mockResolvedValue([]);
 
             const result = await repo.findByUser(TEST_USER_ID);
 

--- a/packages/db/src/repositories/subscriptions.ts
+++ b/packages/db/src/repositories/subscriptions.ts
@@ -3,23 +3,66 @@ import type { DB } from '../connection';
 import * as schema from '../schema';
 import { createRepository } from './create';
 
-export type SubscriptionPlan = Pick<
-    typeof schema.subscriptions.$inferSelect,
-    'storageLimit' | 'planTier'
->;
+export type Subscription = typeof schema.subscriptions.$inferSelect;
+export type NewSubscription = typeof schema.subscriptions.$inferInsert;
+
+export type SubscriptionPlan = Pick<Subscription, 'storageLimit' | 'planTier'>;
 
 function findByUserId(
     db: DB,
     userId: string
-): Promise<SubscriptionPlan | undefined> {
+): Promise<Subscription | undefined> {
     return db.query.subscriptions.findFirst({
         where: eq(schema.subscriptions.userId, userId),
-        columns: { storageLimit: true, planTier: true },
     });
+}
+
+function findByStripeCustomerId(
+    db: DB,
+    customerId: string
+): Promise<Subscription | undefined> {
+    return db.query.subscriptions.findFirst({
+        where: eq(schema.subscriptions.stripeCustomerId, customerId),
+    });
+}
+
+async function insert(db: DB, data: NewSubscription): Promise<Subscription> {
+    const [sub] = await db
+        .insert(schema.subscriptions)
+        .values(data)
+        .returning();
+    return sub;
+}
+
+async function upsertFromWebhook(
+    db: DB,
+    data: NewSubscription
+): Promise<Subscription> {
+    const [sub] = await db
+        .insert(schema.subscriptions)
+        .values(data)
+        .onConflictDoUpdate({
+            target: schema.subscriptions.stripeCustomerId,
+            set: {
+                stripeSubscriptionId: data.stripeSubscriptionId,
+                planTier: data.planTier,
+                status: data.status,
+                storageLimit: data.storageLimit,
+                currentPeriodStart: data.currentPeriodStart,
+                currentPeriodEnd: data.currentPeriodEnd,
+                cancelAtPeriodEnd: data.cancelAtPeriodEnd,
+                trialEnd: data.trialEnd,
+            },
+        })
+        .returning();
+    return sub;
 }
 
 export const createSubscriptionRepo = createRepository({
     findByUserId,
+    findByStripeCustomerId,
+    insert,
+    upsertFromWebhook,
 });
 
 export type SubscriptionRepo = ReturnType<typeof createSubscriptionRepo>;

--- a/packages/db/src/seed/constants.ts
+++ b/packages/db/src/seed/constants.ts
@@ -1,5 +1,5 @@
 import type { Connection, DB } from '../connection';
-import type { PlanTier } from './types';
+export { PLAN_LIMITS, type PlanTier } from '../plans';
 
 // Seed ID prefixes
 // All seeded entities use these prefixes so cleanup can target them
@@ -13,15 +13,6 @@ export const SEED_RETRIEVAL_PREFIX = 'seed_ret_';
 export const SEED_STORAGE_PREFIX = 'seed_sto_';
 
 export const SEED_EMAIL_DOMAIN = 'seed.nexus.local';
-
-// Plan storage limits
-
-export const PLAN_LIMITS: Record<PlanTier, number> = {
-    starter: 10 * 1024 ** 3, //    10 GB
-    pro: 100 * 1024 ** 3, //   100 GB
-    max: 1024 * 1024 ** 3, // 1,024 GB (1 TB)
-    enterprise: 10 * 1024 ** 4, //  10 TB
-};
 
 // Realistic file data pools
 // Each entry: [filename, mimeType, minBytes, maxBytes]


### PR DESCRIPTION
## Summary

Implements Stripe integration for subscription management: webhook handling for subscription lifecycle events, checkout session creation for upgrades, customer portal access, and trial provisioning at signup.

Closes #21

## Changes

- **Subscription repository** (`packages/db/src/repositories/subscriptions.ts`): Expanded with `findByStripeCustomerId`, `insert`, and `upsertFromWebhook` methods
- **Shared plan constants** (`packages/db/src/plans.ts`): Extracted `PLAN_LIMITS` and `PlanTier` to a single source of truth, imported by both seed and web app
- **Cached price resolver** (`apps/web/lib/stripe/prices.ts`): Metadata-based price lookup (no hardcoded Stripe Price IDs) with process-lifetime caching
- **BetterAuth signup hook** (`apps/web/lib/auth/server.ts`): Creates Stripe Customer + trialing subscription on user registration
- **Stripe webhook endpoint** (`apps/web/app/api/webhooks/stripe/route.ts`): Handles 5 event types (`checkout.session.completed`, `customer.subscription.created/updated/deleted`, `invoice.payment_failed`) with idempotency via `webhookEvents` table
- **Subscription service** (`apps/web/server/services/subscriptions.ts`): `getCurrentSubscription`, `createCheckoutSession`, `createPortalSession`, `provisionTrialSubscription`
- **tRPC router** (`apps/web/server/trpc/routers/subscriptions.ts`): `subscriptions.current`, `subscriptions.createCheckoutSession`, `subscriptions.createPortalSession`
- **Fix**: Removed invalid `'use server'` directive from `lib/stripe/client.ts` (exported an object, not async functions)

## Test Plan

- [ ] Sign up a new user → verify Stripe Customer created + subscription record with `status: trialing`, `planTier: starter`
- [ ] Call `subscriptions.current` via tRPC → returns subscription data
- [ ] Call `subscriptions.createCheckoutSession` with `{ tier: 'pro', interval: 'month' }` → returns Stripe checkout URL
- [ ] Call `subscriptions.createPortalSession` → returns Stripe portal URL
- [ ] Send test webhook events via Stripe CLI (`stripe trigger checkout.session.completed`) → verify subscription record updated
- [ ] Send duplicate webhook event → verify idempotency (returns `{ received: true, duplicate: true }`)
- [ ] Send `invoice.payment_failed` event → verify subscription marked `past_due`
- [ ] Verify `pnpm check` passes (lint + build + test)