### PR TITLE
ci: cancel superseded PR runs, skip duplicate ci on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,10 @@ name: CI
 
 on:
     pull_request:
-    push:
-        branches: [main]
+
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
     ci:


### PR DESCRIPTION
## Summary

Two cheap CI optimizations identified during PR #220 review:

1. **Cancel superseded PR runs.** Adding `concurrency: { group: ci-${{ github.ref }}, cancel-in-progress: true }` means pushing N commits in quick succession runs CI once for the latest tip, not N times in parallel.
2. **Skip the duplicate `ci.yml` run on the merge commit.** The same lint/typecheck/test that just passed on the PR was running again on `push: main` (~24s of redundant compute per merge). `post-merge.yml` continues to cover smoke tests + migrations on main.

## Test Plan

- [x] `actionlint` clean (only pre-existing SC2086 info-level pattern, identical to the rest of the workflows)
- [ ] Verify CI runs on this PR and shows the new concurrency group
- [ ] After merge: confirm `ci.yml` does NOT run on the merge commit, and `post-merge.yml` (migrate + smoke) still does

## Tradeoff (acknowledged)

Removing `push: main` from `ci.yml` means a direct push to main (or a non-PR rebase) wouldn't get lint/typecheck/test coverage. For a solo dev who only lands on main via PR merges, this is fine. If/when this changes, restore the trigger.

No-Issue: ci config