### PR TITLE
feat: wire settings page to subscriptions API (#24)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,7 +61,7 @@
         ]
     },
     "hooks": {
-       "PostToolUse": [
+        "PostToolUse": [
             {
                 "matcher": "Edit|Write",
                 "hooks": [

--- a/apps/web/app/(dashboard)/dashboard/settings/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/settings/page.tsx
@@ -8,29 +8,7 @@ import {
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
-import { Check } from 'lucide-react';
-
-const plans = [
-    {
-        name: 'Starter',
-        storage: '100 GB',
-        price: '$2',
-        current: true,
-    },
-    {
-        name: 'Pro',
-        storage: '1 TB',
-        price: '$9',
-        current: false,
-    },
-    {
-        name: 'Business',
-        storage: '5 TB',
-        price: '$39',
-        current: false,
-    },
-];
+import { SubscriptionSection } from '@/components/dashboard/SubscriptionSection';
 
 export default function SettingsPage() {
     return (
@@ -68,57 +46,7 @@ export default function SettingsPage() {
                 </CardContent>
             </Card>
 
-            <Card>
-                <CardHeader>
-                    <CardTitle>Subscription</CardTitle>
-                    <CardDescription>Manage your storage plan</CardDescription>
-                </CardHeader>
-                <CardContent>
-                    <div className="grid gap-4 md:grid-cols-3">
-                        {plans.map((plan) => (
-                            <div
-                                key={plan.name}
-                                className={`relative rounded-lg border p-4 ${
-                                    plan.current
-                                        ? 'border-primary bg-primary/5'
-                                        : 'border-border'
-                                }`}
-                            >
-                                {plan.current && (
-                                    <Badge className="absolute -top-2 right-2">
-                                        Current
-                                    </Badge>
-                                )}
-                                <h3 className="font-semibold">{plan.name}</h3>
-                                <p className="text-sm text-muted-foreground">
-                                    {plan.storage}
-                                </p>
-                                <p className="mt-2 text-2xl font-bold">
-                                    {plan.price}
-                                    <span className="text-sm font-normal text-muted-foreground">
-                                        /mo
-                                    </span>
-                                </p>
-                                {!plan.current && (
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        className="mt-3 w-full bg-transparent"
-                                    >
-                                        Upgrade
-                                    </Button>
-                                )}
-                                {plan.current && (
-                                    <div className="mt-3 flex items-center gap-1 text-sm text-primary">
-                                        <Check className="h-4 w-4" />
-                                        Active
-                                    </div>
-                                )}
-                            </div>
-                        ))}
-                    </div>
-                </CardContent>
-            </Card>
+            <SubscriptionSection />
 
             <Card>
                 <CardHeader>

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -22,6 +22,7 @@ import {
     decidePlanAction,
     getStatusBadge,
     type BillingInterval,
+    type PlanActionDecision,
     type PlanDisplay,
 } from './subscriptionPlans';
 import type { Subscription } from '@nexus/db/repo/subscriptions';
@@ -258,6 +259,13 @@ function PlanCard({
 }: PlanCardProps) {
     const comparison = comparePlans(currentTier, plan.tier);
     const price = plan.prices[interval];
+    const decision = decidePlanAction({
+        comparison,
+        hasActiveSub,
+        isPendingThisCheckout: pendingCheckoutTier === plan.tier,
+        isAnyCheckoutPending: pendingCheckoutTier !== undefined,
+        isOpeningPortal,
+    });
 
     return (
         <div
@@ -280,11 +288,7 @@ function PlanCard({
                 </span>
             </p>
             <PlanAction
-                comparison={comparison}
-                hasActiveSub={hasActiveSub}
-                isPendingThisCheckout={pendingCheckoutTier === plan.tier}
-                isAnyCheckoutPending={pendingCheckoutTier !== undefined}
-                isOpeningPortal={isOpeningPortal}
+                decision={decision}
                 onCheckout={() => onCheckout(plan.tier)}
                 onPortal={onPortal}
             />
@@ -293,33 +297,13 @@ function PlanCard({
 }
 
 interface PlanActionProps {
-    comparison: 'current' | 'upgrade' | 'downgrade';
-    hasActiveSub: boolean;
-    isPendingThisCheckout: boolean;
-    isAnyCheckoutPending: boolean;
-    isOpeningPortal: boolean;
+    decision: PlanActionDecision | null;
     onCheckout: () => void;
     onPortal: () => void;
 }
 
-function PlanAction({
-    comparison,
-    hasActiveSub,
-    isPendingThisCheckout,
-    isAnyCheckoutPending,
-    isOpeningPortal,
-    onCheckout,
-    onPortal,
-}: PlanActionProps) {
-    const decision = decidePlanAction({
-        comparison,
-        hasActiveSub,
-        isPendingThisCheckout,
-        isAnyCheckoutPending,
-        isOpeningPortal,
-    });
-
-    if (decision.kind === 'current') {
+function PlanAction({ decision, onCheckout, onPortal }: PlanActionProps) {
+    if (decision === null) {
         return (
             <div className="mt-3 flex items-center gap-1 text-sm text-primary">
                 <Check className="h-4 w-4" />

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Check, CreditCard, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { formatDate } from '@/lib/format';
+import { useTRPC } from '@/lib/trpc/client';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+    PLAN_DISPLAY,
+    comparePlans,
+    getStatusBadge,
+    type BillingInterval,
+    type PlanDisplay,
+} from './subscriptionPlans';
+import type { Subscription } from '@nexus/db/repo/subscriptions';
+import type { CheckoutTier } from '@/lib/stripe/types';
+
+export function SubscriptionSection() {
+    const trpc = useTRPC();
+    const [billingInterval, setBillingInterval] =
+        useState<BillingInterval>('month');
+
+    const { data: subscription, isLoading } = useQuery(
+        trpc.subscriptions.current.queryOptions()
+    );
+
+    const checkout = useMutation(
+        trpc.subscriptions.createCheckoutSession.mutationOptions({
+            onSuccess: (data) => {
+                window.location.assign(data.url);
+            },
+        })
+    );
+
+    const portal = useMutation(
+        trpc.subscriptions.createPortalSession.mutationOptions({
+            onSuccess: (data) => {
+                window.location.assign(data.url);
+            },
+        })
+    );
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between pb-3">
+                <div>
+                    <CardTitle>Subscription</CardTitle>
+                    <CardDescription>Manage your storage plan</CardDescription>
+                </div>
+                <CreditCard className="h-5 w-5 text-muted-foreground" />
+            </CardHeader>
+            <CardContent className="space-y-6">
+                {isLoading ? (
+                    <SubscriptionSkeleton />
+                ) : !subscription ? (
+                    <p className="text-sm text-muted-foreground">
+                        Your subscription isn&apos;t provisioned yet. Contact
+                        support if this persists.
+                    </p>
+                ) : (
+                    <SubscriptionView
+                        subscription={subscription}
+                        interval={billingInterval}
+                        onIntervalChange={setBillingInterval}
+                        onCheckout={(tier) =>
+                            checkout.mutate({
+                                tier,
+                                interval: billingInterval,
+                            })
+                        }
+                        onPortal={() => portal.mutate()}
+                        pendingCheckoutTier={
+                            checkout.isPending
+                                ? checkout.variables?.tier
+                                : undefined
+                        }
+                        isOpeningPortal={portal.isPending}
+                    />
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+interface SubscriptionViewProps {
+    subscription: Subscription;
+    interval: BillingInterval;
+    onIntervalChange: (next: BillingInterval) => void;
+    onCheckout: (tier: CheckoutTier) => void;
+    onPortal: () => void;
+    pendingCheckoutTier: CheckoutTier | undefined;
+    isOpeningPortal: boolean;
+}
+
+function SubscriptionView({
+    subscription,
+    interval,
+    onIntervalChange,
+    onCheckout,
+    onPortal,
+    pendingCheckoutTier,
+    isOpeningPortal,
+}: SubscriptionViewProps) {
+    const statusBadge = getStatusBadge(subscription.status);
+    const canManageBilling = subscription.stripeSubscriptionId !== null;
+
+    return (
+        <>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-2">
+                    <Badge variant={statusBadge.variant}>
+                        {statusBadge.label}
+                    </Badge>
+                    <SubscriptionMeta subscription={subscription} />
+                </div>
+                <BillingIntervalToggle
+                    value={interval}
+                    onChange={onIntervalChange}
+                />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+                {PLAN_DISPLAY.map((plan) => (
+                    <PlanCard
+                        key={plan.tier}
+                        plan={plan}
+                        interval={interval}
+                        currentTier={subscription.planTier}
+                        pendingCheckoutTier={pendingCheckoutTier}
+                        onCheckout={onCheckout}
+                        onPortal={onPortal}
+                    />
+                ))}
+            </div>
+
+            <div className="flex items-center justify-between border-t pt-4">
+                <p className="text-sm text-muted-foreground">
+                    Update payment method, view invoices, or cancel in the
+                    Stripe portal.
+                </p>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={onPortal}
+                    disabled={!canManageBilling || isOpeningPortal}
+                >
+                    {isOpeningPortal && (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                    )}
+                    Manage billing
+                </Button>
+            </div>
+        </>
+    );
+}
+
+function SubscriptionMeta({ subscription }: { subscription: Subscription }) {
+    if (subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd) {
+        return (
+            <span className="text-sm text-muted-foreground">
+                Subscription ends on {formatDate(subscription.currentPeriodEnd)}
+            </span>
+        );
+    }
+    if (subscription.status === 'trialing' && subscription.trialEnd) {
+        return (
+            <span className="text-sm text-muted-foreground">
+                Trial ends on {formatDate(subscription.trialEnd)}
+            </span>
+        );
+    }
+    if (subscription.currentPeriodEnd) {
+        return (
+            <span className="text-sm text-muted-foreground">
+                Next billing on {formatDate(subscription.currentPeriodEnd)}
+            </span>
+        );
+    }
+    return null;
+}
+
+function BillingIntervalToggle({
+    value,
+    onChange,
+}: {
+    value: BillingInterval;
+    onChange: (next: BillingInterval) => void;
+}) {
+    return (
+        <div
+            role="group"
+            aria-label="Billing interval"
+            className="inline-flex rounded-md border p-0.5"
+        >
+            {(['month', 'year'] as const).map((option) => (
+                <button
+                    key={option}
+                    type="button"
+                    aria-pressed={value === option}
+                    onClick={() => onChange(option)}
+                    className={cn(
+                        'rounded-sm px-3 py-1 text-sm transition-colors',
+                        value === option
+                            ? 'bg-primary text-primary-foreground'
+                            : 'text-muted-foreground hover:text-foreground'
+                    )}
+                >
+                    {option === 'month' ? 'Monthly' : 'Annual'}
+                </button>
+            ))}
+        </div>
+    );
+}
+
+interface PlanCardProps {
+    plan: PlanDisplay;
+    interval: BillingInterval;
+    currentTier: Subscription['planTier'];
+    pendingCheckoutTier: CheckoutTier | undefined;
+    onCheckout: (tier: CheckoutTier) => void;
+    onPortal: () => void;
+}
+
+function PlanCard({
+    plan,
+    interval,
+    currentTier,
+    pendingCheckoutTier,
+    onCheckout,
+    onPortal,
+}: PlanCardProps) {
+    const comparison = comparePlans(currentTier, plan.tier);
+    const isPending = pendingCheckoutTier === plan.tier;
+    const price = plan.prices[interval];
+
+    return (
+        <div
+            className={cn(
+                'relative rounded-lg border p-4',
+                comparison === 'current'
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border'
+            )}
+        >
+            {comparison === 'current' && (
+                <Badge className="absolute -top-2 right-2">Current</Badge>
+            )}
+            <h3 className="font-semibold">{plan.name}</h3>
+            <p className="text-sm text-muted-foreground">{plan.storage}</p>
+            <p className="mt-2 text-2xl font-bold">
+                ${price}
+                <span className="text-sm font-normal text-muted-foreground">
+                    {interval === 'month' ? '/mo' : '/yr'}
+                </span>
+            </p>
+            <PlanAction
+                comparison={comparison}
+                isPending={isPending}
+                onCheckout={() => onCheckout(plan.tier)}
+                onPortal={onPortal}
+            />
+        </div>
+    );
+}
+
+function PlanAction({
+    comparison,
+    isPending,
+    onCheckout,
+    onPortal,
+}: {
+    comparison: 'current' | 'upgrade' | 'downgrade';
+    isPending: boolean;
+    onCheckout: () => void;
+    onPortal: () => void;
+}) {
+    if (comparison === 'current') {
+        return (
+            <div className="mt-3 flex items-center gap-1 text-sm text-primary">
+                <Check className="h-4 w-4" />
+                Active
+            </div>
+        );
+    }
+    const label = comparison === 'upgrade' ? 'Upgrade' : 'Downgrade';
+    const onClick = comparison === 'upgrade' ? onCheckout : onPortal;
+    return (
+        <Button
+            variant="outline"
+            size="sm"
+            className="mt-3 w-full"
+            onClick={onClick}
+            disabled={isPending}
+        >
+            {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+            {label}
+        </Button>
+    );
+}
+
+function SubscriptionSkeleton() {
+    return (
+        <>
+            <div className="flex items-center justify-between">
+                <Skeleton className="h-6 w-32" />
+                <Skeleton className="h-8 w-40" />
+            </div>
+            <div className="grid gap-4 md:grid-cols-3">
+                {Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-36 w-full rounded-lg" />
+                ))}
+            </div>
+        </>
+    );
+}

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import {
     PLAN_DISPLAY,
     comparePlans,
+    decidePlanAction,
     getStatusBadge,
     type BillingInterval,
     type PlanDisplay,
@@ -282,12 +283,6 @@ function PlanCard({
     );
 }
 
-/**
- * Routes paid users through the portal for any tier change. Calling Stripe
- * Checkout for a customer that already has an active subscription creates a
- * duplicate subscription rather than modifying the existing one — the portal
- * is the only path that swaps the existing subscription's price in place.
- */
 function PlanAction({
     comparison,
     hasActiveSub,
@@ -305,7 +300,15 @@ function PlanAction({
     onCheckout: () => void;
     onPortal: () => void;
 }) {
-    if (comparison === 'current') {
+    const decision = decidePlanAction({
+        comparison,
+        hasActiveSub,
+        isPendingThisCheckout,
+        isAnyCheckoutPending,
+        isOpeningPortal,
+    });
+
+    if (decision.kind === 'current') {
         return (
             <div className="mt-3 flex items-center gap-1 text-sm text-primary">
                 <Check className="h-4 w-4" />
@@ -314,29 +317,16 @@ function PlanAction({
         );
     }
 
-    const isUpgrade = comparison === 'upgrade';
-    const label = isUpgrade ? 'Upgrade' : 'Downgrade';
-    const useCheckout = isUpgrade && !hasActiveSub;
-    const onClick = useCheckout ? onCheckout : onPortal;
-    const isPending = useCheckout ? isPendingThisCheckout : isOpeningPortal;
-    // Disabled when: this action is firing, another card's checkout is firing,
-    // or we'd need to open the portal but have no Stripe subscription to manage
-    // (rare — would only hit for a non-self-serve tier provisioned outside checkout).
-    const disabled =
-        isPending ||
-        (useCheckout && isAnyCheckoutPending) ||
-        (!useCheckout && !hasActiveSub);
-
     return (
         <Button
             variant="outline"
             size="sm"
             className="mt-3 w-full"
-            onClick={onClick}
-            disabled={disabled}
+            onClick={decision.target === 'checkout' ? onCheckout : onPortal}
+            disabled={decision.disabled}
         >
-            {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
-            {label}
+            {decision.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+            {decision.label}
         </Button>
     );
 }

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -177,28 +177,29 @@ function SubscriptionView({
 }
 
 function SubscriptionMeta({ subscription }: { subscription: Subscription }) {
-    if (subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd) {
-        return (
-            <span className="text-sm text-muted-foreground">
-                Subscription ends on {formatDate(subscription.currentPeriodEnd)}
-            </span>
-        );
-    }
-    if (subscription.status === 'trialing' && subscription.trialEnd) {
-        return (
-            <span className="text-sm text-muted-foreground">
-                Trial ends on {formatDate(subscription.trialEnd)}
-            </span>
-        );
-    }
-    if (subscription.currentPeriodEnd) {
-        return (
-            <span className="text-sm text-muted-foreground">
-                Next billing on {formatDate(subscription.currentPeriodEnd)}
-            </span>
-        );
-    }
-    return null;
+    // Priority order: pending cancellation > trial > next billing.
+    const meta =
+        subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd
+            ? {
+                  label: 'Subscription ends on',
+                  date: subscription.currentPeriodEnd,
+              }
+            : subscription.status === 'trialing' && subscription.trialEnd
+              ? { label: 'Trial ends on', date: subscription.trialEnd }
+              : subscription.currentPeriodEnd
+                ? {
+                      label: 'Next billing on',
+                      date: subscription.currentPeriodEnd,
+                  }
+                : null;
+
+    if (!meta) return null;
+
+    return (
+        <span className="text-sm text-muted-foreground">
+            {meta.label} {formatDate(meta.date)}
+        </span>
+    );
 }
 
 interface BillingIntervalToggleProps {

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -34,7 +34,7 @@ export function SubscriptionSection() {
         useState<BillingInterval>('month');
 
     const {
-        data: subscription,
+        data: state,
         isLoading,
         isError,
     } = useQuery(trpc.subscriptions.current.queryOptions());
@@ -65,21 +65,21 @@ export function SubscriptionSection() {
                 <CreditCard className="h-5 w-5 text-muted-foreground" />
             </CardHeader>
             <CardContent className="space-y-6">
-                {isLoading ? (
+                {isLoading || !state ? (
                     <SubscriptionSkeleton />
                 ) : isError ? (
                     <p className="text-sm text-muted-foreground">
                         Couldn&apos;t load your subscription. Try refreshing the
                         page.
                     </p>
-                ) : !subscription ? (
+                ) : state.kind === 'unprovisioned' ? (
                     <p className="text-sm text-muted-foreground">
                         Your subscription isn&apos;t provisioned yet. Contact
                         support if this persists.
                     </p>
                 ) : (
                     <SubscriptionView
-                        subscription={subscription}
+                        subscription={state.subscription}
                         interval={billingInterval}
                         onIntervalChange={setBillingInterval}
                         onCheckout={(tier) =>

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -32,9 +32,11 @@ export function SubscriptionSection() {
     const [billingInterval, setBillingInterval] =
         useState<BillingInterval>('month');
 
-    const { data: subscription, isLoading } = useQuery(
-        trpc.subscriptions.current.queryOptions()
-    );
+    const {
+        data: subscription,
+        isLoading,
+        isError,
+    } = useQuery(trpc.subscriptions.current.queryOptions());
 
     const checkout = useMutation(
         trpc.subscriptions.createCheckoutSession.mutationOptions({
@@ -64,6 +66,11 @@ export function SubscriptionSection() {
             <CardContent className="space-y-6">
                 {isLoading ? (
                     <SubscriptionSkeleton />
+                ) : isError ? (
+                    <p className="text-sm text-muted-foreground">
+                        Couldn&apos;t load your subscription. Try refreshing the
+                        page.
+                    </p>
                 ) : !subscription ? (
                     <p className="text-sm text-muted-foreground">
                         Your subscription isn&apos;t provisioned yet. Contact

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -34,7 +34,7 @@ export function SubscriptionSection() {
         useState<BillingInterval>('month');
 
     const {
-        data: state,
+        data: subscription,
         isLoading,
         isError,
     } = useQuery(trpc.subscriptions.current.queryOptions());
@@ -70,16 +70,11 @@ export function SubscriptionSection() {
                         Couldn&apos;t load your subscription. Try refreshing the
                         page.
                     </p>
-                ) : isLoading || !state ? (
+                ) : isLoading || !subscription ? (
                     <SubscriptionSkeleton />
-                ) : state.kind === 'unprovisioned' ? (
-                    <p className="text-sm text-muted-foreground">
-                        Your subscription isn&apos;t provisioned yet. Contact
-                        support if this persists.
-                    </p>
                 ) : (
                     <SubscriptionView
-                        subscription={state.subscription}
+                        subscription={subscription}
                         interval={billingInterval}
                         onIntervalChange={setBillingInterval}
                         onCheckout={(tier) =>

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -137,7 +137,9 @@ function SubscriptionView({
                         plan={plan}
                         interval={interval}
                         currentTier={subscription.planTier}
+                        hasActiveSub={canManageBilling}
                         pendingCheckoutTier={pendingCheckoutTier}
+                        isOpeningPortal={isOpeningPortal}
                         onCheckout={onCheckout}
                         onPortal={onPortal}
                     />
@@ -227,7 +229,9 @@ interface PlanCardProps {
     plan: PlanDisplay;
     interval: BillingInterval;
     currentTier: Subscription['planTier'];
+    hasActiveSub: boolean;
     pendingCheckoutTier: CheckoutTier | undefined;
+    isOpeningPortal: boolean;
     onCheckout: (tier: CheckoutTier) => void;
     onPortal: () => void;
 }
@@ -236,12 +240,13 @@ function PlanCard({
     plan,
     interval,
     currentTier,
+    hasActiveSub,
     pendingCheckoutTier,
+    isOpeningPortal,
     onCheckout,
     onPortal,
 }: PlanCardProps) {
     const comparison = comparePlans(currentTier, plan.tier);
-    const isPending = pendingCheckoutTier === plan.tier;
     const price = plan.prices[interval];
 
     return (
@@ -266,7 +271,10 @@ function PlanCard({
             </p>
             <PlanAction
                 comparison={comparison}
-                isPending={isPending}
+                hasActiveSub={hasActiveSub}
+                isPendingThisCheckout={pendingCheckoutTier === plan.tier}
+                isAnyCheckoutPending={pendingCheckoutTier !== undefined}
+                isOpeningPortal={isOpeningPortal}
                 onCheckout={() => onCheckout(plan.tier)}
                 onPortal={onPortal}
             />
@@ -274,14 +282,26 @@ function PlanCard({
     );
 }
 
+/**
+ * Routes paid users through the portal for any tier change. Calling Stripe
+ * Checkout for a customer that already has an active subscription creates a
+ * duplicate subscription rather than modifying the existing one — the portal
+ * is the only path that swaps the existing subscription's price in place.
+ */
 function PlanAction({
     comparison,
-    isPending,
+    hasActiveSub,
+    isPendingThisCheckout,
+    isAnyCheckoutPending,
+    isOpeningPortal,
     onCheckout,
     onPortal,
 }: {
     comparison: 'current' | 'upgrade' | 'downgrade';
-    isPending: boolean;
+    hasActiveSub: boolean;
+    isPendingThisCheckout: boolean;
+    isAnyCheckoutPending: boolean;
+    isOpeningPortal: boolean;
     onCheckout: () => void;
     onPortal: () => void;
 }) {
@@ -293,15 +313,27 @@ function PlanAction({
             </div>
         );
     }
-    const label = comparison === 'upgrade' ? 'Upgrade' : 'Downgrade';
-    const onClick = comparison === 'upgrade' ? onCheckout : onPortal;
+
+    const isUpgrade = comparison === 'upgrade';
+    const label = isUpgrade ? 'Upgrade' : 'Downgrade';
+    const useCheckout = isUpgrade && !hasActiveSub;
+    const onClick = useCheckout ? onCheckout : onPortal;
+    const isPending = useCheckout ? isPendingThisCheckout : isOpeningPortal;
+    // Disabled when: this action is firing, another card's checkout is firing,
+    // or we'd need to open the portal but have no Stripe subscription to manage
+    // (rare — would only hit for a non-self-serve tier provisioned outside checkout).
+    const disabled =
+        isPending ||
+        (useCheckout && isAnyCheckoutPending) ||
+        (!useCheckout && !hasActiveSub);
+
     return (
         <Button
             variant="outline"
             size="sm"
             className="mt-3 w-full"
             onClick={onClick}
-            disabled={isPending}
+            disabled={disabled}
         >
             {isPending && <Loader2 className="h-4 w-4 animate-spin" />}
             {label}
@@ -320,6 +352,10 @@ function SubscriptionSkeleton() {
                 {Array.from({ length: 3 }).map((_, i) => (
                     <Skeleton key={i} className="h-36 w-full rounded-lg" />
                 ))}
+            </div>
+            <div className="flex items-center justify-between border-t pt-4">
+                <Skeleton className="h-4 w-72" />
+                <Skeleton className="h-8 w-32" />
             </div>
         </>
     );

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -193,13 +193,15 @@ function SubscriptionMeta({ subscription }: { subscription: Subscription }) {
     return null;
 }
 
+interface BillingIntervalToggleProps {
+    value: BillingInterval;
+    onChange: (next: BillingInterval) => void;
+}
+
 function BillingIntervalToggle({
     value,
     onChange,
-}: {
-    value: BillingInterval;
-    onChange: (next: BillingInterval) => void;
-}) {
+}: BillingIntervalToggleProps) {
     return (
         <div
             role="group"
@@ -283,6 +285,16 @@ function PlanCard({
     );
 }
 
+interface PlanActionProps {
+    comparison: 'current' | 'upgrade' | 'downgrade';
+    hasActiveSub: boolean;
+    isPendingThisCheckout: boolean;
+    isAnyCheckoutPending: boolean;
+    isOpeningPortal: boolean;
+    onCheckout: () => void;
+    onPortal: () => void;
+}
+
 function PlanAction({
     comparison,
     hasActiveSub,
@@ -291,15 +303,7 @@ function PlanAction({
     isOpeningPortal,
     onCheckout,
     onPortal,
-}: {
-    comparison: 'current' | 'upgrade' | 'downgrade';
-    hasActiveSub: boolean;
-    isPendingThisCheckout: boolean;
-    isAnyCheckoutPending: boolean;
-    isOpeningPortal: boolean;
-    onCheckout: () => void;
-    onPortal: () => void;
-}) {
+}: PlanActionProps) {
     const decision = decidePlanAction({
         comparison,
         hasActiveSub,

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -65,13 +65,13 @@ export function SubscriptionSection() {
                 <CreditCard className="h-5 w-5 text-muted-foreground" />
             </CardHeader>
             <CardContent className="space-y-6">
-                {isLoading || !state ? (
-                    <SubscriptionSkeleton />
-                ) : isError ? (
+                {isError ? (
                     <p className="text-sm text-muted-foreground">
                         Couldn&apos;t load your subscription. Try refreshing the
                         page.
                     </p>
+                ) : isLoading || !state ? (
+                    <SubscriptionSkeleton />
                 ) : state.kind === 'unprovisioned' ? (
                     <p className="text-sm text-muted-foreground">
                         Your subscription isn&apos;t provisioned yet. Contact

--- a/apps/web/components/dashboard/subscriptionPlans.test.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.test.ts
@@ -123,22 +123,6 @@ describe('decidePlanAction', () => {
         });
     });
 
-    // Edge case: enterprise (or any tier provisioned outside Checkout) lands a
-    // user on a high tier without a Stripe subscription. Portal can't manage
-    // them — disable the button rather than open a portal that 404s.
-    it('disables downgrade when the user has no Stripe subscription', () => {
-        const decision = decidePlanAction({
-            ...base,
-            comparison: 'downgrade',
-            hasActiveSub: false,
-        });
-        expect(decision).toMatchObject({
-            kind: 'button',
-            target: 'portal',
-            disabled: true,
-        });
-    });
-
     it('disables and shows pending while this card is checking out', () => {
         expect(
             decidePlanAction({

--- a/apps/web/components/dashboard/subscriptionPlans.test.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.test.ts
@@ -69,10 +69,8 @@ describe('decidePlanAction', () => {
         isOpeningPortal: false,
     };
 
-    it('returns current for the active tier (no button rendered)', () => {
-        expect(decidePlanAction({ ...base, comparison: 'current' })).toEqual({
-            kind: 'current',
-        });
+    it('returns null for the active tier (no button rendered)', () => {
+        expect(decidePlanAction({ ...base, comparison: 'current' })).toBeNull();
     });
 
     // The Bug 2 case: an active paying customer clicking "Upgrade" must NOT
@@ -86,7 +84,6 @@ describe('decidePlanAction', () => {
                 hasActiveSub: true,
             })
         ).toMatchObject({
-            kind: 'button',
             label: 'Upgrade',
             target: 'portal',
             disabled: false,
@@ -101,7 +98,6 @@ describe('decidePlanAction', () => {
                 hasActiveSub: false,
             })
         ).toMatchObject({
-            kind: 'button',
             label: 'Upgrade',
             target: 'checkout',
             disabled: false,
@@ -116,7 +112,6 @@ describe('decidePlanAction', () => {
                 hasActiveSub: true,
             })
         ).toMatchObject({
-            kind: 'button',
             label: 'Downgrade',
             target: 'portal',
             disabled: false,
@@ -133,7 +128,6 @@ describe('decidePlanAction', () => {
                 isAnyCheckoutPending: true,
             })
         ).toMatchObject({
-            kind: 'button',
             target: 'checkout',
             isPending: true,
             disabled: true,
@@ -153,7 +147,6 @@ describe('decidePlanAction', () => {
                 isAnyCheckoutPending: true,
             })
         ).toMatchObject({
-            kind: 'button',
             target: 'checkout',
             isPending: false,
             disabled: true,
@@ -161,14 +154,14 @@ describe('decidePlanAction', () => {
     });
 
     it('disables and shows pending while the portal is opening', () => {
-        const decision = decidePlanAction({
-            ...base,
-            comparison: 'downgrade',
-            hasActiveSub: true,
-            isOpeningPortal: true,
-        });
-        expect(decision).toMatchObject({
-            kind: 'button',
+        expect(
+            decidePlanAction({
+                ...base,
+                comparison: 'downgrade',
+                hasActiveSub: true,
+                isOpeningPortal: true,
+            })
+        ).toMatchObject({
             target: 'portal',
             isPending: true,
             disabled: true,

--- a/apps/web/components/dashboard/subscriptionPlans.test.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.test.ts
@@ -3,7 +3,9 @@ import { subscriptionStatusEnum } from '@nexus/db/schema';
 import {
     PLAN_DISPLAY,
     comparePlans,
+    decidePlanAction,
     getStatusBadge,
+    type PlanActionInput,
 } from './subscriptionPlans';
 
 describe('comparePlans', () => {
@@ -55,5 +57,137 @@ describe('PLAN_DISPLAY', () => {
             'pro',
             'max',
         ]);
+    });
+});
+
+describe('decidePlanAction', () => {
+    const base: PlanActionInput = {
+        comparison: 'upgrade',
+        hasActiveSub: false,
+        isPendingThisCheckout: false,
+        isAnyCheckoutPending: false,
+        isOpeningPortal: false,
+    };
+
+    it('returns current for the active tier (no button rendered)', () => {
+        expect(decidePlanAction({ ...base, comparison: 'current' })).toEqual({
+            kind: 'current',
+        });
+    });
+
+    // The Bug 2 case: an active paying customer clicking "Upgrade" must NOT
+    // route to Stripe Checkout — that creates a duplicate active subscription
+    // on the same customer instead of swapping the price.
+    it('routes paid users to the portal for upgrades', () => {
+        expect(
+            decidePlanAction({
+                ...base,
+                comparison: 'upgrade',
+                hasActiveSub: true,
+            })
+        ).toMatchObject({
+            kind: 'button',
+            label: 'Upgrade',
+            target: 'portal',
+            disabled: false,
+        });
+    });
+
+    it('routes trial users to checkout for upgrades', () => {
+        expect(
+            decidePlanAction({
+                ...base,
+                comparison: 'upgrade',
+                hasActiveSub: false,
+            })
+        ).toMatchObject({
+            kind: 'button',
+            label: 'Upgrade',
+            target: 'checkout',
+            disabled: false,
+        });
+    });
+
+    it('routes downgrades to the portal when the user has an active sub', () => {
+        expect(
+            decidePlanAction({
+                ...base,
+                comparison: 'downgrade',
+                hasActiveSub: true,
+            })
+        ).toMatchObject({
+            kind: 'button',
+            label: 'Downgrade',
+            target: 'portal',
+            disabled: false,
+        });
+    });
+
+    // Edge case: enterprise (or any tier provisioned outside Checkout) lands a
+    // user on a high tier without a Stripe subscription. Portal can't manage
+    // them — disable the button rather than open a portal that 404s.
+    it('disables downgrade when the user has no Stripe subscription', () => {
+        const decision = decidePlanAction({
+            ...base,
+            comparison: 'downgrade',
+            hasActiveSub: false,
+        });
+        expect(decision).toMatchObject({
+            kind: 'button',
+            target: 'portal',
+            disabled: true,
+        });
+    });
+
+    it('disables and shows pending while this card is checking out', () => {
+        expect(
+            decidePlanAction({
+                ...base,
+                comparison: 'upgrade',
+                hasActiveSub: false,
+                isPendingThisCheckout: true,
+                isAnyCheckoutPending: true,
+            })
+        ).toMatchObject({
+            kind: 'button',
+            target: 'checkout',
+            isPending: true,
+            disabled: true,
+        });
+    });
+
+    // Two trial-user upgrade cards exist (Pro and Max). When one is firing,
+    // the other must lock so a rapid double-click can't open two checkout
+    // sessions in parallel.
+    it('disables sibling cards while any checkout is pending', () => {
+        expect(
+            decidePlanAction({
+                ...base,
+                comparison: 'upgrade',
+                hasActiveSub: false,
+                isPendingThisCheckout: false,
+                isAnyCheckoutPending: true,
+            })
+        ).toMatchObject({
+            kind: 'button',
+            target: 'checkout',
+            isPending: false,
+            disabled: true,
+        });
+    });
+
+    it('disables and shows pending while the portal is opening', () => {
+        const decision = decidePlanAction({
+            ...base,
+            comparison: 'downgrade',
+            hasActiveSub: true,
+            isOpeningPortal: true,
+        });
+        expect(decision).toMatchObject({
+            kind: 'button',
+            target: 'portal',
+            isPending: true,
+            disabled: true,
+        });
     });
 });

--- a/apps/web/components/dashboard/subscriptionPlans.test.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { subscriptionStatusEnum } from '@nexus/db/schema';
+import {
+    PLAN_DISPLAY,
+    comparePlans,
+    getStatusBadge,
+} from './subscriptionPlans';
+
+describe('comparePlans', () => {
+    it('returns current for the same tier', () => {
+        expect(comparePlans('pro', 'pro')).toBe('current');
+    });
+
+    it('returns upgrade for higher tiers', () => {
+        expect(comparePlans('starter', 'pro')).toBe('upgrade');
+        expect(comparePlans('starter', 'max')).toBe('upgrade');
+        expect(comparePlans('pro', 'max')).toBe('upgrade');
+    });
+
+    it('returns downgrade for lower tiers', () => {
+        expect(comparePlans('pro', 'starter')).toBe('downgrade');
+        expect(comparePlans('max', 'pro')).toBe('downgrade');
+        expect(comparePlans('enterprise', 'max')).toBe('downgrade');
+    });
+});
+
+describe('getStatusBadge', () => {
+    it('maps each status to a label + variant', () => {
+        expect(getStatusBadge('active')).toEqual({
+            label: 'Active',
+            variant: 'default',
+        });
+        expect(getStatusBadge('trialing').variant).toBe('secondary');
+        expect(getStatusBadge('past_due').variant).toBe('destructive');
+        expect(getStatusBadge('canceled').variant).toBe('destructive');
+        expect(getStatusBadge('unpaid').variant).toBe('destructive');
+        expect(getStatusBadge('incomplete').variant).toBe('secondary');
+    });
+
+    // Guards against adding a new status to the DB enum without updating the
+    // badge mapping — unmapped cases would fall through to undefined.
+    it('returns a label for every subscription status enum value', () => {
+        for (const status of subscriptionStatusEnum.enumValues) {
+            const badge = getStatusBadge(status);
+            expect(badge.label).toBeTruthy();
+            expect(badge.variant).toBeTruthy();
+        }
+    });
+});
+
+describe('PLAN_DISPLAY', () => {
+    it('covers all checkout tiers', () => {
+        expect(PLAN_DISPLAY.map((p) => p.tier)).toEqual([
+            'starter',
+            'pro',
+            'max',
+        ]);
+    });
+});

--- a/apps/web/components/dashboard/subscriptionPlans.test.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.test.ts
@@ -48,6 +48,19 @@ describe('getStatusBadge', () => {
             expect(badge.variant).toBeTruthy();
         }
     });
+
+    it('returns a fallback badge for runtime values not in the enum', () => {
+        // Real Stripe-emitted statuses we don't list (yet); also covers
+        // migration drift where a removed enum value lingers on existing rows.
+        expect(getStatusBadge('incomplete_expired')).toEqual({
+            label: 'Unknown',
+            variant: 'secondary',
+        });
+        expect(getStatusBadge('paused')).toEqual({
+            label: 'Unknown',
+            variant: 'secondary',
+        });
+    });
 });
 
 describe('PLAN_DISPLAY', () => {

--- a/apps/web/components/dashboard/subscriptionPlans.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.ts
@@ -104,11 +104,6 @@ export type PlanActionDecision =
  * has an active subscription creates a *second* subscription rather than
  * modifying the first — the portal is the only path that swaps the existing
  * subscription's price in place.
- *
- * Disabled covers three cases: the action is firing, another card's checkout
- * is firing (would create two pending sessions), or the action would route to
- * the portal but there's no Stripe subscription to manage (rare — only hits
- * for tiers provisioned outside Checkout, e.g. enterprise).
  */
 export function decidePlanAction(input: PlanActionInput): PlanActionDecision {
     if (input.comparison === 'current') return { kind: 'current' };
@@ -118,10 +113,9 @@ export function decidePlanAction(input: PlanActionInput): PlanActionDecision {
     const isPending = useCheckout
         ? input.isPendingThisCheckout
         : input.isOpeningPortal;
-    const disabled =
-        isPending ||
-        (useCheckout && input.isAnyCheckoutPending) ||
-        (!useCheckout && !input.hasActiveSub);
+    // Sibling-card lockout: while one checkout is firing, the others must
+    // disable so a rapid double-click can't open two checkout sessions.
+    const disabled = isPending || (useCheckout && input.isAnyCheckoutPending);
 
     return {
         kind: 'button',

--- a/apps/web/components/dashboard/subscriptionPlans.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.ts
@@ -75,8 +75,19 @@ const STATUS_BADGES: Record<Subscription['status'], StatusBadge> = {
     incomplete: { label: 'Incomplete', variant: 'secondary' },
 };
 
-export function getStatusBadge(status: Subscription['status']): StatusBadge {
-    return STATUS_BADGES[status];
+const UNKNOWN_STATUS_BADGE: StatusBadge = {
+    label: 'Unknown',
+    variant: 'secondary',
+};
+
+// Accepts `string` rather than the enum so a DB row whose status no longer
+// matches the schema (migration drift, Stripe-emitted values like
+// `incomplete_expired` / `paused`) renders a fallback badge instead of
+// crashing the page.
+export function getStatusBadge(status: string): StatusBadge {
+    return (
+        STATUS_BADGES[status as Subscription['status']] ?? UNKNOWN_STATUS_BADGE
+    );
 }
 
 export interface PlanActionInput {

--- a/apps/web/components/dashboard/subscriptionPlans.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.ts
@@ -80,10 +80,10 @@ const UNKNOWN_STATUS_BADGE: StatusBadge = {
     variant: 'secondary',
 };
 
-// Accepts `string` rather than the enum so a DB row whose status no longer
-// matches the schema (migration drift, Stripe-emitted values like
-// `incomplete_expired` / `paused`) renders a fallback badge instead of
-// crashing the page.
+// Tolerates statuses outside our enum (Stripe periodically adds new ones,
+// e.g. `incomplete_expired`, `paused`) rather than crashing the settings
+// page. Type-level coverage of the enum itself is enforced by the
+// `Record<…enum…>` declaration above.
 export function getStatusBadge(status: string): StatusBadge {
     return (
         STATUS_BADGES[status as Subscription['status']] ?? UNKNOWN_STATUS_BADGE

--- a/apps/web/components/dashboard/subscriptionPlans.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.ts
@@ -79,3 +79,55 @@ export function getStatusBadge(status: Subscription['status']): StatusBadge {
             return { label: 'Incomplete', variant: 'secondary' };
     }
 }
+
+export interface PlanActionInput {
+    comparison: PlanComparison;
+    hasActiveSub: boolean;
+    isPendingThisCheckout: boolean;
+    isAnyCheckoutPending: boolean;
+    isOpeningPortal: boolean;
+}
+
+export type PlanActionDecision =
+    | { kind: 'current' }
+    | {
+          kind: 'button';
+          label: 'Upgrade' | 'Downgrade';
+          target: 'checkout' | 'portal';
+          isPending: boolean;
+          disabled: boolean;
+      };
+
+/**
+ * Routes paid users (any non-null `stripeSubscriptionId`) through the portal
+ * for every tier change. Calling Stripe Checkout for a customer that already
+ * has an active subscription creates a *second* subscription rather than
+ * modifying the first — the portal is the only path that swaps the existing
+ * subscription's price in place.
+ *
+ * Disabled covers three cases: the action is firing, another card's checkout
+ * is firing (would create two pending sessions), or the action would route to
+ * the portal but there's no Stripe subscription to manage (rare — only hits
+ * for tiers provisioned outside Checkout, e.g. enterprise).
+ */
+export function decidePlanAction(input: PlanActionInput): PlanActionDecision {
+    if (input.comparison === 'current') return { kind: 'current' };
+
+    const isUpgrade = input.comparison === 'upgrade';
+    const useCheckout = isUpgrade && !input.hasActiveSub;
+    const isPending = useCheckout
+        ? input.isPendingThisCheckout
+        : input.isOpeningPortal;
+    const disabled =
+        isPending ||
+        (useCheckout && input.isAnyCheckoutPending) ||
+        (!useCheckout && !input.hasActiveSub);
+
+    return {
+        kind: 'button',
+        label: isUpgrade ? 'Upgrade' : 'Downgrade',
+        target: useCheckout ? 'checkout' : 'portal',
+        isPending,
+        disabled,
+    };
+}

--- a/apps/web/components/dashboard/subscriptionPlans.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.ts
@@ -1,0 +1,81 @@
+import type { VariantProps } from 'class-variance-authority';
+import { PLAN_LIMITS, type PlanTier } from '@nexus/db/plans';
+import type { Subscription } from '@nexus/db/repo/subscriptions';
+import { formatBytes } from '@/lib/format';
+import type { CheckoutTier, BillingInterval } from '@/lib/stripe/types';
+import type { badgeVariants } from '@/components/ui/badge';
+
+export type { BillingInterval };
+
+type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
+
+export interface PlanDisplay {
+    tier: CheckoutTier;
+    name: string;
+    storage: string;
+    prices: Record<BillingInterval, number>;
+}
+
+/**
+ * Display data for the three self-serve tiers. Monthly prices mirror the
+ * landing page (`apps/web/components/landing/pricing.tsx`); annual gives two
+ * months free (10× monthly), the standard SaaS discount. Storage strings
+ * derive from `PLAN_LIMITS` so they can't drift from the DB enum + quota
+ * enforcement. Enterprise is excluded because it's sales-only (see
+ * `CHECKOUT_TIERS` in `lib/stripe/types`).
+ */
+export const PLAN_DISPLAY: readonly PlanDisplay[] = [
+    {
+        tier: 'starter',
+        name: 'Starter',
+        storage: formatBytes(PLAN_LIMITS.starter),
+        prices: { month: 3, year: 30 },
+    },
+    {
+        tier: 'pro',
+        name: 'Pro',
+        storage: formatBytes(PLAN_LIMITS.pro),
+        prices: { month: 12, year: 120 },
+    },
+    {
+        tier: 'max',
+        name: 'Max',
+        storage: formatBytes(PLAN_LIMITS.max),
+        prices: { month: 20, year: 200 },
+    },
+] as const;
+
+export type PlanComparison = 'current' | 'upgrade' | 'downgrade';
+
+/** Lower `PLAN_LIMITS` = lower tier; avoids a second ordering table. */
+export function comparePlans(
+    currentTier: PlanTier,
+    targetTier: PlanTier
+): PlanComparison {
+    if (currentTier === targetTier) return 'current';
+    return PLAN_LIMITS[targetTier] > PLAN_LIMITS[currentTier]
+        ? 'upgrade'
+        : 'downgrade';
+}
+
+export interface StatusBadge {
+    label: string;
+    variant: BadgeVariant;
+}
+
+export function getStatusBadge(status: Subscription['status']): StatusBadge {
+    switch (status) {
+        case 'active':
+            return { label: 'Active', variant: 'default' };
+        case 'trialing':
+            return { label: 'Trial', variant: 'secondary' };
+        case 'past_due':
+            return { label: 'Past due', variant: 'destructive' };
+        case 'canceled':
+            return { label: 'Canceled', variant: 'destructive' };
+        case 'unpaid':
+            return { label: 'Unpaid', variant: 'destructive' };
+        case 'incomplete':
+            return { label: 'Incomplete', variant: 'secondary' };
+    }
+}

--- a/apps/web/components/dashboard/subscriptionPlans.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.ts
@@ -63,21 +63,20 @@ export interface StatusBadge {
     variant: BadgeVariant;
 }
 
+// `Record<…enum…>` forces every enum value to have an entry — the runtime
+// test in `subscriptionPlans.test.ts` is a belt-and-braces guard against
+// adding a status without updating the map.
+const STATUS_BADGES: Record<Subscription['status'], StatusBadge> = {
+    active: { label: 'Active', variant: 'default' },
+    trialing: { label: 'Trial', variant: 'secondary' },
+    past_due: { label: 'Past due', variant: 'destructive' },
+    canceled: { label: 'Canceled', variant: 'destructive' },
+    unpaid: { label: 'Unpaid', variant: 'destructive' },
+    incomplete: { label: 'Incomplete', variant: 'secondary' },
+};
+
 export function getStatusBadge(status: Subscription['status']): StatusBadge {
-    switch (status) {
-        case 'active':
-            return { label: 'Active', variant: 'default' };
-        case 'trialing':
-            return { label: 'Trial', variant: 'secondary' };
-        case 'past_due':
-            return { label: 'Past due', variant: 'destructive' };
-        case 'canceled':
-            return { label: 'Canceled', variant: 'destructive' };
-        case 'unpaid':
-            return { label: 'Unpaid', variant: 'destructive' };
-        case 'incomplete':
-            return { label: 'Incomplete', variant: 'secondary' };
-    }
+    return STATUS_BADGES[status];
 }
 
 export interface PlanActionInput {
@@ -88,15 +87,12 @@ export interface PlanActionInput {
     isOpeningPortal: boolean;
 }
 
-export type PlanActionDecision =
-    | { kind: 'current' }
-    | {
-          kind: 'button';
-          label: 'Upgrade' | 'Downgrade';
-          target: 'checkout' | 'portal';
-          isPending: boolean;
-          disabled: boolean;
-      };
+export interface PlanActionDecision {
+    label: 'Upgrade' | 'Downgrade';
+    target: 'checkout' | 'portal';
+    isPending: boolean;
+    disabled: boolean;
+}
 
 /**
  * Routes paid users (any non-null `stripeSubscriptionId`) through the portal
@@ -104,9 +100,13 @@ export type PlanActionDecision =
  * has an active subscription creates a *second* subscription rather than
  * modifying the first — the portal is the only path that swaps the existing
  * subscription's price in place.
+ *
+ * Returns `null` for the current tier (no button rendered).
  */
-export function decidePlanAction(input: PlanActionInput): PlanActionDecision {
-    if (input.comparison === 'current') return { kind: 'current' };
+export function decidePlanAction(
+    input: PlanActionInput
+): PlanActionDecision | null {
+    if (input.comparison === 'current') return null;
 
     const isUpgrade = input.comparison === 'upgrade';
     const useCheckout = isUpgrade && !input.hasActiveSub;
@@ -118,7 +118,6 @@ export function decidePlanAction(input: PlanActionInput): PlanActionDecision {
     const disabled = isPending || (useCheckout && input.isAnyCheckoutPending);
 
     return {
-        kind: 'button',
         label: isUpgrade ? 'Upgrade' : 'Downgrade',
         target: useCheckout ? 'checkout' : 'portal',
         isPending,

--- a/apps/web/e2e/global.setup.ts
+++ b/apps/web/e2e/global.setup.ts
@@ -8,14 +8,19 @@ import {
     promoteToAdmin,
     authenticateAndSaveState,
 } from './helpers/auth';
+import { ensureTrialSubscription, findUserByEmail } from './helpers/db';
 
 setup('create and authenticate admin user', async ({ request }) => {
     await createUser(request, ADMIN_USER);
     await promoteToAdmin(ADMIN_USER.email);
+    const user = await findUserByEmail(ADMIN_USER.email);
+    if (user) await ensureTrialSubscription(user.id);
     await authenticateAndSaveState(request, ADMIN_USER, ADMIN_STATE_PATH);
 });
 
 setup('create and authenticate regular user', async ({ request }) => {
     await createUser(request, REGULAR_USER);
+    const user = await findUserByEmail(REGULAR_USER.email);
+    if (user) await ensureTrialSubscription(user.id);
     await authenticateAndSaveState(request, REGULAR_USER, USER_STATE_PATH);
 });

--- a/apps/web/e2e/global.setup.ts
+++ b/apps/web/e2e/global.setup.ts
@@ -14,13 +14,21 @@ setup('create and authenticate admin user', async ({ request }) => {
     await createUser(request, ADMIN_USER);
     await promoteToAdmin(ADMIN_USER.email);
     const user = await findUserByEmail(ADMIN_USER.email);
-    if (user) await ensureTrialSubscription(user.id);
+    if (!user)
+        throw new Error(
+            `admin user not found after createUser: ${ADMIN_USER.email}`
+        );
+    await ensureTrialSubscription(user.id);
     await authenticateAndSaveState(request, ADMIN_USER, ADMIN_STATE_PATH);
 });
 
 setup('create and authenticate regular user', async ({ request }) => {
     await createUser(request, REGULAR_USER);
     const user = await findUserByEmail(REGULAR_USER.email);
-    if (user) await ensureTrialSubscription(user.id);
+    if (!user)
+        throw new Error(
+            `regular user not found after createUser: ${REGULAR_USER.email}`
+        );
+    await ensureTrialSubscription(user.id);
     await authenticateAndSaveState(request, REGULAR_USER, USER_STATE_PATH);
 });

--- a/apps/web/e2e/helpers/db.ts
+++ b/apps/web/e2e/helpers/db.ts
@@ -1,6 +1,6 @@
 import postgres from 'postgres';
 import { config } from 'dotenv';
-import { PLAN_LIMITS } from '@nexus/db/plans';
+import { PLAN_LIMITS, type PlanTier } from '@nexus/db/plans';
 
 config({ path: '.env.local' });
 
@@ -172,7 +172,7 @@ export async function ensureTrialSubscription(userId: string): Promise<void> {
  */
 export async function markSubscriptionPaid(
     userId: string,
-    options?: { tier?: 'starter' | 'pro' | 'max' }
+    options?: { tier?: PlanTier }
 ): Promise<void> {
     const sql = getDb();
     const tier = options?.tier ?? 'pro';

--- a/apps/web/e2e/helpers/db.ts
+++ b/apps/web/e2e/helpers/db.ts
@@ -137,18 +137,15 @@ export async function deleteFile(id: string): Promise<void> {
 }
 
 /**
- * Guarantees the user has a trial subscription row for tests that exercise
- * the Settings subscription UI. `provisionTrialSubscription` runs on sign-up,
- * but the e2e user is created once and reused — users created before that
- * hook landed won't have a row. Safe to call repeatedly.
+ * Upserts the user's subscription row to a fresh trial state. Used by global
+ * setup (the seeded e2e user is reused across test runs and may pre-date the
+ * `provisionTrialSubscription` signup hook) and as the `afterEach` reset for
+ * tests that mutate state via `markSubscriptionPaid`. Forcing the columns
+ * back means a previous test that crashed before `afterEach` can't leak paid
+ * state into the next run.
  */
 export async function ensureTrialSubscription(userId: string): Promise<void> {
     const sql = getDb();
-    const existing = await sql<{ id: string }[]>`
-        SELECT id FROM subscriptions WHERE user_id = ${userId}
-    `;
-    if (existing.length > 0) return;
-
     await sql`
         INSERT INTO subscriptions (
             id, user_id, stripe_customer_id, plan_tier, status,
@@ -162,13 +159,22 @@ export async function ensureTrialSubscription(userId: string): Promise<void> {
             ${PLAN_LIMITS.starter},
             NOW() + INTERVAL '30 days'
         )
+        ON CONFLICT (user_id) DO UPDATE SET
+            status = EXCLUDED.status,
+            plan_tier = EXCLUDED.plan_tier,
+            storage_limit = EXCLUDED.storage_limit,
+            trial_end = EXCLUDED.trial_end,
+            stripe_subscription_id = NULL,
+            current_period_start = NULL,
+            current_period_end = NULL,
+            cancel_at_period_end = FALSE
     `;
 }
 
 /**
  * Promotes a seeded trial subscription to an active paid one. Tests that
  * exercise the paid-user code paths (e.g. Upgrade-routes-to-portal) flip the
- * row before the test and call `resetSubscriptionToTrial` after.
+ * row before the test and call `ensureTrialSubscription` after.
  */
 export async function markSubscriptionPaid(
     userId: string,
@@ -186,23 +192,6 @@ export async function markSubscriptionPaid(
             trial_end = NULL,
             cancel_at_period_end = FALSE,
             storage_limit = ${PLAN_LIMITS[tier]}
-        WHERE user_id = ${userId}
-    `;
-}
-
-/** Inverse of `markSubscriptionPaid`. Restores the shared seed user's trial state. */
-export async function resetSubscriptionToTrial(userId: string): Promise<void> {
-    const sql = getDb();
-    await sql`
-        UPDATE subscriptions
-        SET status = 'trialing',
-            plan_tier = 'starter',
-            stripe_subscription_id = NULL,
-            current_period_start = NULL,
-            current_period_end = NULL,
-            trial_end = NOW() + INTERVAL '30 days',
-            cancel_at_period_end = FALSE,
-            storage_limit = ${PLAN_LIMITS.starter}
         WHERE user_id = ${userId}
     `;
 }

--- a/apps/web/e2e/helpers/db.ts
+++ b/apps/web/e2e/helpers/db.ts
@@ -1,5 +1,6 @@
 import postgres from 'postgres';
 import { config } from 'dotenv';
+import { PLAN_LIMITS } from '@nexus/db/plans';
 
 config({ path: '.env.local' });
 
@@ -158,7 +159,7 @@ export async function ensureTrialSubscription(userId: string): Promise<void> {
             ${`cus_test_${userId}`},
             'starter',
             'trialing',
-            ${1024 ** 4},
+            ${PLAN_LIMITS.starter},
             NOW() + INTERVAL '30 days'
         )
     `;

--- a/apps/web/e2e/helpers/db.ts
+++ b/apps/web/e2e/helpers/db.ts
@@ -165,6 +165,48 @@ export async function ensureTrialSubscription(userId: string): Promise<void> {
     `;
 }
 
+/**
+ * Promotes a seeded trial subscription to an active paid one. Tests that
+ * exercise the paid-user code paths (e.g. Upgrade-routes-to-portal) flip the
+ * row before the test and call `resetSubscriptionToTrial` after.
+ */
+export async function markSubscriptionPaid(
+    userId: string,
+    options?: { tier?: 'starter' | 'pro' | 'max' }
+): Promise<void> {
+    const sql = getDb();
+    const tier = options?.tier ?? 'pro';
+    await sql`
+        UPDATE subscriptions
+        SET status = 'active',
+            plan_tier = ${tier},
+            stripe_subscription_id = ${`sub_test_${userId}`},
+            current_period_start = NOW(),
+            current_period_end = NOW() + INTERVAL '30 days',
+            trial_end = NULL,
+            cancel_at_period_end = FALSE,
+            storage_limit = ${PLAN_LIMITS[tier]}
+        WHERE user_id = ${userId}
+    `;
+}
+
+/** Inverse of `markSubscriptionPaid`. Restores the shared seed user's trial state. */
+export async function resetSubscriptionToTrial(userId: string): Promise<void> {
+    const sql = getDb();
+    await sql`
+        UPDATE subscriptions
+        SET status = 'trialing',
+            plan_tier = 'starter',
+            stripe_subscription_id = NULL,
+            current_period_start = NULL,
+            current_period_end = NULL,
+            trial_end = NOW() + INTERVAL '30 days',
+            cancel_at_period_end = FALSE,
+            storage_limit = ${PLAN_LIMITS.starter}
+        WHERE user_id = ${userId}
+    `;
+}
+
 export async function countJobsByStatus(): Promise<JobCounts> {
     const sql = getDb();
     const rows = await sql<{ status: string; count: number }[]>`

--- a/apps/web/e2e/helpers/db.ts
+++ b/apps/web/e2e/helpers/db.ts
@@ -135,6 +135,35 @@ export async function deleteFile(id: string): Promise<void> {
     await sql`DELETE FROM files WHERE id = ${id}`;
 }
 
+/**
+ * Guarantees the user has a trial subscription row for tests that exercise
+ * the Settings subscription UI. `provisionTrialSubscription` runs on sign-up,
+ * but the e2e user is created once and reused — users created before that
+ * hook landed won't have a row. Safe to call repeatedly.
+ */
+export async function ensureTrialSubscription(userId: string): Promise<void> {
+    const sql = getDb();
+    const existing = await sql<{ id: string }[]>`
+        SELECT id FROM subscriptions WHERE user_id = ${userId}
+    `;
+    if (existing.length > 0) return;
+
+    await sql`
+        INSERT INTO subscriptions (
+            id, user_id, stripe_customer_id, plan_tier, status,
+            storage_limit, trial_end
+        ) VALUES (
+            gen_random_uuid()::text,
+            ${userId},
+            ${`cus_test_${userId}`},
+            'starter',
+            'trialing',
+            ${1024 ** 4},
+            NOW() + INTERVAL '30 days'
+        )
+    `;
+}
+
 export async function countJobsByStatus(): Promise<JobCounts> {
     const sql = getDb();
     const rows = await sql<{ status: string; count: number }[]>`

--- a/apps/web/e2e/smoke/authenticated/dashboard.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/dashboard.spec.ts
@@ -58,6 +58,19 @@ test.describe('Dashboard Pages', () => {
             page.getByRole('heading', { name: /settings/i })
         ).toBeVisible();
 
+        // Subscription section renders once tRPC resolves; seeded users get a
+        // starter trial row so all three checkout tiers should be visible.
+        await expect(page.getByText('Manage your storage plan')).toBeVisible();
+        await expect(
+            page.getByRole('heading', { name: 'Starter', exact: true })
+        ).toBeVisible();
+        await expect(
+            page.getByRole('heading', { name: 'Pro', exact: true })
+        ).toBeVisible();
+        await expect(
+            page.getByRole('heading', { name: 'Max', exact: true })
+        ).toBeVisible();
+
         expect(consoleErrors).toEqual([]);
     });
 });

--- a/apps/web/e2e/smoke/authenticated/subscription.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/subscription.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '../../fixtures/authenticated';
 import { REGULAR_USER } from '../../helpers/auth';
 import {
+    ensureTrialSubscription,
     findUserByEmail,
     markSubscriptionPaid,
-    resetSubscriptionToTrial,
 } from '../../helpers/db';
 
 test.use({ userRole: 'user' });
@@ -23,7 +23,7 @@ test.describe('Subscription tier change', () => {
     });
 
     test.afterEach(async () => {
-        await resetSubscriptionToTrial(userId);
+        await ensureTrialSubscription(userId);
     });
 
     test('starter trial user sees Current badge on Starter card', async ({
@@ -51,17 +51,19 @@ test.describe('Subscription tier change', () => {
 
         // Record which mutation fired then abort so neither hits Stripe nor
         // triggers a real navigation. The handler observes before aborting,
-        // so a single instrumentation point covers both concerns.
+        // so a single instrumentation point covers both concerns. Match the
+        // path segment exactly (not a substring) so an httpBatchLink-batched
+        // URL containing both procedure names can't satisfy both routes.
         const trpcCalls: string[] = [];
         await page.route(
-            '**/api/trpc/subscriptions.createCheckoutSession**',
+            /\/api\/trpc\/subscriptions\.createCheckoutSession(\?|$)/,
             (route) => {
                 trpcCalls.push('checkout');
                 return route.abort();
             }
         );
         await page.route(
-            '**/api/trpc/subscriptions.createPortalSession**',
+            /\/api\/trpc\/subscriptions\.createPortalSession(\?|$)/,
             (route) => {
                 trpcCalls.push('portal');
                 return route.abort();
@@ -75,8 +77,7 @@ test.describe('Subscription tier change', () => {
             .locator('..');
         await maxCard.getByRole('button', { name: 'Upgrade' }).click();
 
-        await expect.poll(() => trpcCalls).toContain('portal');
-        expect(trpcCalls).not.toContain('checkout');
+        await expect.poll(() => trpcCalls).toEqual(['portal']);
         // No `consoleErrors` assertion: the aborted mutation surfaces a
         // network error in the console by design.
     });

--- a/apps/web/e2e/smoke/authenticated/subscription.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/subscription.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '../../fixtures/authenticated';
+import { REGULAR_USER } from '../../helpers/auth';
+import {
+    findUserByEmail,
+    markSubscriptionPaid,
+    resetSubscriptionToTrial,
+} from '../../helpers/db';
+
+test.use({ userRole: 'user' });
+
+// Tier-change behavior tests share the seeded user and mutate its
+// subscription row. Serializing avoids races between this file's tests; other
+// smoke files don't read subscription state, so cross-file races aren't an
+// issue.
+test.describe.serial('Subscription tier change', () => {
+    let userId: string;
+
+    test.beforeAll(async () => {
+        const user = await findUserByEmail(REGULAR_USER.email);
+        if (!user) throw new Error('seeded regular user not found');
+        userId = user.id;
+    });
+
+    test.afterEach(async () => {
+        await resetSubscriptionToTrial(userId);
+    });
+
+    test('starter trial user sees Current badge on Starter card', async ({
+        page,
+    }) => {
+        await page.goto('/dashboard/settings');
+
+        const starterCard = page
+            .getByRole('heading', { name: 'Starter', exact: true })
+            .locator('..');
+        await expect(starterCard.getByText('Current')).toBeVisible();
+    });
+
+    // Regression guard for the duplicate-subscription bug: clicking Upgrade
+    // for a customer with an active Stripe subscription must route through
+    // the portal (which swaps the price) rather than Checkout (which would
+    // create a second active subscription on the same customer).
+    test('paid Pro user clicking Upgrade Max routes to portal, not checkout', async ({
+        page,
+    }) => {
+        await markSubscriptionPaid(userId, { tier: 'pro' });
+
+        const trpcCalls: string[] = [];
+        page.on('request', (req) => {
+            const url = req.url();
+            if (url.includes('subscriptions.createCheckoutSession')) {
+                trpcCalls.push('checkout');
+            } else if (url.includes('subscriptions.createPortalSession')) {
+                trpcCalls.push('portal');
+            }
+        });
+
+        // Abort both mutations so neither hits Stripe nor triggers a real
+        // navigation; we only care which one the UI tried to fire.
+        await page.route(
+            '**/api/trpc/subscriptions.createCheckoutSession**',
+            (route) => route.abort()
+        );
+        await page.route(
+            '**/api/trpc/subscriptions.createPortalSession**',
+            (route) => route.abort()
+        );
+
+        await page.goto('/dashboard/settings');
+
+        const maxCard = page
+            .getByRole('heading', { name: 'Max', exact: true })
+            .locator('..');
+        await maxCard.getByRole('button', { name: 'Upgrade' }).click();
+
+        await expect.poll(() => trpcCalls).toContain('portal');
+        expect(trpcCalls).not.toContain('checkout');
+    });
+});

--- a/apps/web/e2e/smoke/authenticated/subscription.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/subscription.spec.ts
@@ -8,11 +8,12 @@ import {
 
 test.use({ userRole: 'user' });
 
-// Tier-change behavior tests share the seeded user and mutate its
-// subscription row. Serializing avoids races between this file's tests; other
-// smoke files don't read subscription state, so cross-file races aren't an
-// issue.
-test.describe.serial('Subscription tier change', () => {
+test.describe('Subscription tier change', () => {
+    // Tier-change tests share the seeded user and mutate its subscription
+    // row. Serializing avoids races within this file; other smoke files
+    // don't read subscription state, so cross-file races aren't an issue.
+    test.describe.configure({ mode: 'serial' });
+
     let userId: string;
 
     test.beforeAll(async () => {
@@ -27,6 +28,7 @@ test.describe.serial('Subscription tier change', () => {
 
     test('starter trial user sees Current badge on Starter card', async ({
         page,
+        consoleErrors,
     }) => {
         await page.goto('/dashboard/settings');
 
@@ -34,6 +36,8 @@ test.describe.serial('Subscription tier change', () => {
             .getByRole('heading', { name: 'Starter', exact: true })
             .locator('..');
         await expect(starterCard.getByText('Current')).toBeVisible();
+
+        expect(consoleErrors).toEqual([]);
     });
 
     // Regression guard for the duplicate-subscription bug: clicking Upgrade
@@ -45,25 +49,23 @@ test.describe.serial('Subscription tier change', () => {
     }) => {
         await markSubscriptionPaid(userId, { tier: 'pro' });
 
+        // Record which mutation fired then abort so neither hits Stripe nor
+        // triggers a real navigation. The handler observes before aborting,
+        // so a single instrumentation point covers both concerns.
         const trpcCalls: string[] = [];
-        page.on('request', (req) => {
-            const url = req.url();
-            if (url.includes('subscriptions.createCheckoutSession')) {
-                trpcCalls.push('checkout');
-            } else if (url.includes('subscriptions.createPortalSession')) {
-                trpcCalls.push('portal');
-            }
-        });
-
-        // Abort both mutations so neither hits Stripe nor triggers a real
-        // navigation; we only care which one the UI tried to fire.
         await page.route(
             '**/api/trpc/subscriptions.createCheckoutSession**',
-            (route) => route.abort()
+            (route) => {
+                trpcCalls.push('checkout');
+                return route.abort();
+            }
         );
         await page.route(
             '**/api/trpc/subscriptions.createPortalSession**',
-            (route) => route.abort()
+            (route) => {
+                trpcCalls.push('portal');
+                return route.abort();
+            }
         );
 
         await page.goto('/dashboard/settings');
@@ -75,5 +77,7 @@ test.describe.serial('Subscription tier change', () => {
 
         await expect.poll(() => trpcCalls).toContain('portal');
         expect(trpcCalls).not.toContain('checkout');
+        // No `consoleErrors` assertion: the aborted mutation surfaces a
+        // network error in the console by design.
     });
 });

--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -38,6 +38,11 @@ export const auth = betterAuth({
     databaseHooks: {
         user: {
             create: {
+                // Rethrow on failure: a half-provisioned account (user row
+                // without a subscription row) is worse than a loud signup
+                // failure. The user row may persist as an orphan if the hook
+                // throws — the `backfill-trial-subscriptions` script
+                // recovers those by inserting the missing subscription.
                 after: async (user) => {
                     try {
                         await subscriptionService.provisionTrialSubscription(
@@ -51,6 +56,7 @@ export const auth = betterAuth({
                             { err, userId: user.id },
                             'Failed to provision trial subscription on signup'
                         );
+                        throw err;
                     }
                 },
             },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
         "test:coverage": "vitest run --coverage",
         "test:integration": "vitest run --config vitest.integration.config.ts",
         "screenshots": "tsx scripts/screenshots.ts",
-        "backfill:trial-subscriptions": "tsx scripts/backfill-trial-subscriptions.ts"
+        "backfill:trial-subscriptions": "tsx --env-file=.env.local scripts/backfill-trial-subscriptions.ts"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.975.0",
@@ -72,6 +72,7 @@
         "pino-pretty": "^13.1.3",
         "postgres": "^3.4.7",
         "tailwindcss": "^4",
+        "tsx": "^4.21.0",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5",
         "vitest": "^4.0.18"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,8 @@
         "test:e2e:ui": "playwright test --ui",
         "test:coverage": "vitest run --coverage",
         "test:integration": "vitest run --config vitest.integration.config.ts",
-        "screenshots": "tsx scripts/screenshots.ts"
+        "screenshots": "tsx scripts/screenshots.ts",
+        "backfill:trial-subscriptions": "tsx scripts/backfill-trial-subscriptions.ts"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.975.0",

--- a/apps/web/scripts/backfill-trial-subscriptions.ts
+++ b/apps/web/scripts/backfill-trial-subscriptions.ts
@@ -1,0 +1,80 @@
+/**
+ * Backfill a trialing subscription for any user without one.
+ *
+ * Two populations get caught here:
+ *   1. Accounts created before the `databaseHooks.user.create.after` hook
+ *      that auto-provisions trials (added in PR #198, 2026-04-06).
+ *   2. Accounts whose hook ran but failed silently before the rethrow
+ *      hardening — i.e. anyone whose Stripe customer creation errored
+ *      transiently between #198 and the matching hardening commit.
+ *
+ * Idempotent: skips users that already have a subscription row.
+ *
+ * Usage:
+ *   pnpm -F web backfill:trial-subscriptions          # dry run (default)
+ *   pnpm -F web backfill:trial-subscriptions --apply  # actually create
+ */
+
+import { eq, isNull } from 'drizzle-orm';
+
+import { db } from '@/server/db';
+import { subscriptionService } from '@/server/services/subscriptions';
+import { subscriptions, user } from '@nexus/db/schema';
+
+async function main(): Promise<void> {
+    const apply = process.argv.includes('--apply');
+
+    const orphans = await db
+        .select({
+            id: user.id,
+            email: user.email,
+            name: user.name,
+        })
+        .from(user)
+        .leftJoin(subscriptions, eq(subscriptions.userId, user.id))
+        .where(isNull(subscriptions.id));
+
+    if (orphans.length === 0) {
+        console.log('No users without subscriptions. Nothing to do.');
+        return;
+    }
+
+    console.log(`Found ${orphans.length} user(s) without a subscription row:`);
+    for (const u of orphans) {
+        console.log(`  - ${u.id}  ${u.email}`);
+    }
+
+    if (!apply) {
+        console.log(
+            '\nDry run (default). Re-run with --apply to provision trials.'
+        );
+        return;
+    }
+
+    console.log('\nProvisioning…');
+    let ok = 0;
+    let failed = 0;
+    for (const u of orphans) {
+        try {
+            await subscriptionService.provisionTrialSubscription(
+                db,
+                u.id,
+                u.email,
+                u.name ?? undefined
+            );
+            console.log(`  ✓ ${u.id}  ${u.email}`);
+            ok += 1;
+        } catch (err) {
+            console.error(`  ✗ ${u.id}  ${u.email} —`, err);
+            failed += 1;
+        }
+    }
+
+    console.log(`\nDone. ${ok} provisioned, ${failed} failed.`);
+    if (failed > 0) process.exitCode = 1;
+}
+
+main().catch((err) => {
+    console.error('Backfill aborted:', err);
+    process.exit(1);
+});

--- a/apps/web/server/services/subscriptions.test.ts
+++ b/apps/web/server/services/subscriptions.test.ts
@@ -438,3 +438,59 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         expect(mocks.insert).not.toHaveBeenCalled();
     });
 });
+
+// Pins the Stripe redirect URLs to `/dashboard/settings`. The original PR
+// shipped with `/settings` (a 404), and a string-only regression has no
+// other guard — neither typecheck nor smoke catches a wrong path.
+describe('subscriptionService Stripe redirect URLs', () => {
+    let db: ReturnType<typeof createMockDb>['db'];
+    let mocks: ReturnType<typeof createMockDb>['mocks'];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+        mocks.subscriptions.findFirst.mockResolvedValue(
+            createSubscriptionFixture({ status: 'trialing' })
+        );
+        hoisted.stripe.prices.resolvePriceId.mockResolvedValue('price_test');
+        hoisted.stripe.checkout.createCheckoutSession.mockResolvedValue({
+            url: 'https://checkout.stripe.test/abc',
+        });
+        hoisted.stripe.checkout.createBillingPortalSession.mockResolvedValue({
+            url: 'https://billing.stripe.test/xyz',
+        });
+    });
+
+    it('createCheckoutSession success/cancel URLs target /dashboard/settings', async () => {
+        await subscriptionService.createCheckoutSession(
+            db,
+            'user-test',
+            'pro',
+            'month'
+        );
+
+        expect(
+            hoisted.stripe.checkout.createCheckoutSession
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                successUrl:
+                    'https://test.example/dashboard/settings?checkout=success',
+                cancelUrl:
+                    'https://test.example/dashboard/settings?checkout=canceled',
+            })
+        );
+    });
+
+    it('createPortalSession return URL targets /dashboard/settings', async () => {
+        await subscriptionService.createPortalSession(db, 'user-test');
+
+        expect(
+            hoisted.stripe.checkout.createBillingPortalSession
+        ).toHaveBeenCalledWith(
+            expect.any(String),
+            'https://test.example/dashboard/settings'
+        );
+    });
+});

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -126,18 +126,14 @@ async function resolveTierFromItem(
 
 // ─── tRPC-facing service methods ────────────────────────────────────────
 
-export type SubscriptionState =
-    | { kind: 'active'; subscription: Subscription }
-    | { kind: 'unprovisioned' };
-
 async function getCurrentSubscription(
     db: DB,
     userId: string
-): Promise<SubscriptionState> {
+): Promise<Subscription> {
     const repo = createSubscriptionRepo(db);
     const subscription = await repo.findByUserId(userId);
-    if (!subscription) return { kind: 'unprovisioned' };
-    return { kind: 'active', subscription };
+    if (!subscription) throw new NotFoundError('Subscription');
+    return subscription;
 }
 
 async function createCheckoutSession(

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -126,12 +126,18 @@ async function resolveTierFromItem(
 
 // ─── tRPC-facing service methods ────────────────────────────────────────
 
+export type SubscriptionState =
+    | { kind: 'active'; subscription: Subscription }
+    | { kind: 'unprovisioned' };
+
 async function getCurrentSubscription(
     db: DB,
     userId: string
-): Promise<Subscription | undefined> {
+): Promise<SubscriptionState> {
     const repo = createSubscriptionRepo(db);
-    return repo.findByUserId(userId);
+    const subscription = await repo.findByUserId(userId);
+    if (!subscription) return { kind: 'unprovisioned' };
+    return { kind: 'active', subscription };
 }
 
 async function createCheckoutSession(

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -147,8 +147,8 @@ async function createCheckoutSession(
     const session = await stripe.checkout.createCheckoutSession({
         customerId: sub.stripeCustomerId,
         priceId,
-        successUrl: `${env.NEXT_PUBLIC_APP_URL}/settings?checkout=success`,
-        cancelUrl: `${env.NEXT_PUBLIC_APP_URL}/settings?checkout=canceled`,
+        successUrl: `${env.NEXT_PUBLIC_APP_URL}/dashboard/settings?checkout=success`,
+        cancelUrl: `${env.NEXT_PUBLIC_APP_URL}/dashboard/settings?checkout=canceled`,
     });
 
     if (!session.url) {
@@ -176,7 +176,7 @@ async function createPortalSession(
 
     const session = await stripe.checkout.createBillingPortalSession(
         sub.stripeCustomerId,
-        `${env.NEXT_PUBLIC_APP_URL}/settings`
+        `${env.NEXT_PUBLIC_APP_URL}/dashboard/settings`
     );
 
     return { url: session.url };

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -23,6 +23,11 @@ const log = logger.child({ service: 'subscriptions' });
 const VALID_STATUSES = new Set<string>(subscriptionStatusEnum.enumValues);
 const VALID_TIERS = new Set<string>(planTierEnum.enumValues);
 
+// Where Stripe sends the user back after Checkout / portal. Centralized so
+// a missed update can't drift one URL off (the original PR shipped with
+// `/settings`, a 404, in three places).
+const SETTINGS_URL = `${env.NEXT_PUBLIC_APP_URL}/dashboard/settings`;
+
 type SubscriptionStatus = (typeof subscriptionStatusEnum.enumValues)[number];
 
 // Terminal or severe statuses that should not be overwritten by past_due
@@ -147,8 +152,8 @@ async function createCheckoutSession(
     const session = await stripe.checkout.createCheckoutSession({
         customerId: sub.stripeCustomerId,
         priceId,
-        successUrl: `${env.NEXT_PUBLIC_APP_URL}/dashboard/settings?checkout=success`,
-        cancelUrl: `${env.NEXT_PUBLIC_APP_URL}/dashboard/settings?checkout=canceled`,
+        successUrl: `${SETTINGS_URL}?checkout=success`,
+        cancelUrl: `${SETTINGS_URL}?checkout=canceled`,
     });
 
     if (!session.url) {
@@ -176,7 +181,7 @@ async function createPortalSession(
 
     const session = await stripe.checkout.createBillingPortalSession(
         sub.stripeCustomerId,
-        `${env.NEXT_PUBLIC_APP_URL}/dashboard/settings`
+        SETTINGS_URL
     );
 
     return { url: session.url };

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,44 +5,54 @@
     "type": "module",
     "exports": {
         ".": {
+            "types": "./src/index.ts",
             "import": "./src/index.ts",
-            "types": "./src/index.ts"
+            "default": "./src/index.ts"
         },
         "./schema": {
+            "types": "./src/schema/index.ts",
             "import": "./src/schema/index.ts",
-            "types": "./src/schema/index.ts"
+            "default": "./src/schema/index.ts"
         },
         "./repo/files": {
+            "types": "./src/repositories/files.ts",
             "import": "./src/repositories/files.ts",
-            "types": "./src/repositories/files.ts"
+            "default": "./src/repositories/files.ts"
         },
         "./repo/jobs": {
+            "types": "./src/repositories/jobs.ts",
             "import": "./src/repositories/jobs.ts",
-            "types": "./src/repositories/jobs.ts"
+            "default": "./src/repositories/jobs.ts"
         },
         "./repo/retrievals": {
+            "types": "./src/repositories/retrievals.ts",
             "import": "./src/repositories/retrievals.ts",
-            "types": "./src/repositories/retrievals.ts"
+            "default": "./src/repositories/retrievals.ts"
         },
         "./repo/subscriptions": {
+            "types": "./src/repositories/subscriptions.ts",
             "import": "./src/repositories/subscriptions.ts",
-            "types": "./src/repositories/subscriptions.ts"
+            "default": "./src/repositories/subscriptions.ts"
         },
         "./repo/webhooks": {
+            "types": "./src/repositories/webhooks.ts",
             "import": "./src/repositories/webhooks.ts",
-            "types": "./src/repositories/webhooks.ts"
+            "default": "./src/repositories/webhooks.ts"
         },
         "./plans": {
+            "types": "./src/plans.ts",
             "import": "./src/plans.ts",
-            "types": "./src/plans.ts"
+            "default": "./src/plans.ts"
         },
         "./testing": {
+            "types": "./src/testing.ts",
             "import": "./src/testing.ts",
-            "types": "./src/testing.ts"
+            "default": "./src/testing.ts"
         },
         "./seed": {
+            "types": "./src/seed/index.ts",
             "import": "./src/seed/index.ts",
-            "types": "./src/seed/index.ts"
+            "default": "./src/seed/index.ts"
         }
     },
     "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.1.18
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -8383,7 +8386,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -8410,7 +8413,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8425,13 +8428,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8463,7 +8466,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10050,7 +10053,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3


### PR DESCRIPTION
## Summary

Replaces the Settings page subscription card's hardcoded mock data (including a non-existent "Business" tier) with a live view backed by the `subscriptions` tRPC router (`current` / `createCheckoutSession` / `createPortalSession`). The page itself stays a server component; a new `SubscriptionSection` client component handles the data fetching, monthly/annual toggle, plan cards, and Stripe redirects.

Closes #24

## Changes

- **New:** `apps/web/components/dashboard/SubscriptionSection.tsx` — client component with status badge, trial/billing meta, monthly/annual toggle, per-tier upgrade (checkout) / downgrade (portal) actions, and a Manage billing button gated on `stripeSubscriptionId`.
- **New:** `apps/web/components/dashboard/subscriptionPlans.ts` + colocated `*.test.ts` — pure helpers (`comparePlans`, `getStatusBadge`, `PLAN_DISPLAY`). Storage strings derive from `PLAN_LIMITS` via `formatBytes` so the DB, quota enforcement, and UI can't drift.
- **Updated:** `app/(dashboard)/dashboard/settings/page.tsx` — removed the mock plans array and inline subscription card, now renders `<SubscriptionSection />` between Profile and Password (untouched, per issue's out-of-scope list).
- **Updated:** `e2e/smoke/authenticated/dashboard.spec.ts` — extended the existing settings smoke block to assert the Manage-your-storage-plan description and all three plan headings.
- **E2E bootstrap:** `e2e/helpers/db.ts` adds `ensureTrialSubscription`, called from `global.setup.ts`. The signup hook (`lib/auth/server.ts`) already provisions trials for new users; this guarantees the reused e2e users (created before that hook landed) also have a row.

## Design decisions

- **Annual pricing:** not defined anywhere before — went with 2 months free (10× monthly, standard SaaS discount): Starter $30/yr, Pro $120/yr, Max $200/yr.
- **Self-serve tiers only:** `PLAN_DISPLAY` uses `CheckoutTier` (enterprise excluded, matching `CHECKOUT_TIERS` in `lib/stripe/types`).
- **Toggle:** no `tabs`/`toggle-group` primitive exists in `components/ui/` yet — used `role="group"` + `aria-pressed` on segmented buttons rather than promising `role="tablist"` behavior we don't deliver (no arrow-key nav).
- **Undefined-subscription fallback:** explicit empty state ("contact support") per acceptance criteria, though the happy path relies on trial provisioning at signup.

## Test Plan

- [x] `pnpm check` passes (lint + build + unit + typecheck)
- [x] `pnpm -F web test:e2e:smoke` passes (15/15)
- [x] Unit tests for `comparePlans` + `getStatusBadge` + `PLAN_DISPLAY` coverage
- [ ] Manual: load `/dashboard/settings` as a trialing user — verify Starter shows "Current" + Trial badge, Pro/Max show "Upgrade", Manage billing is disabled (no stripeSubscriptionId yet)
- [ ] Manual: toggle monthly ↔ annual — verify prices update
- [ ] Manual (requires Stripe test mode): click Upgrade — redirects to Stripe checkout