### PR TITLE
perf: lazy subscription getter on tRPC context (#205)

### DIFF
--- a/apps/web/lib/async/lazy.ts
+++ b/apps/web/lib/async/lazy.ts
@@ -1,0 +1,11 @@
+/**
+ * Memoizes `factory` at the promise level so concurrent callers share
+ * the in-flight promise — the factory fires at most once per lifetime.
+ */
+export function lazyAsync<T>(factory: () => Promise<T>): () => Promise<T> {
+    let promise: Promise<T> | null = null;
+    return () => {
+        if (!promise) promise = factory();
+        return promise;
+    };
+}

--- a/apps/web/server/services/constants.ts
+++ b/apps/web/server/services/constants.ts
@@ -1,5 +1,23 @@
-export { PLAN_LIMITS, type PlanTier } from '@nexus/db/plans';
+import { PLAN_LIMITS, type PlanTier } from '@nexus/db/plans';
+import type { Subscription } from '@nexus/db/repo/subscriptions';
+
+export { PLAN_LIMITS, type PlanTier };
 export type { CheckoutTier, BillingInterval } from '@/lib/stripe/types';
 
 /** Trial duration in days. */
 export const TRIAL_DURATION_DAYS = 30;
+
+/**
+ * Resolves the effective plan (limit + tier) for a user, falling back to
+ * starter when no subscription exists. Centralizes the starter-default so
+ * callers don't duplicate the null-coalesce across services.
+ */
+export function resolvePlan(sub: Subscription | undefined): {
+    quotaBytes: number;
+    planTier: PlanTier;
+} {
+    return {
+        quotaBytes: sub?.storageLimit ?? PLAN_LIMITS.starter,
+        planTier: sub?.planTier ?? 'starter',
+    };
+}

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -39,11 +39,16 @@ describe('files service', () => {
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
-            const result = await fileService.initiateUpload(db, TEST_USER_ID, {
-                name: 'test.pdf',
-                sizeBytes: 1024,
-                mimeType: 'application/pdf',
-            });
+            const result = await fileService.initiateUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'test.pdf',
+                    sizeBytes: 1024,
+                    mimeType: 'application/pdf',
+                },
+                undefined
+            );
 
             expect(result).toHaveProperty('fileId');
             expect(result).toHaveProperty('uploadUrl');
@@ -60,10 +65,15 @@ describe('files service', () => {
             mocks.where.mockResolvedValue([{ total: tenGBMinus1 }]);
 
             await expect(
-                fileService.initiateUpload(db, TEST_USER_ID, {
-                    name: 'test.pdf',
-                    sizeBytes: 2, // This would exceed quota
-                })
+                fileService.initiateUpload(
+                    db,
+                    TEST_USER_ID,
+                    {
+                        name: 'test.pdf',
+                        sizeBytes: 2, // This would exceed quota
+                    },
+                    undefined
+                )
             ).rejects.toThrow(QuotaExceededError);
         });
 
@@ -76,10 +86,15 @@ describe('files service', () => {
 
             // 1GB file should fit exactly at 10GB limit
             const oneGB = 1 * 1024 * 1024 * 1024;
-            const result = await fileService.initiateUpload(db, TEST_USER_ID, {
-                name: 'test.pdf',
-                sizeBytes: oneGB,
-            });
+            const result = await fileService.initiateUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'test.pdf',
+                    sizeBytes: oneGB,
+                },
+                undefined
+            );
 
             expect(result).toHaveProperty('fileId');
         });
