### PR TITLE
feat: server-driven pagination, search, sort for FileBrowser (#39)

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/admin/jobs/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/jobs/page.tsx
@@ -16,8 +16,9 @@ import { cn } from '@/lib/cn';
 import { useTRPC } from '@/lib/trpc/client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
-import { ChevronLeft, ChevronRight, Loader2, RotateCw } from 'lucide-react';
+import { Loader2, RotateCw } from 'lucide-react';
 import type { Job } from '@nexus/db/repo/jobs';
+import { TablePagination } from '@/components/ui/table-pagination';
 
 type JobStatus = Job['status'];
 
@@ -67,8 +68,6 @@ export default function AdminJobsPage() {
         queryClient.invalidateQueries({ queryKey: countsOptions.queryKey });
     }
 
-    const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
-
     return (
         <div className="mx-auto max-w-6xl space-y-6">
             <div>
@@ -107,10 +106,7 @@ export default function AdminJobsPage() {
                     className="ml-auto"
                 >
                     <RotateCw
-                        className={cn(
-                            'h-4 w-4',
-                            isRefreshing && 'animate-spin'
-                        )}
+                        className={cn('size-4', isRefreshing && 'animate-spin')}
                     />
                 </Button>
             </div>
@@ -192,36 +188,12 @@ export default function AdminJobsPage() {
                 )}
             </Card>
 
-            {totalPages > 1 && (
-                <div className="flex items-center justify-between">
-                    <p className="text-sm text-muted-foreground">
-                        Showing {page * PAGE_SIZE + 1}–
-                        {Math.min((page + 1) * PAGE_SIZE, data?.total ?? 0)} of{' '}
-                        {data?.total ?? 0}
-                    </p>
-                    <div className="flex items-center gap-2">
-                        <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={() => setPage((p) => p - 1)}
-                            disabled={page === 0}
-                        >
-                            <ChevronLeft className="h-4 w-4" />
-                        </Button>
-                        <span className="text-sm text-muted-foreground">
-                            Page {page + 1} of {totalPages}
-                        </span>
-                        <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={() => setPage((p) => p + 1)}
-                            disabled={!data?.hasMore}
-                        >
-                            <ChevronRight className="h-4 w-4" />
-                        </Button>
-                    </div>
-                </div>
-            )}
+            <TablePagination
+                page={page}
+                pageSize={PAGE_SIZE}
+                total={data?.total ?? 0}
+                onPageChange={setPage}
+            />
         </div>
     );
 }

