### PR TITLE
ci: add Supabase keepalive workflow

### DIFF
--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -1,0 +1,18 @@
+name: Supabase Keepalive
+
+on:
+    schedule:
+        # Mon and Thu at 12:00 UTC — keep within Supabase's ~7-day inactivity window
+        - cron: '0 12 * * 1,4'
+    workflow_dispatch:
+
+jobs:
+    ping:
+        name: Ping database
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Run trivial query
+              env:
+                  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+              run: psql "$DATABASE_URL" -c 'select 1' -v ON_ERROR_STOP=1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/supabase-keepalive.yml` that runs `select 1` against the database on Mon + Thu at 12:00 UTC, plus `workflow_dispatch` for manual triggering.
- Prevents the free-tier Supabase project from auto-pausing after ~7 days of inactivity.

## Test plan
- [ ] Manually trigger the workflow from the Actions tab and confirm it succeeds.
- [ ] Verify the run shows `select 1` returning successfully against the linked Supabase project.

No-Issue: trivial CI addition