@@ -89,11 +104,16 @@ describe('files service', () => {
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
-            await fileService.initiateUpload(db, TEST_USER_ID, {
-                name: 'test.pdf',
-                sizeBytes: 1024,
-                mimeType: 'application/pdf',
-            });
+            await fileService.initiateUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'test.pdf',
+                    sizeBytes: 1024,
+                    mimeType: 'application/pdf',
+                },
+                undefined
+            );
 
             expect(mocks.insert).toHaveBeenCalledOnce();
             expect(mocks.values).toHaveBeenCalledWith(
@@ -112,10 +132,15 @@ describe('files service', () => {
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
-            await fileService.initiateUpload(db, TEST_USER_ID, {
-                name: 'document.pdf',
-                sizeBytes: 1024,
-            });
+            await fileService.initiateUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'document.pdf',
+                    sizeBytes: 1024,
+                },
+                undefined
+            );
 
             // S3 key format: {userId}/{fileId}/{filename}
             expect(mocks.values).toHaveBeenCalledWith(
@@ -136,117 +161,135 @@ describe('files service', () => {
 
         it('uses subscription storageLimit instead of starter default', async () => {
             // Pro subscription with 100 GB limit — user is already at 50 GB
-            mocks.subscriptions.findFirst.mockResolvedValue(
-                createSubscriptionFixture({
-                    planTier: 'pro',
-                    status: 'active',
-                    storageLimit: hundredGB,
-                })
-            );
+            const sub = createSubscriptionFixture({
+                planTier: 'pro',
+                status: 'active',
+                storageLimit: hundredGB,
+            });
             mocks.where.mockResolvedValue([{ total: 50 * oneGB }]);
             mocks.returning.mockResolvedValue([createFileFixture()]);
 
             // 40 GB upload would exceed starter (10 GB) but fits in pro (100 GB)
-            const result = await fileService.initiateUpload(db, TEST_USER_ID, {
-                name: 'big.bin',
-                sizeBytes: 40 * oneGB,
-            });
+            const result = await fileService.initiateUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'big.bin',
+                    sizeBytes: 40 * oneGB,
+                },
+                sub
+            );
 
             expect(result).toHaveProperty('fileId');
         });
 
         it('throws QuotaExceededError when over subscription limit', async () => {
-            mocks.subscriptions.findFirst.mockResolvedValue(
-                createSubscriptionFixture({
-                    planTier: 'pro',
-                    status: 'active',
-                    storageLimit: hundredGB,
-                })
-            );
+            const sub = createSubscriptionFixture({
+                planTier: 'pro',
+                status: 'active',
+                storageLimit: hundredGB,
+            });
             // At 99 GB, a 2 GB upload would exceed the 100 GB limit
             mocks.where.mockResolvedValue([{ total: 99 * oneGB }]);
 
             await expect(
-                fileService.initiateUpload(db, TEST_USER_ID, {
-                    name: 'overflow.bin',
-                    sizeBytes: 2 * oneGB,
-                })
+                fileService.initiateUpload(
+                    db,
+                    TEST_USER_ID,
+                    {
+                        name: 'overflow.bin',
+                        sizeBytes: 2 * oneGB,
+                    },
+                    sub
+                )
             ).rejects.toThrow(QuotaExceededError);
         });
 
         it('allows upload during active trial within quota', async () => {
             const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000); // +7 days
-            mocks.subscriptions.findFirst.mockResolvedValue(
-                createSubscriptionFixture({
-                    status: 'trialing',
-                    trialEnd: future,
-                })
-            );
+            const sub = createSubscriptionFixture({
+                status: 'trialing',
+                trialEnd: future,
+            });
             mocks.where.mockResolvedValue([{ total: 0 }]);
             mocks.returning.mockResolvedValue([createFileFixture()]);
 
-            const result = await fileService.initiateUpload(db, TEST_USER_ID, {
-                name: 'trial.pdf',
-                sizeBytes: 1024,
-            });
+            const result = await fileService.initiateUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'trial.pdf',
+                    sizeBytes: 1024,
+                },
+                sub
+            );
 
             expect(result).toHaveProperty('fileId');
         });
 
         it('throws TrialExpiredError when trial has ended', async () => {
             const past = new Date(Date.now() - 24 * 60 * 60 * 1000); // -1 day
-            mocks.subscriptions.findFirst.mockResolvedValue(
-                createSubscriptionFixture({
-                    status: 'trialing',
-                    trialEnd: past,
-                })
-            );
+            const sub = createSubscriptionFixture({
+                status: 'trialing',
+                trialEnd: past,
+            });
             mocks.where.mockResolvedValue([{ total: 0 }]);
 
             await expect(
-                fileService.initiateUpload(db, TEST_USER_ID, {
-                    name: 'expired.pdf',
-                    sizeBytes: 1024,
-                })
+                fileService.initiateUpload(
+                    db,
+                    TEST_USER_ID,
+                    {
+                        name: 'expired.pdf',
+                        sizeBytes: 1024,
+                    },
+                    sub
+                )
             ).rejects.toThrow(TrialExpiredError);
         });
 
         it('prefers TrialExpiredError over QuotaExceededError when both apply', async () => {
             // Expired trial AND over quota — trial check must run first
             const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
-            mocks.subscriptions.findFirst.mockResolvedValue(
-                createSubscriptionFixture({
-                    status: 'trialing',
-                    trialEnd: past,
-                    storageLimit: oneGB,
-                })
-            );
+            const sub = createSubscriptionFixture({
+                status: 'trialing',
+                trialEnd: past,
+                storageLimit: oneGB,
+            });
             mocks.where.mockResolvedValue([{ total: oneGB }]); // already at quota
 
             await expect(
-                fileService.initiateUpload(db, TEST_USER_ID, {
-                    name: 'double-fail.pdf',
-                    sizeBytes: 1024,
-                })
+                fileService.initiateUpload(
+                    db,
+                    TEST_USER_ID,
+                    {
+                        name: 'double-fail.pdf',
+                        sizeBytes: 1024,
+                    },
+                    sub
+                )
             ).rejects.toThrow(TrialExpiredError);
         });
 
         it('ignores trialEnd when status is not trialing', async () => {
             // Active sub with a stale trialEnd in the past — should not throw
             const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
-            mocks.subscriptions.findFirst.mockResolvedValue(
-                createSubscriptionFixture({
-                    status: 'active',
-                    trialEnd: past,
-                })
-            );
+            const sub = createSubscriptionFixture({
+                status: 'active',
+                trialEnd: past,
+            });
             mocks.where.mockResolvedValue([{ total: 0 }]);
             mocks.returning.mockResolvedValue([createFileFixture()]);
 
-            const result = await fileService.initiateUpload(db, TEST_USER_ID, {
-                name: 'active.pdf',
-                sizeBytes: 1024,
-            });
+            const result = await fileService.initiateUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'active.pdf',
+                    sizeBytes: 1024,
+                },
+                sub
+            );
 
             expect(result).toHaveProperty('fileId');
         });
