### PR TITLE
ci: automate DB migration apply, flag, and drift check

### DIFF
--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -1,0 +1,35 @@
+name: Migration Drift Check
+
+on:
+    schedule:
+        - cron: '0 4 * * *'
+    workflow_dispatch:
+
+jobs:
+    drift-check:
+        name: Check migration drift
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Read Node version
+              id: node-version
+              run: echo "version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ steps.node-version.outputs.version }}
+                  cache: 'pnpm'
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Check migration drift
+              run: pnpm -F db db:drift
+              env:
+                  DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -3,10 +3,44 @@ name: Post-Merge
 on:
     push:
         branches: [main]
+    workflow_dispatch:
+
+concurrency:
+    group: post-merge-main
+    cancel-in-progress: false
 
 jobs:
+    migrate:
+        name: Apply DB migrations
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Read Node version
+              id: node-version
+              run: echo "version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ steps.node-version.outputs.version }}
+                  cache: 'pnpm'
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Apply migrations
+              run: pnpm -F db db:migrate
+              env:
+                  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
     smoke-tests:
         name: Smoke Tests
+        needs: migrate
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,7 +2,7 @@ name: PR Check
 
 on:
     pull_request:
-        types: [opened, edited, synchronize]
+        types: [opened, edited, synchronize, reopened]
 
 jobs:
     check-issue-reference:
@@ -24,3 +24,107 @@ jobs:
 
                       Valid no-issue reasons: typo, docs only, ci config, deps, hotfix`);
                       }
+
+    flag-migrations:
+        name: Flag migrations
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Detect migrations and post sticky comment
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const { execSync } = require('child_process');
+                      const fs = require('fs');
+
+                      const base = context.payload.pull_request.base.sha;
+                      const head = context.payload.pull_request.head.sha;
+                      const diff = execSync(
+                        `git diff --name-only --diff-filter=AM ${base}...${head} -- 'packages/db/src/migrations/*.sql'`,
+                        { encoding: 'utf8' }
+                      ).trim();
+
+                      const MARKER = '<!-- migration-bot -->';
+                      const { data: comments } = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                      });
+                      const existing = comments.find(c => c.body.includes(MARKER));
+
+                      if (!diff) {
+                        if (existing) {
+                          await github.rest.issues.deleteComment({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            comment_id: existing.id,
+                          });
+                          console.log('Removed stale migration-bot comment.');
+                        }
+                        try {
+                          await github.rest.issues.removeLabel({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: context.issue.number,
+                            name: 'has-migration',
+                          });
+                          console.log('Removed has-migration label.');
+                        } catch (e) {
+                          // Label not present — fine.
+                        }
+                        return;
+                      }
+
+                      const files = diff.split('\n');
+                      const sqlBlocks = files.map(f => {
+                        const content = fs.readFileSync(f, 'utf8').trim();
+                        return `### \`${f}\`\n\n\`\`\`sql\n${content}\n\`\`\``;
+                      }).join('\n\n');
+
+                      const body = [
+                        MARKER,
+                        '## :warning: This PR contains DB migration(s)',
+                        '',
+                        'On merge, `post-merge.yml` applies these to production before smoke tests run. If apply fails, the workflow fails loudly.',
+                        '',
+                        sqlBlocks,
+                        '',
+                        '**Reviewer checklist:**',
+                        '- [ ] Migration is additive, or paired with a code change that tolerates pre-migration state',
+                        '- [ ] No `ALTER TABLE ... ADD COLUMN ... NOT NULL` without a default or backfill',
+                        '- [ ] Indexes use `CONCURRENTLY` if the table has meaningful row count',
+                        '- [ ] If perf-only, justify with a query plan in the PR description',
+                      ].join('\n');
+
+                      if (existing) {
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existing.id,
+                          body,
+                        });
+                        console.log('Updated existing migration-bot comment.');
+                      } else {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                          body,
+                        });
+                        console.log('Posted migration-bot comment.');
+                      }
+
+                      await github.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                        labels: ['has-migration'],
+                      });
+                      console.log('Added has-migration label.');

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -50,6 +50,7 @@
         "db:migrate": "drizzle-kit migrate",
         "db:studio": "drizzle-kit studio",
         "db:custom": "drizzle-kit generate --custom --name",
+        "db:drift": "node scripts/check-drift.mjs",
         "db:seed": "npx tsx src/seed/cli.ts",
         "test": "vitest",
         "test:run": "vitest run",

