### PR TITLE
fix: trust LAN origins for BetterAuth in dev

### DIFF
--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -7,11 +7,19 @@ import { logger } from '@/server/lib/logger';
 
 const log = logger.child({ module: 'auth' });
 
+// In dev, allow access from any device on the local network (e.g. phone testing)
+// across the RFC1918 private ranges. Production stays restricted to baseURL.
+const devLanOrigins =
+    process.env.NODE_ENV === 'development'
+        ? ['http://192.168.*:3000', 'http://10.*:3000', 'http://172.*:3000']
+        : [];
+
 export const auth = betterAuth({
     database: drizzleAdapter(db, {
         provider: 'pg',
         schema,
     }),
+    trustedOrigins: devLanOrigins,
     emailAndPassword: {
         enabled: true,
     },


### PR DESCRIPTION
## Summary
- BetterAuth rejected LAN-IP origins (e.g. `http://192.168.76.150:3000`) when testing the dev server from another device on the network, since it falls back to trusting only the configured `baseURL`.
- Added `trustedOrigins` wildcards covering the RFC1918 private ranges (`192.168.*`, `10.*`, `172.*` on port 3000), gated to `NODE_ENV=development`. Production behavior is unchanged.

## Test plan
- [ ] `pnpm check` passes
- [ ] Sign in from `http://localhost:3000` still works
- [ ] Sign in from a LAN IP (e.g. phone on Wi-Fi pointing at `http://<host-lan-ip>:3000`) no longer logs `Invalid origin`
- [ ] Verify production build does not include the LAN origins (compile a prod build and confirm `NODE_ENV` gating excludes them)

No-Issue: trivial dev-ergonomics fix