@@ -418,7 +461,8 @@ describe('files service', () => {
                     name: 'large-file.zip',
                     sizeBytes: 50 * 1024 * 1024, // 50MB = 5 parts
                     mimeType: 'application/zip',
-                }
+                },
+                undefined
             );
 
             expect(result).toHaveProperty('fileId');
@@ -433,10 +477,15 @@ describe('files service', () => {
             mocks.where.mockResolvedValue([{ total: tenGBMinus1 }]);
 
             await expect(
-                fileService.initiateMultipartUpload(db, TEST_USER_ID, {
-                    name: 'large-file.zip',
-                    sizeBytes: 2,
-                })
+                fileService.initiateMultipartUpload(
+                    db,
+                    TEST_USER_ID,
+                    {
+                        name: 'large-file.zip',
+                        sizeBytes: 2,
+                    },
+                    undefined
+                )
             ).rejects.toThrow(QuotaExceededError);
         });
 
@@ -445,10 +494,15 @@ describe('files service', () => {
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
-            await fileService.initiateMultipartUpload(db, TEST_USER_ID, {
-                name: 'large-file.zip',
-                sizeBytes: 50 * 1024 * 1024,
-            });
+            await fileService.initiateMultipartUpload(
+                db,
+                TEST_USER_ID,
+                {
+                    name: 'large-file.zip',
+                    sizeBytes: 50 * 1024 * 1024,
+                },
+                undefined
+            );
 
             expect(mocks.insert).toHaveBeenCalledOnce();
             expect(mocks.values).toHaveBeenCalledWith(
@@ -471,7 +525,8 @@ describe('files service', () => {
                 {
                     name: 'exact.bin',
                     sizeBytes: 20 * 1024 * 1024, // exactly 2 chunks
-                }
+                },
+                undefined
             );
 
             expect(result.partUrls).toHaveLength(2);

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -1,6 +1,6 @@
 import type { DB } from '@nexus/db';
 import { createFileRepo, type File } from '@nexus/db/repo/files';
-import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
+import type { Subscription } from '@nexus/db/repo/subscriptions';
 import {
     NotFoundError,
     QuotaExceededError,
@@ -8,7 +8,7 @@ import {
     TrialExpiredError,
 } from '@/server/errors';
 import { s3 } from '@/lib/storage';
-import { PLAN_LIMITS } from './constants';
+import { resolvePlan } from './constants';
 
 const PRESIGNED_URL_EXPIRY_SECONDS = 900; // 15 minutes
 const MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024; // 10MB
@@ -51,15 +51,11 @@ interface ConfirmUploadResult {
 async function assertWithinQuota(
     db: DB,
     userId: string,
-    additionalBytes: number
+    additionalBytes: number,
+    sub: Subscription | undefined
 ): Promise<void> {
     const fileRepo = createFileRepo(db);
-    const subscriptionRepo = createSubscriptionRepo(db);
-
-    const [currentUsage, sub] = await Promise.all([
-        fileRepo.sumStorageByUser(userId),
-        subscriptionRepo.findByUserId(userId),
-    ]);
+    const currentUsage = await fileRepo.sumStorageByUser(userId);
 
     if (
         sub?.status === 'trialing' &&
@@ -69,7 +65,7 @@ async function assertWithinQuota(
         throw new TrialExpiredError();
     }
 
-    const quotaBytes = sub?.storageLimit ?? PLAN_LIMITS.starter;
+    const { quotaBytes } = resolvePlan(sub);
     if (currentUsage + additionalBytes > quotaBytes) {
         throw new QuotaExceededError('Storage quota exceeded');
     }
@@ -78,9 +74,10 @@ async function assertWithinQuota(
 async function initiateUpload(
     db: DB,
     userId: string,
-    input: UploadInput
+    input: UploadInput,
+    sub: Subscription | undefined
 ): Promise<InitiateUploadResult> {
-    await assertWithinQuota(db, userId, input.sizeBytes);
+    await assertWithinQuota(db, userId, input.sizeBytes, sub);
 
     const fileRepo = createFileRepo(db);
     const fileId = crypto.randomUUID();
@@ -138,9 +135,10 @@ async function confirmUpload(
 async function initiateMultipartUpload(
     db: DB,
     userId: string,
-    input: UploadInput
+    input: UploadInput,
+    sub: Subscription | undefined
 ): Promise<InitiateMultipartResult> {
-    await assertWithinQuota(db, userId, input.sizeBytes);
+    await assertWithinQuota(db, userId, input.sizeBytes, sub);
 
     const fileRepo = createFileRepo(db);
     const fileId = crypto.randomUUID();

--- a/apps/web/server/services/storage.ts
+++ b/apps/web/server/services/storage.ts
@@ -4,8 +4,8 @@ import {
     type StorageByCategory,
     type DailyUploadVolume,
 } from '@nexus/db/repo/files';
-import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
-import { PLAN_LIMITS, type PlanTier } from './constants';
+import type { Subscription } from '@nexus/db/repo/subscriptions';
+import { resolvePlan, type PlanTier } from './constants';
 
 interface StorageUsage {
     usedBytes: number;
@@ -15,17 +15,19 @@ interface StorageUsage {
     planTier: PlanTier;
 }
 
-async function getUsage(db: DB, userId: string): Promise<StorageUsage> {
+async function getUsage(
+    db: DB,
+    userId: string,
+    sub: Subscription | undefined
+): Promise<StorageUsage> {
     const fileRepo = createFileRepo(db);
-    const subscriptionRepo = createSubscriptionRepo(db);
 
-    const [usedBytes, fileCount, sub] = await Promise.all([
+    const [usedBytes, fileCount] = await Promise.all([
         fileRepo.sumStorageByUser(userId),
         fileRepo.countByUser(userId),
-        subscriptionRepo.findByUserId(userId),
     ]);
 
-    const quotaBytes = sub?.storageLimit ?? PLAN_LIMITS.starter;
+    const { quotaBytes, planTier } = resolvePlan(sub);
     const percentage = quotaBytes > 0 ? (usedBytes / quotaBytes) * 100 : 0;
 
     return {
@@ -33,7 +35,7 @@ async function getUsage(db: DB, userId: string): Promise<StorageUsage> {
         quotaBytes,
         percentage: Math.min(percentage, 100),
         fileCount,
-        planTier: sub?.planTier ?? 'starter',
+        planTier,
     };
 }
 

--- a/apps/web/server/trpc/init.ts
+++ b/apps/web/server/trpc/init.ts
@@ -17,6 +17,14 @@ export async function createTRPCContext() {
     return {
         db,
         session,
+        // Request-scoped: one DB fetch per HTTP request, shared across every
+        // procedure in a tRPC batch. Returns undefined for unauthenticated
+        // callers; protected services receive it as-is.
+        getSubscription: lazyAsync(() =>
+            session
+                ? createSubscriptionRepo(db).findByUserId(session.user.id)
+                : Promise.resolve(undefined)
+        ),
     };
 }
 
@@ -87,17 +95,10 @@ export const protectedProcedure = baseProcedure.use(({ ctx, next }) => {
         throw new TRPCError({ code: 'UNAUTHORIZED' });
     }
 
-    const userId = ctx.session.user.id;
-
     return next({
         ctx: {
             ...ctx,
             session: ctx.session,
-            // Bulk uploads call services that each need the subscription;
-            // this lazy getter ensures one DB query per request, not per file.
-            getSubscription: lazyAsync(() =>
-                createSubscriptionRepo(ctx.db).findByUserId(userId)
-            ),
         },
     });
 });

--- a/apps/web/server/trpc/init.ts
+++ b/apps/web/server/trpc/init.ts
@@ -1,6 +1,8 @@
 import { auth } from '@/lib/auth/server';
+import { lazyAsync } from '@/lib/async/lazy';
 import { db } from '@/server/db';
 import { isDomainError } from '@/server/errors';
+import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
 import { initTRPC, TRPCError } from '@trpc/server';
 import { headers } from 'next/headers';
 import superjson from 'superjson';
@@ -85,10 +87,17 @@ export const protectedProcedure = baseProcedure.use(({ ctx, next }) => {
         throw new TRPCError({ code: 'UNAUTHORIZED' });
     }
 
+    const userId = ctx.session.user.id;
+
     return next({
         ctx: {
             ...ctx,
             session: ctx.session,
+            // Bulk uploads call services that each need the subscription;
+            // this lazy getter ensures one DB query per request, not per file.
+            getSubscription: lazyAsync(() =>
+                createSubscriptionRepo(ctx.db).findByUserId(userId)
+            ),
         },
     });
 });

--- a/apps/web/server/trpc/init.ts
+++ b/apps/web/server/trpc/init.ts
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth/server';
 import { lazyAsync } from '@/lib/async/lazy';
 import { db } from '@/server/db';
+import type { Connection } from '@nexus/db';
 import { isDomainError } from '@/server/errors';
 import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
 import { initTRPC, TRPCError } from '@trpc/server';
@@ -9,23 +10,35 @@ import superjson from 'superjson';
 import { domainErrorFormatter } from './error-formatter';
 import { logRequest, type LoggingContext } from './middleware/logging';
 
-export async function createTRPCContext() {
-    const session = await auth.api.getSession({
-        headers: await headers(),
-    });
+type Session = Awaited<ReturnType<typeof auth.api.getSession>>;
 
+/**
+ * Pure context builder — assembles the tRPC ctx from its inputs. Kept
+ * separate from `createTRPCContext` so tests can build an equivalent ctx
+ * without running the Next-specific session fetch. New ctx fields added
+ * here flow into both production and test callers automatically.
+ */
+export function buildContext(deps: { db: Connection; session: Session }) {
     return {
-        db,
-        session,
+        ...deps,
         // Request-scoped: one DB fetch per HTTP request, shared across every
         // procedure in a tRPC batch. Returns undefined for unauthenticated
         // callers; protected services receive it as-is.
         getSubscription: lazyAsync(() =>
-            session
-                ? createSubscriptionRepo(db).findByUserId(session.user.id)
+            deps.session
+                ? createSubscriptionRepo(deps.db).findByUserId(
+                      deps.session.user.id
+                  )
                 : Promise.resolve(undefined)
         ),
     };
+}
+
+export async function createTRPCContext() {
+    const session = await auth.api.getSession({
+        headers: await headers(),
+    });
+    return buildContext({ db, session });
 }
 
 export type Context = Awaited<ReturnType<typeof createTRPCContext>>;

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -55,11 +55,12 @@ export const filesRouter = router({
 
     upload: protectedProcedure
         .input(uploadInputSchema)
-        .mutation(({ ctx, input }) => {
+        .mutation(async ({ ctx, input }) => {
             return fileService.initiateUpload(
                 ctx.db,
                 ctx.session.user.id,
-                input
+                input,
+                await ctx.getSubscription()
             );
         }),
 
@@ -138,11 +139,12 @@ export const filesRouter = router({
     multipart: router({
         init: protectedProcedure
             .input(uploadInputSchema)
-            .mutation(({ ctx, input }) => {
+            .mutation(async ({ ctx, input }) => {
                 return fileService.initiateMultipartUpload(
                     ctx.db,
                     ctx.session.user.id,
-                    input
+                    input,
+                    await ctx.getSubscription()
                 );
             }),
 

--- a/apps/web/server/trpc/routers/storage.ts
+++ b/apps/web/server/trpc/routers/storage.ts
@@ -2,8 +2,12 @@ import { storageService } from '@/server/services/storage';
 import { protectedProcedure, router } from '../init';
 
 export const storageRouter = router({
-    getUsage: protectedProcedure.query(({ ctx }) => {
-        return storageService.getUsage(ctx.db, ctx.session.user.id);
+    getUsage: protectedProcedure.query(async ({ ctx }) => {
+        return storageService.getUsage(
+            ctx.db,
+            ctx.session.user.id,
+            await ctx.getSubscription()
+        );
     }),
 
     getByType: protectedProcedure.query(({ ctx }) => {

--- a/apps/web/server/trpc/test-utils.ts
+++ b/apps/web/server/trpc/test-utils.ts
@@ -5,9 +5,7 @@ import {
     createUserFixture,
     type User,
 } from '@nexus/db/testing';
-import { lazyAsync } from '@/lib/async/lazy';
-import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
-import type { Context, LoggedContext } from './init';
+import { buildContext, type LoggedContext } from './init';
 
 /**
  * Options for creating a mock tRPC context
@@ -125,18 +123,8 @@ export function createMockContext(
         log,
     };
 
-    const baseContext: Context = {
-        db,
-        session,
-        getSubscription: lazyAsync(() =>
-            session
-                ? createSubscriptionRepo(db).findByUserId(session.user.id)
-                : Promise.resolve(undefined)
-        ),
-    };
-
     const ctx: LoggedContext = {
-        ...baseContext,
+        ...buildContext({ db, session }),
         ...loggingContext,
     };
 

--- a/apps/web/server/trpc/test-utils.ts
+++ b/apps/web/server/trpc/test-utils.ts
@@ -5,6 +5,8 @@ import {
     createUserFixture,
     type User,
 } from '@nexus/db/testing';
+import { lazyAsync } from '@/lib/async/lazy';
+import { createSubscriptionRepo } from '@nexus/db/repo/subscriptions';
 import type { Context, LoggedContext } from './init';
 
 /**
@@ -126,6 +128,11 @@ export function createMockContext(
     const baseContext: Context = {
         db,
         session,
+        getSubscription: lazyAsync(() =>
+            session
+                ? createSubscriptionRepo(db).findByUserId(session.user.id)
+                : Promise.resolve(undefined)
+        ),
     };
 
     const ctx: LoggedContext = {


### PR DESCRIPTION
## Summary

Adds a request-scoped `ctx.getSubscription()` on the tRPC base context. The lazy getter memoizes the subscription fetch at the promise level and is **shared across every procedure in a tRPC batched HTTP request** — so a batched dashboard call (e.g., `storage.getUsage` + any other sub-dependent procedure) incurs one `subscriptions` SELECT per HTTP request instead of N.

Closes #205

## Changes

- `apps/web/lib/async/lazy.ts` — new `lazyAsync<T>` helper (promise-level memoization so concurrent callers share the in-flight promise).
- `apps/web/server/trpc/init.ts` — `getSubscription` lives on the base `createTRPCContext`, not inside `protectedProcedure` middleware. Middleware-scoped would re-create the lazy per procedure invocation and lose cross-batch dedup; hoisting to base ctx keeps it request-scoped. Returns `undefined` for unauthenticated callers.
- `apps/web/server/services/files.ts` — `assertWithinQuota`, `initiateUpload`, `initiateMultipartUpload` accept `sub: Subscription | undefined` instead of fetching internally.
- `apps/web/server/services/storage.ts` — `getUsage` accepts `sub` parameter.
- `apps/web/server/services/constants.ts` — new `resolvePlan(sub)` helper centralizes the `?? PLAN_LIMITS.starter` / `?? 'starter'` fallback previously duplicated across services.
- Routers (`routers/files.ts`, `routers/storage.ts`) pass `await ctx.getSubscription()` to the services.
- `apps/web/server/trpc/test-utils.ts` — `createMockContext` now wires the same lazy getter so existing router/service tests keep working.

## Test Plan

- [x] `pnpm check` passes (lint + build + test)
- [x] Existing service tests updated to pass subscription fixture directly; all green
- [ ] Optional: enable `postgres({ debug: ... })` in dev and trigger a dashboard page load that batches multiple protected procedures — confirm only one `SELECT ... FROM subscriptions WHERE user_id = ...` fires per HTTP batch