--- a/packages/db/scripts/check-drift.mjs
+++ b/packages/db/scripts/check-drift.mjs
@@ -1,0 +1,41 @@
+import postgres from 'postgres';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const journalPath = join(
+    __dirname,
+    '..',
+    'src',
+    'migrations',
+    'meta',
+    '_journal.json'
+);
+const journal = JSON.parse(readFileSync(journalPath, 'utf8'));
+const expected = journal.entries.length;
+
+if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL is not set.');
+    process.exit(2);
+}
+
+const sql = postgres(process.env.DATABASE_URL, { ssl: 'require', max: 1 });
+try {
+    const [{ n: applied }] = await sql`
+        SELECT COUNT(*)::int AS n FROM drizzle.__drizzle_migrations
+    `;
+
+    if (applied === expected) {
+        console.log(`OK: ${applied} migrations applied, matches repo journal.`);
+        process.exit(0);
+    }
+
+    console.error(
+        `DRIFT: repo has ${expected} migrations in _journal.json, DB has ${applied} applied.`
+    );
+    console.error('Run `pnpm -F db db:migrate` against the prod DB.');
+    process.exit(1);
+} finally {
+    await sql.end();
+}

--- a/packages/db/src/migrations/9999_test_flag_migrations.sql
+++ b/packages/db/src/migrations/9999_test_flag_migrations.sql
@@ -1,2 +1,0 @@
--- TEMP: validates flag-migrations workflow on PR #220. Will be reverted before merge.
-SELECT 1;

--- a/packages/db/src/migrations/9999_test_flag_migrations.sql
+++ b/packages/db/src/migrations/9999_test_flag_migrations.sql
@@ -1,0 +1,2 @@
+-- TEMP: validates flag-migrations workflow on PR #220. Will be reverted before merge.
+SELECT 1;


### PR DESCRIPTION
## Summary

Three workflows that close the gap between merging migration files and applying them to prod. Triggered by #212 — an additive index migration that would have been silently forgotten if the PR description hadn't been read carefully (and would have manifested as silent query slowdowns once the library grew).

## Changes

- **`post-merge.yml`** — new `migrate` job runs `pnpm -F db db:migrate` against prod before smoke tests. `concurrency: post-merge-main, cancel-in-progress: false` serializes back-to-back merges. Adds `workflow_dispatch` for manual reruns.
- **`pr-check.yml`** — new `flag-migrations` job. When a PR adds/modifies `.sql` files under `packages/db/src/migrations/`, it adds a `has-migration` label and posts a sticky comment with the migration SQL inline + a reviewer checklist. If the migration is removed in a later push, the comment and label are cleaned up.
- **`migration-drift.yml`** (new) — nightly cron at 04:00 UTC + `workflow_dispatch`. Compares `_journal.json` entries against `drizzle.__drizzle_migrations` row count; fails loudly on mismatch.
- **`packages/db/scripts/check-drift.mjs`** (new) + `db:drift` script entry — drift check implementation.

## Failure-mode coverage

| Failure mode | Caught by |
|---|---|
| Forgot to apply migration after merge | post-merge auto-applies + drift detector catches if the auto-apply silently broke |
| Reviewer didn't notice PR had a migration | flag-migrations sticky comment + label |
| Migration drifts (applied locally, not prod) | drift detector |
| Migration SQL is broken | migrate step fails, post-merge workflow goes red |

## Known limits (documented for future work)

- Vercel deploys auto on push; migrate runs in parallel via this Action. Safe for additive/perf migrations, has a small race window for breaking schema changes. Long-term fix is moving deploys behind GH Actions.
- Drift detector uses count comparison, not hash comparison. Catches "forgot to apply" but not "manual SQL outside drizzle." Acceptable trade-off; `drizzle-kit check` exists if we want stronger guarantees later.

## Test Plan

- [x] `actionlint` passes (only pre-existing SC2086 info warnings, identical to `ci.yml`)
- [x] `node --check` clean on `check-drift.mjs`
- [x] `pnpm -F db db:drift` runs locally against prod DB → "OK: 10 migrations applied, matches repo journal"
- [x] `has-migration` label created in repo
- [ ] CI green on this PR (no migration files → flag-migrations exits cleanly with no comment/label)
- [ ] Add a temp 0010 migration file in a follow-up commit on this branch → confirm sticky comment + label appear
- [ ] Remove the temp migration → confirm comment + label cleaned up
- [ ] After merge: post-merge migrate job runs and reports no pending migrations (10/10 already applied)
- [ ] After merge: trigger `migration-drift.yml` via `workflow_dispatch` → green

No-Issue: ci config