--- a/apps/web/components/dashboard/file-browser.tsx
+++ b/apps/web/components/dashboard/file-browser.tsx
@@ -276,10 +276,16 @@ export function FileBrowser() {
 
     const debouncedSearch = useDebouncedValue(searchQuery, SEARCH_DEBOUNCE_MS);
 
-    const handleSearchChange = (value: string) => {
-        setSearchQuery(value);
+    // Reset to page 0 when the *debounced* search takes effect (not on every
+    // keystroke — that would cause an extra fetch at page 0 with the old
+    // search before the new search fetches). Render-time state adjustment
+    // per https://react.dev/reference/react/useState#storing-information-from-previous-renders
+    const [prevDebouncedSearch, setPrevDebouncedSearch] =
+        useState(debouncedSearch);
+    if (prevDebouncedSearch !== debouncedSearch) {
+        setPrevDebouncedSearch(debouncedSearch);
         setPage(0);
-    };
+    }
 
     const handlePageChange = (next: number) => {
         // Page-scoped selection: clear on navigation.
@@ -300,6 +306,13 @@ export function FileBrowser() {
     const files = data?.files ?? [];
     const total = data?.total ?? 0;
     const counts = data?.counts ?? { archived: 0, retrieving: 0, available: 0 };
+
+    // Clamp page when total shrinks (e.g. after a bulk delete) so the user
+    // doesn't land on an empty page past the end. Render-time adjustment.
+    const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+    if (page >= totalPages) {
+        setPage(totalPages - 1);
+    }
 
     const deleteManyMutation = useMutation(
         trpc.files.deleteMany.mutationOptions({
@@ -471,7 +484,7 @@ export function FileBrowser() {
                     <Input
                         placeholder="Search files..."
                         value={searchQuery}
-                        onChange={(e) => handleSearchChange(e.target.value)}
+                        onChange={(e) => setSearchQuery(e.target.value)}
                         className="pl-9"
                     />
                 </div>
@@ -521,7 +534,8 @@ export function FileBrowser() {
                     <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-16">
                         <Search className="mb-3 size-5 text-muted-foreground/60" />
                         <p className="text-sm text-muted-foreground">
-                            No files match &ldquo;{debouncedSearch}&rdquo;
+                            No files match &ldquo;{debouncedSearch.trim()}
+                            &rdquo;
                         </p>
                     </div>
                 ) : viewMode === 'list' ? (

--- a/apps/web/components/dashboard/file-browser.tsx
+++ b/apps/web/components/dashboard/file-browser.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -30,6 +30,7 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { Card, CardContent } from '@/components/ui/card';
+import { TablePagination } from '@/components/ui/table-pagination';
 import {
     Search,
     LayoutGrid,
@@ -56,13 +57,18 @@ import { formatBytes, formatDate } from '@/lib/format';
 import { useTRPC } from '@/lib/trpc/client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import type { File } from '@nexus/db/repo/files';
+import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
+import { useInvalidateFileList } from '@/lib/hooks/useInvalidateFileList';
+import type { File, FileSortKey, FileSortOrder } from '@nexus/db/repo/files';
 
 type DerivedStatus = 'archived' | 'retrieving' | 'available';
 
-type SortKey = 'name' | 'size' | 'uploadedAt';
-type SortOrder = 'asc' | 'desc';
+const PAGE_SIZE = 24;
+const SEARCH_DEBOUNCE_MS = 300;
 
+// Keep in lockstep with countStatusesByUser in
+// packages/db/src/repositories/files.ts — the library-wide stats bar bucket
+// counts must match the per-row status dots derived here.
 function deriveStatus(file: File): DerivedStatus {
     if (file.status === 'restoring') return 'retrieving';
     if (
@@ -258,22 +264,42 @@ function SelectableIcon({
 
 export function FileBrowser() {
     const trpc = useTRPC();
-    const queryClient = useQueryClient();
+    const invalidateFileList = useInvalidateFileList();
 
     const [viewMode, setViewMode] = useState<'list' | 'grid'>('list');
     const [searchQuery, setSearchQuery] = useState('');
     const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
-    const [sortKey, setSortKey] = useState<SortKey>('uploadedAt');
-    const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+    const [sortKey, setSortKey] = useState<FileSortKey>('uploadedAt');
+    const [sortOrder, setSortOrder] = useState<FileSortOrder>('desc');
+    const [page, setPage] = useState(0);
     const lastSelectedIndex = useRef<number | null>(null);
 
-    const listOptions = trpc.files.list.queryOptions();
-    const { data, isLoading } = useQuery(listOptions);
+    const debouncedSearch = useDebouncedValue(searchQuery, SEARCH_DEBOUNCE_MS);
+
+    const handleSearchChange = (value: string) => {
+        setSearchQuery(value);
+        setPage(0);
+    };
+
+    const handlePageChange = (next: number) => {
+        // Page-scoped selection: clear on navigation.
+        setSelectedFiles([]);
+        lastSelectedIndex.current = null;
+        setPage(next);
+    };
+
+    const listOptions = trpc.files.list.queryOptions({
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
+        search: debouncedSearch || undefined,
+        sortKey,
+        sortOrder,
+    });
+    const { data, isLoading, isFetching } = useQuery(listOptions);
 
     const files = data?.files ?? [];
-
-    const invalidateFileList = () =>
-        queryClient.invalidateQueries({ queryKey: listOptions.queryKey });
+    const total = data?.total ?? 0;
+    const counts = data?.counts ?? { archived: 0, retrieving: 0, available: 0 };
 
     const deleteManyMutation = useMutation(
         trpc.files.deleteMany.mutationOptions({
@@ -294,31 +320,7 @@ export function FileBrowser() {
         })
     );
 
-    const filteredFiles = files.filter((file) =>
-        file.name.toLowerCase().includes(searchQuery.toLowerCase())
-    );
-
-    const sortedFiles = [...filteredFiles].sort((a, b) => {
-        let comparison = 0;
-        switch (sortKey) {
-            case 'name':
-                comparison = a.name.localeCompare(b.name);
-                break;
-            case 'size':
-                comparison = a.size - b.size;
-                break;
-            case 'uploadedAt':
-                comparison =
-                    new Date(a.createdAt).getTime() -
-                    new Date(b.createdAt).getTime();
-                break;
-        }
-        return sortOrder === 'asc' ? comparison : -comparison;
-    });
-
-    const hasRestoringFiles = filteredFiles.some(
-        (f) => f.status === 'restoring'
-    );
+    const hasRestoringFiles = counts.retrieving > 0;
 
     const hasSelection = selectedFiles.length > 0;
 
@@ -329,54 +331,43 @@ export function FileBrowser() {
         (f) => deriveStatus(f) === 'archived'
     );
 
-    const statusCounts = {
-        archived: files.filter((f) => deriveStatus(f) === 'archived').length,
-        retrieving: files.filter((f) => deriveStatus(f) === 'retrieving')
-            .length,
-        available: files.filter((f) => deriveStatus(f) === 'available').length,
-    };
-
-    const toggleSort = (key: SortKey) => {
+    const toggleSort = (key: FileSortKey) => {
         if (sortKey === key) {
             setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
         } else {
             setSortKey(key);
             setSortOrder('desc');
         }
+        setPage(0);
     };
 
     const toggleSelectAll = () => {
-        if (selectedFiles.length === sortedFiles.length) {
+        if (selectedFiles.length === files.length) {
             setSelectedFiles([]);
         } else {
-            setSelectedFiles(sortedFiles.map((f) => f.id));
+            setSelectedFiles(files.map((f) => f.id));
         }
     };
 
-    const handleSelect = useCallback(
-        (id: string, index: number, shiftKey: boolean) => {
-            setSelectedFiles((prev) => {
-                if (
-                    shiftKey &&
-                    lastSelectedIndex.current !== null &&
-                    lastSelectedIndex.current !== index
-                ) {
-                    const start = Math.min(lastSelectedIndex.current, index);
-                    const end = Math.max(lastSelectedIndex.current, index);
-                    const rangeIds = sortedFiles
-                        .slice(start, end + 1)
-                        .map((f) => f.id);
-                    const merged = new Set([...prev, ...rangeIds]);
-                    return Array.from(merged);
-                }
-                return prev.includes(id)
-                    ? prev.filter((f) => f !== id)
-                    : [...prev, id];
-            });
-            lastSelectedIndex.current = index;
-        },
-        [sortedFiles]
-    );
+    const handleSelect = (id: string, index: number, shiftKey: boolean) => {
+        setSelectedFiles((prev) => {
+            if (
+                shiftKey &&
+                lastSelectedIndex.current !== null &&
+                lastSelectedIndex.current !== index
+            ) {
+                const start = Math.min(lastSelectedIndex.current, index);
+                const end = Math.max(lastSelectedIndex.current, index);
+                const rangeIds = files.slice(start, end + 1).map((f) => f.id);
+                const merged = new Set([...prev, ...rangeIds]);
+                return Array.from(merged);
+            }
+            return prev.includes(id)
+                ? prev.filter((f) => f !== id)
+                : [...prev, id];
+        });
+        lastSelectedIndex.current = index;
+    };
 
     function handleBulkDelete() {
         deleteManyMutation.reset();
@@ -407,7 +398,8 @@ export function FileBrowser() {
         );
     }
 
-    const isEmpty = filteredFiles.length === 0 && searchQuery === '';
+    const hasActiveSearch = debouncedSearch.trim() !== '';
+    const isEmpty = total === 0 && !hasActiveSearch;
 
     if (isEmpty) {
         return (
@@ -438,39 +430,39 @@ export function FileBrowser() {
         );
     }
 
+    const libraryTotal = counts.archived + counts.retrieving + counts.available;
+
     return (
         <div className="space-y-4">
-            {/* Stats bar */}
-            {files.length > 0 && (
-                <div className="flex items-center gap-4 text-sm">
-                    <span className="font-medium tabular-nums">
-                        {files.length} file{files.length !== 1 ? 's' : ''}
-                    </span>
-                    <span className="h-3.5 w-px bg-border" />
-                    <div className="flex items-center gap-3 text-muted-foreground">
-                        {statusCounts.archived > 0 && (
-                            <span className="flex items-center gap-1.5">
-                                <span className="size-1.5 rounded-full bg-muted-foreground/50" />
-                                {statusCounts.archived} archived
+            {/* Stats bar — counts are library-wide, not page-scoped */}
+            <div className="flex items-center gap-4 text-sm">
+                <span className="font-medium tabular-nums">
+                    {libraryTotal} file{libraryTotal !== 1 ? 's' : ''}
+                </span>
+                <span className="h-3.5 w-px bg-border" />
+                <div className="flex items-center gap-3 text-muted-foreground">
+                    {counts.archived > 0 && (
+                        <span className="flex items-center gap-1.5">
+                            <span className="size-1.5 rounded-full bg-muted-foreground/50" />
+                            {counts.archived} archived
+                        </span>
+                    )}
+                    {counts.retrieving > 0 && (
+                        <span className="flex items-center gap-1.5">
+                            <span className="relative size-1.5 rounded-full bg-blue-500">
+                                <span className="absolute inset-0 animate-ping rounded-full bg-blue-500/60" />
                             </span>
-                        )}
-                        {statusCounts.retrieving > 0 && (
-                            <span className="flex items-center gap-1.5">
-                                <span className="relative size-1.5 rounded-full bg-blue-500">
-                                    <span className="absolute inset-0 animate-ping rounded-full bg-blue-500/60" />
-                                </span>
-                                {statusCounts.retrieving} retrieving
-                            </span>
-                        )}
-                        {statusCounts.available > 0 && (
-                            <span className="flex items-center gap-1.5">
-                                <span className="size-1.5 rounded-full bg-emerald-500" />
-                                {statusCounts.available} available
-                            </span>
-                        )}
-                    </div>
+                            {counts.retrieving} retrieving
+                        </span>
+                    )}
+                    {counts.available > 0 && (
+                        <span className="flex items-center gap-1.5">
+                            <span className="size-1.5 rounded-full bg-emerald-500" />
+                            {counts.available} available
+                        </span>
+                    )}
                 </div>
-            )}
+            </div>
 
             {/* Toolbar */}
             <div className="flex items-center justify-between gap-3">
@@ -479,7 +471,7 @@ export function FileBrowser() {
                     <Input
                         placeholder="Search files..."
                         value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
+                        onChange={(e) => handleSearchChange(e.target.value)}
                         className="pl-9"
                     />
                 </div>
@@ -524,99 +516,123 @@ export function FileBrowser() {
             </div>
 
             {/* Content */}
-            {filteredFiles.length === 0 ? (
-                <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-16">
-                    <Search className="mb-3 size-5 text-muted-foreground/60" />
-                    <p className="text-sm text-muted-foreground">
-                        No files match &ldquo;{searchQuery}&rdquo;
-                    </p>
-                </div>
-            ) : viewMode === 'list' ? (
-                <Card className="py-0">
-                    <Table>
-                        <TableHeader>
-                            <TableRow className="hover:bg-transparent">
-                                <TableHead className="w-[52px] pl-4">
-                                    <div className="flex size-8 items-center justify-center">
-                                        <Checkbox
-                                            checked={
-                                                hasSelection &&
-                                                selectedFiles.length ===
-                                                    sortedFiles.length
+            <div className="relative">
+                {total === 0 && hasActiveSearch ? (
+                    <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-16">
+                        <Search className="mb-3 size-5 text-muted-foreground/60" />
+                        <p className="text-sm text-muted-foreground">
+                            No files match &ldquo;{debouncedSearch}&rdquo;
+                        </p>
+                    </div>
+                ) : viewMode === 'list' ? (
+                    <Card className="py-0">
+                        <Table>
+                            <TableHeader>
+                                <TableRow className="hover:bg-transparent">
+                                    <TableHead className="w-[52px] pl-4">
+                                        <div className="flex size-8 items-center justify-center">
+                                            <Checkbox
+                                                checked={
+                                                    hasSelection &&
+                                                    selectedFiles.length ===
+                                                        files.length
+                                                }
+                                                onCheckedChange={
+                                                    toggleSelectAll
+                                                }
+                                                aria-label="Select all"
+                                            />
+                                        </div>
+                                    </TableHead>
+                                    <TableHead>
+                                        <button
+                                            type="button"
+                                            className="inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+                                            onClick={() => toggleSort('name')}
+                                        >
+                                            Name
+                                            <ArrowUpDown className="size-3" />
+                                        </button>
+                                    </TableHead>
+                                    <TableHead>
+                                        <button
+                                            type="button"
+                                            className="inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+                                            onClick={() => toggleSort('size')}
+                                        >
+                                            Size
+                                            <ArrowUpDown className="size-3" />
+                                        </button>
+                                    </TableHead>
+                                    <TableHead>
+                                        <button
+                                            type="button"
+                                            className="inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+                                            onClick={() =>
+                                                toggleSort('uploadedAt')
                                             }
-                                            onCheckedChange={toggleSelectAll}
-                                            aria-label="Select all"
-                                        />
-                                    </div>
-                                </TableHead>
-                                <TableHead>
-                                    <button
-                                        type="button"
-                                        className="inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
-                                        onClick={() => toggleSort('name')}
-                                    >
-                                        Name
-                                        <ArrowUpDown className="size-3" />
-                                    </button>
-                                </TableHead>
-                                <TableHead>
-                                    <button
-                                        type="button"
-                                        className="inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
-                                        onClick={() => toggleSort('size')}
-                                    >
-                                        Size
-                                        <ArrowUpDown className="size-3" />
-                                    </button>
-                                </TableHead>
-                                <TableHead>
-                                    <button
-                                        type="button"
-                                        className="inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
-                                        onClick={() => toggleSort('uploadedAt')}
-                                    >
-                                        Uploaded
-                                        <ArrowUpDown className="size-3" />
-                                    </button>
-                                </TableHead>
-                                <TableHead>
-                                    <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                                        Status
-                                    </span>
-                                </TableHead>
-                                <TableHead className="w-12" />
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {sortedFiles.map((file, index) => (
-                                <FileRow
-                                    key={file.id}
-                                    file={file}
-                                    isSelected={selectedFiles.includes(file.id)}
-                                    hasSelection={hasSelection}
-                                    onSelect={(shiftKey) =>
-                                        handleSelect(file.id, index, shiftKey)
-                                    }
-                                />
-                            ))}
-                        </TableBody>
-                    </Table>
-                </Card>
-            ) : (
-                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                    {sortedFiles.map((file, index) => (
-                        <FileCard
-                            key={file.id}
-                            file={file}
-                            isSelected={selectedFiles.includes(file.id)}
-                            hasSelection={hasSelection}
-                            onSelect={(shiftKey) =>
-                                handleSelect(file.id, index, shiftKey)
-                            }
-                        />
-                    ))}
-                </div>
-            )}
+                                        >
+                                            Uploaded
+                                            <ArrowUpDown className="size-3" />
+                                        </button>
+                                    </TableHead>
+                                    <TableHead>
+                                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                            Status
+                                        </span>
+                                    </TableHead>
+                                    <TableHead className="w-12" />
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {files.map((file, index) => (
+                                    <FileRow
+                                        key={file.id}
+                                        file={file}
+                                        isSelected={selectedFiles.includes(
+                                            file.id
+                                        )}
+                                        hasSelection={hasSelection}
+                                        onSelect={(shiftKey) =>
+                                            handleSelect(
+                                                file.id,
+                                                index,
+                                                shiftKey
+                                            )
+                                        }
+                                    />
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </Card>
+                ) : (
+                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                        {files.map((file, index) => (
+                            <FileCard
+                                key={file.id}
+                                file={file}
+                                isSelected={selectedFiles.includes(file.id)}
+                                hasSelection={hasSelection}
+                                onSelect={(shiftKey) =>
+                                    handleSelect(file.id, index, shiftKey)
+                                }
+                            />
+                        ))}
+                    </div>
+                )}
+                {isFetching && !isLoading && (
+                    <div className="pointer-events-none absolute inset-0 flex items-start justify-center pt-6">
+                        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+                    </div>
+                )}
+            </div>
+
+            <TablePagination
+                page={page}
+                pageSize={PAGE_SIZE}
+                total={total}
+                onPageChange={handlePageChange}
+            />
 
             {/* Floating selection bar */}
             {hasSelection && (
@@ -707,10 +723,7 @@ interface FileItemProps {
 function useFileActions(file: File) {
     const trpc = useTRPC();
     const queryClient = useQueryClient();
-    const listQueryKey = trpc.files.list.queryOptions().queryKey;
-
-    const invalidateFileList = () =>
-        queryClient.invalidateQueries({ queryKey: listQueryKey });
+    const invalidateFileList = useInvalidateFileList();
 
     const deleteMutation = useMutation(
         trpc.files.delete.mutationOptions({

--- a/apps/web/components/dashboard/file-browser.tsx
+++ b/apps/web/components/dashboard/file-browser.tsx
@@ -55,7 +55,12 @@ import {
 import { cn } from '@/lib/cn';
 import { formatBytes, formatDate } from '@/lib/format';
 import { useTRPC } from '@/lib/trpc/client';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+    keepPreviousData,
+    useMutation,
+    useQuery,
+    useQueryClient,
+} from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
 import { useInvalidateFileList } from '@/lib/hooks/useInvalidateFileList';
@@ -294,23 +299,34 @@ export function FileBrowser() {
         setPage(next);
     };
 
-    const listOptions = trpc.files.list.queryOptions({
-        limit: PAGE_SIZE,
-        offset: page * PAGE_SIZE,
-        search: debouncedSearch || undefined,
-        sortKey,
-        sortOrder,
-    });
-    const { data, isLoading, isFetching } = useQuery(listOptions);
+    const { data, isLoading, isFetching } = useQuery(
+        trpc.files.list.queryOptions(
+            {
+                limit: PAGE_SIZE,
+                offset: page * PAGE_SIZE,
+                search: debouncedSearch || undefined,
+                sortKey,
+                sortOrder,
+            },
+            // Keep previous page visible while the next page fetches; also
+            // prevents the page-clamp below from snapping to 0 when `data`
+            // briefly goes undefined on a new query key.
+            { placeholderData: keepPreviousData }
+        )
+    );
+    const { data: countsData } = useQuery(
+        trpc.files.statusCounts.queryOptions()
+    );
 
     const files = data?.files ?? [];
     const total = data?.total ?? 0;
-    const counts = data?.counts ?? { archived: 0, retrieving: 0, available: 0 };
+    const counts = countsData ?? { archived: 0, retrieving: 0, available: 0 };
 
     // Clamp page when total shrinks (e.g. after a bulk delete) so the user
-    // doesn't land on an empty page past the end. Render-time adjustment.
+    // doesn't land on an empty page past the end. Guarded on `data` to skip
+    // the loading/refetching states where `total` is unknown.
     const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
-    if (page >= totalPages) {
+    if (data && page >= totalPages) {
         setPage(totalPages - 1);
     }
 
@@ -493,7 +509,7 @@ export function FileBrowser() {
                         <Button
                             variant="ghost"
                             size="icon-sm"
-                            onClick={invalidateFileList}
+                            onClick={() => invalidateFileList()}
                             title="Refresh"
                         >
                             <RotateCw className="size-4" />

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -1,8 +1,9 @@
 'use client';
 
 import { useCallback, useRef, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/client';
+import { useInvalidateFileList } from '@/lib/hooks/useInvalidateFileList';
 import { xhrPut } from '@/lib/http/xhr';
 import { retryAsync } from '@/lib/async/retry';
 
@@ -27,17 +28,12 @@ interface InternalUploadFile extends UploadFile {
 
 export function useUpload() {
     const trpc = useTRPC();
-    const queryClient = useQueryClient();
     const [files, setFiles] = useState<InternalUploadFile[]>([]);
     const [isUploading, setIsUploading] = useState(false);
     const filesRef = useRef(files);
     filesRef.current = files;
 
-    const listOptions = trpc.files.list.queryOptions();
-    const invalidateFileList = useCallback(
-        () => queryClient.invalidateQueries({ queryKey: listOptions.queryKey }),
-        [queryClient, listOptions.queryKey]
-    );
+    const invalidateFileList = useInvalidateFileList();
 
     const uploadMutation = useMutation(trpc.files.upload.mutationOptions());
     const confirmMutation = useMutation(

--- a/apps/web/components/ui/pagination.tsx
+++ b/apps/web/components/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react"
+
+import { cn } from "@/lib/cn"
+import { buttonVariants, type Button } from "@/components/ui/button"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/apps/web/components/ui/pagination.tsx
+++ b/apps/web/components/ui/pagination.tsx
@@ -1,127 +1,127 @@
-import * as React from "react"
+import * as React from 'react';
 import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  MoreHorizontalIcon,
-} from "lucide-react"
+    ChevronLeftIcon,
+    ChevronRightIcon,
+    MoreHorizontalIcon,
+} from 'lucide-react';
 
-import { cn } from "@/lib/cn"
-import { buttonVariants, type Button } from "@/components/ui/button"
+import { cn } from '@/lib/cn';
+import { buttonVariants, type Button } from '@/components/ui/button';
 
-function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
-  return (
-    <nav
-      role="navigation"
-      aria-label="pagination"
-      data-slot="pagination"
-      className={cn("mx-auto flex w-full justify-center", className)}
-      {...props}
-    />
-  )
+function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
+    return (
+        <nav
+            role="navigation"
+            aria-label="pagination"
+            data-slot="pagination"
+            className={cn('mx-auto flex w-full justify-center', className)}
+            {...props}
+        />
+    );
 }
 
 function PaginationContent({
-  className,
-  ...props
-}: React.ComponentProps<"ul">) {
-  return (
-    <ul
-      data-slot="pagination-content"
-      className={cn("flex flex-row items-center gap-1", className)}
-      {...props}
-    />
-  )
+    className,
+    ...props
+}: React.ComponentProps<'ul'>) {
+    return (
+        <ul
+            data-slot="pagination-content"
+            className={cn('flex flex-row items-center gap-1', className)}
+            {...props}
+        />
+    );
 }
 
-function PaginationItem({ ...props }: React.ComponentProps<"li">) {
-  return <li data-slot="pagination-item" {...props} />
+function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
+    return <li data-slot="pagination-item" {...props} />;
 }
 
 type PaginationLinkProps = {
-  isActive?: boolean
-} & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">
+    isActive?: boolean;
+} & Pick<React.ComponentProps<typeof Button>, 'size'> &
+    React.ComponentProps<'a'>;
 
 function PaginationLink({
-  className,
-  isActive,
-  size = "icon",
-  ...props
+    className,
+    isActive,
+    size = 'icon',
+    ...props
 }: PaginationLinkProps) {
-  return (
-    <a
-      aria-current={isActive ? "page" : undefined}
-      data-slot="pagination-link"
-      data-active={isActive}
-      className={cn(
-        buttonVariants({
-          variant: isActive ? "outline" : "ghost",
-          size,
-        }),
-        className
-      )}
-      {...props}
-    />
-  )
+    return (
+        <a
+            aria-current={isActive ? 'page' : undefined}
+            data-slot="pagination-link"
+            data-active={isActive}
+            className={cn(
+                buttonVariants({
+                    variant: isActive ? 'outline' : 'ghost',
+                    size,
+                }),
+                className
+            )}
+            {...props}
+        />
+    );
 }
 
 function PaginationPrevious({
-  className,
-  ...props
+    className,
+    ...props
 }: React.ComponentProps<typeof PaginationLink>) {
-  return (
-    <PaginationLink
-      aria-label="Go to previous page"
-      size="default"
-      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
-      {...props}
-    >
-      <ChevronLeftIcon />
-      <span className="hidden sm:block">Previous</span>
-    </PaginationLink>
-  )
+    return (
+        <PaginationLink
+            aria-label="Go to previous page"
+            size="default"
+            className={cn('gap-1 px-2.5 sm:pl-2.5', className)}
+            {...props}
+        >
+            <ChevronLeftIcon />
+            <span className="hidden sm:block">Previous</span>
+        </PaginationLink>
+    );
 }
 
 function PaginationNext({
-  className,
-  ...props
+    className,
+    ...props
 }: React.ComponentProps<typeof PaginationLink>) {
-  return (
-    <PaginationLink
-      aria-label="Go to next page"
-      size="default"
-      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
-      {...props}
-    >
-      <span className="hidden sm:block">Next</span>
-      <ChevronRightIcon />
-    </PaginationLink>
-  )
+    return (
+        <PaginationLink
+            aria-label="Go to next page"
+            size="default"
+            className={cn('gap-1 px-2.5 sm:pr-2.5', className)}
+            {...props}
+        >
+            <span className="hidden sm:block">Next</span>
+            <ChevronRightIcon />
+        </PaginationLink>
+    );
 }
 
 function PaginationEllipsis({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
-  return (
-    <span
-      aria-hidden
-      data-slot="pagination-ellipsis"
-      className={cn("flex size-9 items-center justify-center", className)}
-      {...props}
-    >
-      <MoreHorizontalIcon className="size-4" />
-      <span className="sr-only">More pages</span>
-    </span>
-  )
+    className,
+    ...props
+}: React.ComponentProps<'span'>) {
+    return (
+        <span
+            aria-hidden
+            data-slot="pagination-ellipsis"
+            className={cn('flex size-9 items-center justify-center', className)}
+            {...props}
+        >
+            <MoreHorizontalIcon className="size-4" />
+            <span className="sr-only">More pages</span>
+        </span>
+    );
 }
 
 export {
-  Pagination,
-  PaginationContent,
-  PaginationLink,
-  PaginationItem,
-  PaginationPrevious,
-  PaginationNext,
-  PaginationEllipsis,
-}
+    Pagination,
+    PaginationContent,
+    PaginationLink,
+    PaginationItem,
+    PaginationPrevious,
+    PaginationNext,
+    PaginationEllipsis,
+};

--- a/apps/web/components/ui/table-pagination.tsx
+++ b/apps/web/components/ui/table-pagination.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import {
+    Pagination,
+    PaginationContent,
+    PaginationItem,
+    PaginationNext,
+    PaginationPrevious,
+} from '@/components/ui/pagination';
+
+interface TablePaginationProps {
+    page: number;
+    pageSize: number;
+    total: number;
+    onPageChange: (page: number) => void;
+}
+
+export function TablePagination({
+    page,
+    pageSize,
+    total,
+    onPageChange,
+}: TablePaginationProps) {
+    if (total <= pageSize) return null;
+
+    const totalPages = Math.ceil(total / pageSize);
+    const start = page * pageSize + 1;
+    const end = Math.min((page + 1) * pageSize, total);
+    const isFirst = page === 0;
+    const isLast = page >= totalPages - 1;
+
+    const handlePrev = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault();
+        if (!isFirst) onPageChange(page - 1);
+    };
+
+    const handleNext = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault();
+        if (!isLast) onPageChange(page + 1);
+    };
+
+    return (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-sm text-muted-foreground tabular-nums">
+                Showing {start}–{end} of {total}
+            </p>
+            <Pagination className="mx-0 w-auto justify-end">
+                <PaginationContent>
+                    <PaginationItem>
+                        <PaginationPrevious
+                            href="#"
+                            aria-label="Previous page"
+                            aria-disabled={isFirst}
+                            data-disabled={isFirst || undefined}
+                            tabIndex={isFirst ? -1 : 0}
+                            className={
+                                isFirst
+                                    ? 'pointer-events-none opacity-50'
+                                    : undefined
+                            }
+                            onClick={handlePrev}
+                        />
+                    </PaginationItem>
+                    <PaginationItem>
+                        <span className="px-2 text-sm text-muted-foreground tabular-nums">
+                            Page {page + 1} of {totalPages}
+                        </span>
+                    </PaginationItem>
+                    <PaginationItem>
+                        <PaginationNext
+                            href="#"
+                            aria-label="Next page"
+                            aria-disabled={isLast}
+                            data-disabled={isLast || undefined}
+                            tabIndex={isLast ? -1 : 0}
+                            className={
+                                isLast
+                                    ? 'pointer-events-none opacity-50'
+                                    : undefined
+                            }
+                            onClick={handleNext}
+                        />
+                    </PaginationItem>
+                </PaginationContent>
+            </Pagination>
+        </div>
+    );
+}

--- a/apps/web/components/ui/table-pagination.tsx
+++ b/apps/web/components/ui/table-pagination.tsx
@@ -48,7 +48,7 @@ export function TablePagination({
                 <PaginationContent>
                     <PaginationItem>
                         <PaginationPrevious
-                            href="#"
+                            role="button"
                             aria-label="Previous page"
                             aria-disabled={isFirst}
                             data-disabled={isFirst || undefined}
@@ -68,7 +68,7 @@ export function TablePagination({
                     </PaginationItem>
                     <PaginationItem>
                         <PaginationNext
-                            href="#"
+                            role="button"
                             aria-label="Next page"
                             aria-disabled={isLast}
                             data-disabled={isLast || undefined}

--- a/apps/web/lib/hooks/useDebouncedValue.ts
+++ b/apps/web/lib/hooks/useDebouncedValue.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+    const [debounced, setDebounced] = useState(value);
+
+    useEffect(() => {
+        const handle = setTimeout(() => setDebounced(value), delayMs);
+        return () => clearTimeout(handle);
+    }, [value, delayMs]);
+
+    return debounced;
+}

--- a/apps/web/lib/hooks/useInvalidateFileList.ts
+++ b/apps/web/lib/hooks/useInvalidateFileList.ts
@@ -18,8 +18,12 @@ export function useInvalidateFileList() {
         () => trpc.files.statusCounts.queryFilter(),
         [trpc]
     );
-    return useCallback(() => {
-        queryClient.invalidateQueries(listFilter);
-        queryClient.invalidateQueries(countsFilter);
-    }, [queryClient, listFilter, countsFilter]);
+    return useCallback(
+        () =>
+            Promise.all([
+                queryClient.invalidateQueries(listFilter),
+                queryClient.invalidateQueries(countsFilter),
+            ]),
+        [queryClient, listFilter, countsFilter]
+    );
 }

--- a/apps/web/lib/hooks/useInvalidateFileList.ts
+++ b/apps/web/lib/hooks/useInvalidateFileList.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@/lib/trpc/client';
+
+/**
+ * Invalidates every cached variant of `files.list` via a procedure-level
+ * prefix filter. Use this whenever a mutation changes the user's file set —
+ * exact-key invalidation would miss paginated/searched variants.
+ */
+export function useInvalidateFileList() {
+    const trpc = useTRPC();
+    const queryClient = useQueryClient();
+    const filter = trpc.files.list.queryFilter();
+    return useCallback(
+        () => queryClient.invalidateQueries(filter),
+        [queryClient, filter]
+    );
+}

--- a/apps/web/lib/hooks/useInvalidateFileList.ts
+++ b/apps/web/lib/hooks/useInvalidateFileList.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/client';
 
@@ -13,17 +13,14 @@ import { useTRPC } from '@/lib/trpc/client';
 export function useInvalidateFileList() {
     const trpc = useTRPC();
     const queryClient = useQueryClient();
-    const listFilter = useMemo(() => trpc.files.list.queryFilter(), [trpc]);
-    const countsFilter = useMemo(
-        () => trpc.files.statusCounts.queryFilter(),
-        [trpc]
-    );
     return useCallback(
         () =>
             Promise.all([
-                queryClient.invalidateQueries(listFilter),
-                queryClient.invalidateQueries(countsFilter),
+                queryClient.invalidateQueries(trpc.files.list.queryFilter()),
+                queryClient.invalidateQueries(
+                    trpc.files.statusCounts.queryFilter()
+                ),
             ]),
-        [queryClient, listFilter, countsFilter]
+        [trpc, queryClient]
     );
 }

--- a/apps/web/lib/hooks/useInvalidateFileList.ts
+++ b/apps/web/lib/hooks/useInvalidateFileList.ts
@@ -1,20 +1,25 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/client';
 
 /**
- * Invalidates every cached variant of `files.list` via a procedure-level
- * prefix filter. Use this whenever a mutation changes the user's file set —
- * exact-key invalidation would miss paginated/searched variants.
+ * Invalidates every cached variant of `files.list` and `files.statusCounts`
+ * via procedure-level prefix filters. Use this whenever a mutation changes
+ * the user's file set — exact-key invalidation would miss paginated/searched
+ * variants, and the stats bar query is separate from the list query.
  */
 export function useInvalidateFileList() {
     const trpc = useTRPC();
     const queryClient = useQueryClient();
-    const filter = trpc.files.list.queryFilter();
-    return useCallback(
-        () => queryClient.invalidateQueries(filter),
-        [queryClient, filter]
+    const listFilter = useMemo(() => trpc.files.list.queryFilter(), [trpc]);
+    const countsFilter = useMemo(
+        () => trpc.files.statusCounts.queryFilter(),
+        [trpc]
     );
+    return useCallback(() => {
+        queryClient.invalidateQueries(listFilter);
+        queryClient.invalidateQueries(countsFilter);
+    }, [queryClient, listFilter, countsFilter]);
 }

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -33,7 +33,7 @@ export const filesRouter = router({
                 input;
             const userId = ctx.session.user.id;
 
-            const [files, total, counts] = await Promise.all([
+            const [files, total] = await Promise.all([
                 fileRepo.findByUser(userId, {
                     limit,
                     offset,
@@ -43,16 +43,22 @@ export const filesRouter = router({
                     sortOrder,
                 }),
                 fileRepo.countByUser(userId, { includeHidden, search }),
-                fileRepo.countStatusesByUser(userId),
             ]);
 
             return {
                 files,
                 total,
                 hasMore: offset + files.length < total,
-                counts,
             };
         }),
+
+    // Library-wide status bucket counts. Split from `list` so paging/search/
+    // sort don't trigger this scan, and so the dashboard preview (which only
+    // wants the file list) doesn't pay for it on every load.
+    statusCounts: protectedProcedure.query(({ ctx }) => {
+        const fileRepo = createFileRepo(ctx.db);
+        return fileRepo.countStatusesByUser(ctx.session.user.id);
+    }),
 
     get: protectedProcedure
         .input(z.object({ id: z.string().uuid() }))

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -19,30 +19,38 @@ export const filesRouter = router({
                     limit: z.number().min(1).max(100).default(50),
                     offset: z.number().min(0).default(0),
                     includeHidden: z.boolean().default(false),
+                    search: z.string().trim().optional(),
+                    sortKey: z
+                        .enum(['name', 'size', 'uploadedAt'])
+                        .default('uploadedAt'),
+                    sortOrder: z.enum(['asc', 'desc']).default('desc'),
                 })
-                .optional()
+                .prefault({})
         )
         .query(async ({ ctx, input }) => {
             const fileRepo = createFileRepo(ctx.db);
-            const limit = input?.limit ?? 50;
-            const offset = input?.offset ?? 0;
-            const includeHidden = input?.includeHidden ?? false;
+            const { limit, offset, includeHidden, search, sortKey, sortOrder } =
+                input;
+            const userId = ctx.session.user.id;
 
-            const [files, total] = await Promise.all([
-                fileRepo.findByUser(ctx.session.user.id, {
+            const [files, total, counts] = await Promise.all([
+                fileRepo.findByUser(userId, {
                     limit,
                     offset,
                     includeHidden,
+                    search,
+                    sortKey,
+                    sortOrder,
                 }),
-                fileRepo.countByUser(ctx.session.user.id, {
-                    includeHidden,
-                }),
+                fileRepo.countByUser(userId, { includeHidden, search }),
+                fileRepo.countStatusesByUser(userId, { includeHidden }),
             ]);
 
             return {
                 files,
                 total,
                 hasMore: offset + files.length < total,
+                counts,
             };
         }),
 

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -43,7 +43,7 @@ export const filesRouter = router({
                     sortOrder,
                 }),
                 fileRepo.countByUser(userId, { includeHidden, search }),
-                fileRepo.countStatusesByUser(userId, { includeHidden }),
+                fileRepo.countStatusesByUser(userId),
             ]);
 
             return {

--- a/packages/db/src/migrations/0009_tiny_warstar.sql
+++ b/packages/db/src/migrations/0009_tiny_warstar.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "files_user_id_created_at_idx" ON "files" USING btree ("user_id","created_at" DESC NULLS LAST);

--- a/packages/db/src/migrations/meta/0009_snapshot.json
+++ b/packages/db/src/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1249 @@
+{
+  "id": "8a03580e-d643-4f1b-96c2-4c8532bbb674",
+  "prevId": "58ea2886-d8cd-46c1-b6c5-0aa4766782d1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.background_jobs": {
+      "name": "background_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "background_jobs_status_created_at_idx": {
+          "name": "background_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "storage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'glacier'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_user_id_idx": {
+          "name": "files_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_status_idx": {
+          "name": "files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_storage_tier_idx": {
+          "name": "files_storage_tier_idx",
+          "columns": [
+            {
+              "expression": "storage_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_user_id_created_at_idx": {
+          "name": "files_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_user_id_fk": {
+          "name": "files_user_id_user_id_fk",
+          "tableFrom": "files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_s3_key_unique": {
+          "name": "files_s3_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "s3_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrievals": {
+      "name": "retrievals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "retrieval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "retrieval_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retrievals_file_id_idx": {
+          "name": "retrievals_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_user_id_idx": {
+          "name": "retrievals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_status_idx": {
+          "name": "retrievals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_expires_at_idx": {
+          "name": "retrievals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retrievals_file_id_files_id_fk": {
+          "name": "retrievals_file_id_files_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_user_id_user_id_fk": {
+          "name": "retrievals_user_id_user_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_usage": {
+      "name": "storage_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_bytes": {
+          "name": "used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_usage_user_id_idx": {
+          "name": "storage_usage_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_usage_user_id_user_id_fk": {
+          "name": "storage_usage_user_id_user_id_fk",
+          "tableFrom": "storage_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_usage_user_id_unique": {
+          "name": "storage_usage_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "plan_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starter'"
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trialing'"
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_user_id_unique": {
+          "name": "subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "webhook_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_source_external_id_idx": {
+          "name": "webhook_events_source_external_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_status_created_at_idx": {
+          "name": "webhook_events_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "available",
+        "restoring",
+        "deleted"
+      ]
+    },
+    "public.retrieval_status": {
+      "name": "retrieval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "ready",
+        "expired",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.retrieval_tier": {
+      "name": "retrieval_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "bulk",
+        "expedited"
+      ]
+    },
+    "public.storage_tier": {
+      "name": "storage_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "glacier",
+        "deep_archive"
+      ]
+    },
+    "public.plan_tier": {
+      "name": "plan_tier",
+      "schema": "public",
+      "values": [
+        "starter",
+        "pro",
+        "max",
+        "enterprise"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "incomplete"
+      ]
+    },
+    "public.webhook_source": {
+      "name": "webhook_source",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "sns"
+      ]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1771153902419,
       "tag": "0008_orange_centennial",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776562429200,
+      "tag": "0009_tiny_warstar",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repositories/files.test.ts
+++ b/packages/db/src/repositories/files.test.ts
@@ -102,6 +102,8 @@ describe('files repository', () => {
     });
 
     describe('findByUser', () => {
+        const DEFAULT_OPTS = { limit: 50, offset: 0 } as const;
+
         it('returns array of files for user', async () => {
             const files = [
                 createFileFixture({ id: 'file1' }),
@@ -109,23 +111,10 @@ describe('files repository', () => {
             ];
             mocks.files.findMany.mockResolvedValue(files);
 
-            const result = await repo.findByUser(TEST_USER_ID);
+            const result = await repo.findByUser(TEST_USER_ID, DEFAULT_OPTS);
 
             expect(result).toEqual(files);
             expect(result).toHaveLength(2);
-        });
-
-        it('uses default pagination (limit: 50, offset: 0)', async () => {
-            mocks.files.findMany.mockResolvedValue([]);
-
-            await repo.findByUser(TEST_USER_ID);
-
-            expect(mocks.files.findMany).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    limit: 50,
-                    offset: 0,
-                })
-            );
         });
 
         it('respects custom pagination options', async () => {
@@ -144,7 +133,7 @@ describe('files repository', () => {
         it('returns empty array when user has no files', async () => {
             mocks.files.findMany.mockResolvedValue([]);
 
-            const result = await repo.findByUser(TEST_USER_ID);
+            const result = await repo.findByUser(TEST_USER_ID, DEFAULT_OPTS);
 
             expect(result).toEqual([]);
         });

--- a/packages/db/src/repositories/files.ts
+++ b/packages/db/src/repositories/files.ts
@@ -1,4 +1,15 @@
-import { eq, and, desc, sql, notInArray, inArray, ne, gte } from 'drizzle-orm';
+import {
+    eq,
+    and,
+    asc,
+    desc,
+    sql,
+    notInArray,
+    inArray,
+    ne,
+    gte,
+    ilike,
+} from 'drizzle-orm';
 import type { DB } from '../connection';
 import * as schema from '../schema';
 import { createRepository } from './create';
@@ -6,11 +17,34 @@ import { createRepository } from './create';
 export type File = typeof schema.files.$inferSelect;
 export type NewFile = typeof schema.files.$inferInsert;
 
+export type FileSortKey = 'name' | 'size' | 'uploadedAt';
+export type FileSortOrder = 'asc' | 'desc';
+
 export interface FindByUserOptions {
     limit: number;
     offset: number;
     includeHidden?: boolean;
+    search?: string;
+    sortKey?: FileSortKey;
+    sortOrder?: FileSortOrder;
 }
+
+export interface CountByUserOptions {
+    includeHidden?: boolean;
+    search?: string;
+}
+
+export interface StatusCategoryCounts {
+    archived: number;
+    retrieving: number;
+    available: number;
+}
+
+const SORT_COLUMNS = {
+    name: schema.files.name,
+    size: schema.files.size,
+    uploadedAt: schema.files.createdAt,
+} as const;
 
 function findById(db: DB, id: string): Promise<File | undefined> {
     return db.query.files.findFirst({
@@ -56,23 +90,37 @@ const hiddenStatuses: (typeof schema.files.status.enumValues)[number][] = [
     'deleted',
 ];
 
-function buildUserFilesWhereClause(userId: string, includeHidden: boolean) {
-    return includeHidden
-        ? eq(schema.files.userId, userId)
-        : and(
-              eq(schema.files.userId, userId),
-              notInArray(schema.files.status, hiddenStatuses)
-          );
+function buildUserFilesWhereClause(
+    userId: string,
+    includeHidden: boolean,
+    search?: string
+) {
+    const trimmed = search?.trim();
+    const conditions = [eq(schema.files.userId, userId)];
+    if (!includeHidden) {
+        conditions.push(notInArray(schema.files.status, hiddenStatuses));
+    }
+    if (trimmed) {
+        conditions.push(ilike(schema.files.name, `%${trimmed}%`));
+    }
+    return and(...conditions);
 }
 
 function findByUser(
     db: DB,
     userId: string,
-    opts: FindByUserOptions = { limit: 50, offset: 0 }
+    opts: FindByUserOptions
 ): Promise<File[]> {
+    const direction = opts.sortOrder === 'asc' ? asc : desc;
+    const sortColumn = SORT_COLUMNS[opts.sortKey ?? 'uploadedAt'];
     return db.query.files.findMany({
-        where: buildUserFilesWhereClause(userId, opts.includeHidden ?? false),
-        orderBy: desc(schema.files.createdAt),
+        where: buildUserFilesWhereClause(
+            userId,
+            opts.includeHidden ?? false,
+            opts.search
+        ),
+        // Tiebreak on id to guarantee stable paging when sort values tie.
+        orderBy: [direction(sortColumn), direction(schema.files.id)],
         limit: opts.limit,
         offset: opts.offset,
     });
@@ -81,14 +129,57 @@ function findByUser(
 async function countByUser(
     db: DB,
     userId: string,
-    opts: { includeHidden?: boolean } = {}
+    opts: CountByUserOptions = {}
 ): Promise<number> {
     const [result] = await db
         .select({ count: sql<number>`count(*)::int` })
         .from(schema.files)
-        .where(buildUserFilesWhereClause(userId, opts.includeHidden ?? false));
+        .where(
+            buildUserFilesWhereClause(
+                userId,
+                opts.includeHidden ?? false,
+                opts.search
+            )
+        );
 
     return result?.count ?? 0;
+}
+
+/**
+ * Library-wide status bucket counts for a user. Mirrors deriveStatus in
+ * apps/web/components/dashboard/file-browser.tsx — keep the two in lockstep
+ * or UI counts will disagree with per-row status dots.
+ */
+async function countStatusesByUser(
+    db: DB,
+    userId: string,
+    opts: { includeHidden?: boolean } = {}
+): Promise<StatusCategoryCounts> {
+    const rows = await db
+        .select({
+            category: sql<keyof StatusCategoryCounts>`
+                CASE
+                    WHEN ${schema.files.status} = 'restoring' THEN 'retrieving'
+                    WHEN ${schema.files.status} = 'available'
+                        AND ${schema.files.storageTier} IN ('glacier', 'deep_archive') THEN 'archived'
+                    WHEN ${schema.files.status} = 'available'
+                        AND ${schema.files.storageTier} = 'standard' THEN 'available'
+                END`.as('category'),
+            count: sql<number>`count(*)::int`.as('count'),
+        })
+        .from(schema.files)
+        .where(buildUserFilesWhereClause(userId, opts.includeHidden ?? false))
+        .groupBy(sql`category`);
+
+    const counts: StatusCategoryCounts = {
+        archived: 0,
+        retrieving: 0,
+        available: 0,
+    };
+    for (const row of rows) {
+        counts[row.category] = row.count;
+    }
+    return counts;
 }
 
 async function sumStorageByUser(db: DB, userId: string): Promise<number> {
@@ -276,6 +367,7 @@ export const createFileRepo = createRepository({
     findManyByUserAndIds,
     findByUser,
     countByUser,
+    countStatusesByUser,
     sumStorageByUser,
     insert,
     update,

--- a/packages/db/src/repositories/files.ts
+++ b/packages/db/src/repositories/files.ts
@@ -90,6 +90,12 @@ const hiddenStatuses: (typeof schema.files.status.enumValues)[number][] = [
     'deleted',
 ];
 
+// Escape LIKE/ILIKE wildcards so a search for "100%" or "foo_bar" is treated
+// as a literal substring, not a pattern. Postgres' default escape char is `\`.
+function escapeLikePattern(s: string): string {
+    return s.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
 function buildUserFilesWhereClause(
     userId: string,
     includeHidden: boolean,
@@ -101,7 +107,9 @@ function buildUserFilesWhereClause(
         conditions.push(notInArray(schema.files.status, hiddenStatuses));
     }
     if (trimmed) {
-        conditions.push(ilike(schema.files.name, `%${trimmed}%`));
+        conditions.push(
+            ilike(schema.files.name, `%${escapeLikePattern(trimmed)}%`)
+        );
     }
     return and(...conditions);
 }
@@ -148,27 +156,29 @@ async function countByUser(
 /**
  * Library-wide status bucket counts for a user. Mirrors deriveStatus in
  * apps/web/components/dashboard/file-browser.tsx — keep the two in lockstep
- * or UI counts will disagree with per-row status dots.
+ * or UI counts will disagree with per-row status dots. Hidden statuses
+ * (`uploading`, `deleted`) are always excluded since they don't fit any
+ * bucket and would produce a NULL category from the CASE below.
  */
 async function countStatusesByUser(
     db: DB,
-    userId: string,
-    opts: { includeHidden?: boolean } = {}
+    userId: string
 ): Promise<StatusCategoryCounts> {
     const rows = await db
         .select({
-            category: sql<keyof StatusCategoryCounts>`
+            category: sql<keyof StatusCategoryCounts | null>`
                 CASE
                     WHEN ${schema.files.status} = 'restoring' THEN 'retrieving'
                     WHEN ${schema.files.status} = 'available'
                         AND ${schema.files.storageTier} IN ('glacier', 'deep_archive') THEN 'archived'
                     WHEN ${schema.files.status} = 'available'
                         AND ${schema.files.storageTier} = 'standard' THEN 'available'
+                    ELSE NULL
                 END`.as('category'),
             count: sql<number>`count(*)::int`.as('count'),
         })
         .from(schema.files)
-        .where(buildUserFilesWhereClause(userId, opts.includeHidden ?? false))
+        .where(buildUserFilesWhereClause(userId, false))
         .groupBy(sql`category`);
 
     const counts: StatusCategoryCounts = {
@@ -177,7 +187,7 @@ async function countStatusesByUser(
         available: 0,
     };
     for (const row of rows) {
-        counts[row.category] = row.count;
+        if (row.category) counts[row.category] = row.count;
     }
     return counts;
 }

--- a/packages/db/src/schema/storage.ts
+++ b/packages/db/src/schema/storage.ts
@@ -75,6 +75,10 @@ export const files = pgTable(
         index('files_user_id_idx').on(table.userId),
         index('files_status_idx').on(table.status),
         index('files_storage_tier_idx').on(table.storageTier),
+        index('files_user_id_created_at_idx').on(
+            table.userId,
+            table.createdAt.desc()
+        ),
     ]
 );
 


### PR DESCRIPTION
## Summary

Move FileBrowser to server-driven pagination, search, sort, and status counts so it works on arbitrarily large libraries. Previously, all client-side operations silently became per-page once pagination landed (filtered counts, searched page, sorted page). Everything that has to be library-wide is now library-wide on the server.

Closes #39

## Changes

- **`files.list` tRPC**: added `search`, `sortKey` (`name` / `size` / `uploadedAt`), `sortOrder` (`asc` / `desc`); response now includes `counts: { archived, retrieving, available }` library-wide (respects `userId`/`includeHidden`, ignores search and pagination). Inputs are optional via `.prefault({})` so existing callers (`dashboard/page.tsx` with `{ limit: 5 }` and no-arg cache invalidation) keep working.
- **Repo layer**: `findByUser` / `countByUser` extended with `search` (case-insensitive `ilike`) and dynamic `orderBy` with `id` tiebreak for stable paging. New `countStatusesByUser` does a SQL `CASE` over `(status, storageTier)` that mirrors the UI's `deriveStatus`; both functions cross-reference each other in comments so drift is visible.
- **DB index**: composite `(user_id, created_at DESC)` on `files` to cover the default sort path.
- **Shared primitive**: `<TablePagination>` composes shadcn's `Pagination`, `PaginationPrevious`, `PaginationNext` — hides when `total <= pageSize`, renders "Page X of Y" + "Showing N–M of total", `aria-label="Previous/Next page"`. Refactored `/admin/jobs` to use it.
- **`FileBrowser`**: `PAGE_SIZE = 24`, server-side search with 300 ms debounce via a new `useDebouncedValue` hook, server sort, page resets on filter change, selection resets on page change, stats bar reads from `counts`, manual-refresh button toggles on `counts.retrieving > 0`. Loading spinner (Loader2) overlays content during page transitions without hiding the pagination footer.
- **Cache invalidation**: switched `useUpload` + FileBrowser + `useFileActions` to prefix-match via `trpc.files.list.queryFilter()` (exact-key matching would miss paginated variants). Extracted the three sites to a shared `useInvalidateFileList` hook.

## Test Plan

- [ ] CI: `pnpm check` (lint + typecheck + build + tests) — green locally
- [ ] Apply migration `0009_tiny_warstar.sql` on staging; confirm index exists: `\\d+ files`
- [ ] Seed a user with >24 files; FileBrowser shows prev/next, "Showing 1–24 of N", "Page 1 of ⌈N/24⌉"
- [ ] Type in search box; query is debounced ~300 ms and page resets to 0; "No files match …" empty state shows for no results
- [ ] Toggle each sort column (Name / Size / Uploaded); server returns correctly sorted pages
- [ ] Select a file, change page; selection clears
- [ ] Upload a file on page 3; stats bar + current page refresh via prefix invalidation
- [ ] `/admin/jobs` pagination still works (hides on single-page, prev/next disables correctly)
- [ ] Status counts in the header reflect the whole library, not the current page (verify by filtering)

## Notes

- Local `pnpm -F web test:e2e:smoke` could not run — Supabase DB host unreachable from this environment. CI will validate against the real DB.