### PR TITLE
feat: forward client-side errors to dev log

### DIFF
--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -19,9 +19,8 @@ export default function Error({
     error: Error & { digest?: string };
     reset: () => void;
 }) {
-    // Dedupe against React.StrictMode's dev-mode double-invocation of
-    // effects: without this, a single boundary error writes two `.dev.log`
-    // entries.
+    // React.StrictMode double-invokes effects in dev — dedupe so a single
+    // boundary error doesn't write twice.
     const logged = useRef(new Set<string | Error>());
     useEffect(() => {
         const key = error.digest ?? error;

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -8,14 +8,24 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
+import { log } from '@/lib/logger/client';
 import Link from 'next/link';
+import { useEffect } from 'react';
 
 export default function Error({
+    error,
     reset,
 }: {
     error: Error & { digest?: string };
     reset: () => void;
 }) {
+    useEffect(() => {
+        log.error(
+            { err: error, digest: error.digest },
+            error.message || 'route error boundary'
+        );
+    }, [error]);
+
     return (
         <div className="flex min-h-[50vh] items-center justify-center p-4">
             <Card className="w-full max-w-md">

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/card';
 import { log } from '@/lib/logger/client';
 import Link from 'next/link';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export default function Error({
     error,
@@ -19,7 +19,14 @@ export default function Error({
     error: Error & { digest?: string };
     reset: () => void;
 }) {
+    // Dedupe against React.StrictMode's dev-mode double-invocation of
+    // effects: without this, a single boundary error writes two `.dev.log`
+    // entries.
+    const logged = useRef(new Set<string | Error>());
     useEffect(() => {
+        const key = error.digest ?? error;
+        if (logged.current.has(key)) return;
+        logged.current.add(key);
         log.error(
             { err: error, digest: error.digest },
             error.message || 'route error boundary'

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
+import Link from 'next/link';
+
 import { Button } from '@/components/ui/button';
 import {
     Card,
@@ -9,16 +12,16 @@ import {
     CardTitle,
 } from '@/components/ui/card';
 import { log } from '@/lib/logger/client';
-import Link from 'next/link';
-import { useEffect, useRef } from 'react';
+
+interface ErrorBoundaryProps {
+    error: Error & { digest?: string };
+    reset: () => void;
+}
 
 export default function Error({
     error,
     reset,
-}: {
-    error: Error & { digest?: string };
-    reset: () => void;
-}) {
+}: ErrorBoundaryProps): React.ReactElement {
     // React.StrictMode double-invokes effects in dev — dedupe so a single
     // boundary error doesn't write twice.
     const logged = useRef(new Set<string | Error>());

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,11 +1,22 @@
 'use client';
 
+import { log } from '@/lib/logger/client';
+import { useEffect } from 'react';
+
 export default function GlobalError({
+    error,
     reset,
 }: {
     error: Error & { digest?: string };
     reset: () => void;
 }) {
+    useEffect(() => {
+        log.error(
+            { err: error, digest: error.digest },
+            error.message || 'global error boundary'
+        );
+    }, [error]);
+
     return (
         <html lang="en">
             <body>

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,15 +1,18 @@
 'use client';
 
-import { log } from '@/lib/logger/client';
 import { useEffect, useRef } from 'react';
+
+import { log } from '@/lib/logger/client';
+
+interface GlobalErrorProps {
+    error: Error & { digest?: string };
+    reset: () => void;
+}
 
 export default function GlobalError({
     error,
     reset,
-}: {
-    error: Error & { digest?: string };
-    reset: () => void;
-}) {
+}: GlobalErrorProps): React.ReactElement {
     // React.StrictMode double-invokes effects in dev — dedupe so a single
     // boundary error doesn't write twice.
     const logged = useRef(new Set<string | Error>());

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -10,9 +10,8 @@ export default function GlobalError({
     error: Error & { digest?: string };
     reset: () => void;
 }) {
-    // Dedupe against React.StrictMode's dev-mode double-invocation of
-    // effects: without this, a single boundary error writes two `.dev.log`
-    // entries.
+    // React.StrictMode double-invokes effects in dev — dedupe so a single
+    // boundary error doesn't write twice.
     const logged = useRef(new Set<string | Error>());
     useEffect(() => {
         const key = error.digest ?? error;

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { log } from '@/lib/logger/client';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export default function GlobalError({
     error,
@@ -10,7 +10,14 @@ export default function GlobalError({
     error: Error & { digest?: string };
     reset: () => void;
 }) {
+    // Dedupe against React.StrictMode's dev-mode double-invocation of
+    // effects: without this, a single boundary error writes two `.dev.log`
+    // entries.
+    const logged = useRef(new Set<string | Error>());
     useEffect(() => {
+        const key = error.digest ?? error;
+        if (logged.current.has(key)) return;
+        logged.current.add(key);
         log.error(
             { err: error, digest: error.digest },
             error.message || 'global error boundary'

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,3 +1,4 @@
+import { ClientErrorReporter } from '@/components/ClientErrorReporter';
 import { ThemeProvider } from '@/components/theme-provider';
 import { TRPCReactProvider } from '@/lib/trpc/client';
 import { Analytics } from '@vercel/analytics/next';
@@ -39,7 +40,10 @@ export default function RootLayout({
                     enableSystem
                     disableTransitionOnChange
                 >
-                    <TRPCReactProvider>{children}</TRPCReactProvider>
+                    <TRPCReactProvider>
+                        <ClientErrorReporter />
+                        {children}
+                    </TRPCReactProvider>
                 </ThemeProvider>
                 <Toaster />
                 <Analytics />

--- a/apps/web/components/ClientErrorReporter.test.tsx
+++ b/apps/web/components/ClientErrorReporter.test.tsx
@@ -33,7 +33,7 @@ describe('ClientErrorReporter', () => {
         cleanup();
     });
 
-    it('updates client log context with userId and page on mount', () => {
+    it('updates client log context with userId and page during render', () => {
         hoisted.useSessionMock.mockReturnValue({
             data: { user: { id: 'user-7' } },
         });
@@ -44,6 +44,24 @@ describe('ClientErrorReporter', () => {
         expect(hoisted.setClientLogContextMock).toHaveBeenCalledWith({
             userId: 'user-7',
             page: '/dashboard/files',
+        });
+    });
+
+    it('re-fires setClientLogContext when session or pathname changes', () => {
+        hoisted.useSessionMock.mockReturnValue({ data: null });
+        hoisted.usePathnameMock.mockReturnValue('/');
+        const { rerender } = render(<ClientErrorReporter />);
+
+        hoisted.setClientLogContextMock.mockClear();
+        hoisted.useSessionMock.mockReturnValue({
+            data: { user: { id: 'user-9' } },
+        });
+        hoisted.usePathnameMock.mockReturnValue('/dashboard');
+        rerender(<ClientErrorReporter />);
+
+        expect(hoisted.setClientLogContextMock).toHaveBeenCalledWith({
+            userId: 'user-9',
+            page: '/dashboard',
         });
     });
 
@@ -76,17 +94,38 @@ describe('ClientErrorReporter', () => {
         render(<ClientErrorReporter />);
 
         const err = new Error('rejected');
-        const event = new Event('unhandledrejection') as PromiseRejectionEvent;
-        Object.defineProperty(event, 'reason', { value: err });
-        Object.defineProperty(event, 'promise', {
-            value: Promise.reject(err).catch(() => {}),
-        });
-        window.dispatchEvent(event);
+        dispatchRejection(err);
 
         expect(hoisted.logErrorMock).toHaveBeenCalledOnce();
         const [meta, msg] = hoisted.logErrorMock.mock.calls[0]!;
-        expect(meta).toMatchObject({ err, reason: err });
+        expect(meta).toMatchObject({ err });
+        expect(meta.reason).toBeUndefined();
         expect(msg).toBe('rejected');
+    });
+
+    it('logs unhandled promise rejections with a string reason', () => {
+        render(<ClientErrorReporter />);
+
+        dispatchRejection('quota exceeded');
+
+        expect(hoisted.logErrorMock).toHaveBeenCalledOnce();
+        const [meta, msg] = hoisted.logErrorMock.mock.calls[0]!;
+        expect(meta).toMatchObject({ reason: 'quota exceeded' });
+        expect(meta.err).toBeUndefined();
+        expect(msg).toBe('quota exceeded');
+    });
+
+    it('logs unhandled promise rejections with a non-Error object reason', () => {
+        render(<ClientErrorReporter />);
+
+        const reason = { code: 'INVALID', detail: 'nope' };
+        dispatchRejection(reason);
+
+        expect(hoisted.logErrorMock).toHaveBeenCalledOnce();
+        const [meta, msg] = hoisted.logErrorMock.mock.calls[0]!;
+        expect(meta).toMatchObject({ reason });
+        expect(meta.err).toBeUndefined();
+        expect(msg).toBe('unhandled promise rejection');
     });
 
     it('removes listeners on unmount', () => {
@@ -100,3 +139,12 @@ describe('ClientErrorReporter', () => {
         expect(hoisted.logErrorMock).not.toHaveBeenCalled();
     });
 });
+
+function dispatchRejection(reason: unknown): void {
+    const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+    Object.defineProperty(event, 'reason', { value: reason });
+    Object.defineProperty(event, 'promise', {
+        value: Promise.reject(reason).catch(() => {}),
+    });
+    window.dispatchEvent(event);
+}

--- a/apps/web/components/ClientErrorReporter.test.tsx
+++ b/apps/web/components/ClientErrorReporter.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+    logErrorMock: vi.fn(),
+    setClientLogContextMock: vi.fn(),
+    useSessionMock: vi.fn(),
+    usePathnameMock: vi.fn(),
+}));
+
+vi.mock('@/lib/logger/client', () => ({
+    log: { error: hoisted.logErrorMock },
+    setClientLogContext: hoisted.setClientLogContextMock,
+}));
+vi.mock('@/lib/auth/client', () => ({
+    useSession: () => hoisted.useSessionMock(),
+}));
+vi.mock('next/navigation', () => ({
+    usePathname: () => hoisted.usePathnameMock(),
+}));
+
+import { ClientErrorReporter } from './ClientErrorReporter';
+
+describe('ClientErrorReporter', () => {
+    beforeEach(() => {
+        hoisted.logErrorMock.mockClear();
+        hoisted.setClientLogContextMock.mockClear();
+        hoisted.useSessionMock.mockReturnValue({ data: null });
+        hoisted.usePathnameMock.mockReturnValue('/');
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('updates client log context with userId and page on mount', () => {
+        hoisted.useSessionMock.mockReturnValue({
+            data: { user: { id: 'user-7' } },
+        });
+        hoisted.usePathnameMock.mockReturnValue('/dashboard/files');
+
+        render(<ClientErrorReporter />);
+
+        expect(hoisted.setClientLogContextMock).toHaveBeenCalledWith({
+            userId: 'user-7',
+            page: '/dashboard/files',
+        });
+    });
+
+    it('logs uncaught window errors', () => {
+        render(<ClientErrorReporter />);
+
+        const err = new Error('boom');
+        window.dispatchEvent(
+            new ErrorEvent('error', {
+                message: 'boom',
+                error: err,
+                filename: 'app.js',
+                lineno: 42,
+                colno: 7,
+            })
+        );
+
+        expect(hoisted.logErrorMock).toHaveBeenCalledOnce();
+        const [meta, msg] = hoisted.logErrorMock.mock.calls[0]!;
+        expect(meta).toMatchObject({
+            err,
+            source: 'app.js',
+            line: 42,
+            col: 7,
+        });
+        expect(msg).toBe('boom');
+    });
+
+    it('logs unhandled promise rejections with an Error reason', () => {
+        render(<ClientErrorReporter />);
+
+        const err = new Error('rejected');
+        const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+        Object.defineProperty(event, 'reason', { value: err });
+        Object.defineProperty(event, 'promise', {
+            value: Promise.reject(err).catch(() => {}),
+        });
+        window.dispatchEvent(event);
+
+        expect(hoisted.logErrorMock).toHaveBeenCalledOnce();
+        const [meta, msg] = hoisted.logErrorMock.mock.calls[0]!;
+        expect(meta).toMatchObject({ err, reason: err });
+        expect(msg).toBe('rejected');
+    });
+
+    it('removes listeners on unmount', () => {
+        const { unmount } = render(<ClientErrorReporter />);
+        unmount();
+
+        window.dispatchEvent(
+            new ErrorEvent('error', { message: 'after unmount' })
+        );
+
+        expect(hoisted.logErrorMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/components/ClientErrorReporter.tsx
+++ b/apps/web/components/ClientErrorReporter.tsx
@@ -11,9 +11,11 @@ export function ClientErrorReporter(): null {
     const pathname = usePathname();
     const userId = session?.user?.id;
 
-    useEffect(() => {
-        setClientLogContext({ userId, page: pathname });
-    }, [userId, pathname]);
+    // Update during render (not in useEffect) so an error thrown by a
+    // sibling's first render — the case error.tsx is here to handle — still
+    // transmits with the right userId/page bindings. The setter is
+    // idempotent, so StrictMode double-renders are harmless.
+    setClientLogContext({ userId, page: pathname });
 
     useEffect(() => {
         function handleError(event: ErrorEvent): void {
@@ -30,16 +32,18 @@ export function ClientErrorReporter(): null {
 
         function handleRejection(event: PromiseRejectionEvent): void {
             const reason = event.reason;
+            if (reason instanceof Error) {
+                log.error(
+                    { err: reason },
+                    reason.message || 'unhandled promise rejection'
+                );
+                return;
+            }
             const message =
-                reason instanceof Error
-                    ? reason.message
-                    : typeof reason === 'string'
-                      ? reason
-                      : 'unhandled promise rejection';
-            log.error(
-                { err: reason instanceof Error ? reason : undefined, reason },
-                message
-            );
+                typeof reason === 'string'
+                    ? reason
+                    : 'unhandled promise rejection';
+            log.error({ reason }, message);
         }
 
         window.addEventListener('error', handleError);

--- a/apps/web/components/ClientErrorReporter.tsx
+++ b/apps/web/components/ClientErrorReporter.tsx
@@ -13,9 +13,15 @@ export function ClientErrorReporter(): null {
 
     // Update during render (not in useEffect) so an error thrown by a
     // sibling's first render — the case error.tsx is here to handle — still
-    // transmits with the right userId/page bindings. The setter is
-    // idempotent, so StrictMode double-renders are harmless.
-    setClientLogContext({ userId, page: pathname });
+    // transmits with the right userId/page bindings. Guard for SSR: this
+    // file is also rendered on the server for initial HTML, and the
+    // singleton in `lib/logger/client` is shared across concurrent
+    // requests in the same Node process — mutating it server-side would
+    // leak the most recent request's user across requests if anything
+    // ever reads `context` on the server.
+    if (typeof window !== 'undefined') {
+        setClientLogContext({ userId, page: pathname });
+    }
 
     useEffect(() => {
         function handleError(event: ErrorEvent): void {

--- a/apps/web/components/ClientErrorReporter.tsx
+++ b/apps/web/components/ClientErrorReporter.tsx
@@ -11,14 +11,10 @@ export function ClientErrorReporter(): null {
     const pathname = usePathname();
     const userId = session?.user?.id;
 
-    // Update during render (not in useEffect) so an error thrown by a
-    // sibling's first render — the case error.tsx is here to handle — still
-    // transmits with the right userId/page bindings. Guard for SSR: this
-    // file is also rendered on the server for initial HTML, and the
-    // singleton in `lib/logger/client` is shared across concurrent
-    // requests in the same Node process — mutating it server-side would
-    // leak the most recent request's user across requests if anything
-    // ever reads `context` on the server.
+    // Set during render so first-render errors still transmit with
+    // bindings — useEffect would fire too late. SSR-guarded because the
+    // singleton is shared across concurrent server requests in the same
+    // Node process.
     if (typeof window !== 'undefined') {
         setClientLogContext({ userId, page: pathname });
     }

--- a/apps/web/components/ClientErrorReporter.tsx
+++ b/apps/web/components/ClientErrorReporter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
 
 import { useSession } from '@/lib/auth/client';
 import { log, setClientLogContext } from '@/lib/logger/client';

--- a/apps/web/components/ClientErrorReporter.tsx
+++ b/apps/web/components/ClientErrorReporter.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { useSession } from '@/lib/auth/client';
+import { log, setClientLogContext } from '@/lib/logger/client';
+
+export function ClientErrorReporter(): null {
+    const { data: session } = useSession();
+    const pathname = usePathname();
+    const userId = session?.user?.id;
+
+    useEffect(() => {
+        setClientLogContext({ userId, page: pathname });
+    }, [userId, pathname]);
+
+    useEffect(() => {
+        function handleError(event: ErrorEvent): void {
+            log.error(
+                {
+                    err: event.error,
+                    source: event.filename,
+                    line: event.lineno,
+                    col: event.colno,
+                },
+                event.message || 'uncaught error'
+            );
+        }
+
+        function handleRejection(event: PromiseRejectionEvent): void {
+            const reason = event.reason;
+            const message =
+                reason instanceof Error
+                    ? reason.message
+                    : typeof reason === 'string'
+                      ? reason
+                      : 'unhandled promise rejection';
+            log.error(
+                { err: reason instanceof Error ? reason : undefined, reason },
+                message
+            );
+        }
+
+        window.addEventListener('error', handleError);
+        window.addEventListener('unhandledrejection', handleRejection);
+
+        return () => {
+            window.removeEventListener('error', handleError);
+            window.removeEventListener('unhandledrejection', handleRejection);
+        };
+    }, []);
+
+    return null;
+}

--- a/apps/web/lib/logger/client.test.ts
+++ b/apps/web/lib/logger/client.test.ts
@@ -1,0 +1,80 @@
+import type { LogEvent } from 'pino';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setClientLogContext, transmitToDevServer } from './client';
+
+function makeLogEvent(overrides: Partial<LogEvent> = {}): LogEvent {
+    return {
+        ts: Date.now(),
+        messages: ['boom'],
+        bindings: [],
+        level: { label: 'error', value: 50 },
+        ...overrides,
+    };
+}
+
+const fetchMock = vi.fn(() => Promise.resolve(new Response()));
+
+describe('transmitToDevServer', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', fetchMock);
+        vi.stubEnv('NODE_ENV', 'development');
+        fetchMock.mockClear();
+        // Reset context between tests
+        setClientLogContext({ userId: undefined, page: undefined });
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+    });
+
+    it('POSTs the log event to /api/dev-log in development', () => {
+        transmitToDevServer('error', makeLogEvent());
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const [url, init] = fetchMock.mock.calls[0]!;
+        expect(url).toBe('/api/dev-log');
+        expect(init?.method).toBe('POST');
+        expect(init?.headers).toMatchObject({
+            'Content-Type': 'application/json',
+        });
+    });
+
+    it('does not POST in production', () => {
+        vi.stubEnv('NODE_ENV', 'production');
+
+        transmitToDevServer('error', makeLogEvent());
+
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('appends setClientLogContext bindings to the transmitted event', () => {
+        setClientLogContext({ userId: 'user-123', page: '/dashboard' });
+
+        transmitToDevServer('error', makeLogEvent({ bindings: [{ a: 1 }] }));
+
+        const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+        expect(body.bindings).toEqual([
+            { a: 1 },
+            { userId: 'user-123', page: '/dashboard' },
+        ]);
+    });
+
+    it('updates context across calls (latest wins per key)', () => {
+        setClientLogContext({ userId: 'user-1', page: '/a' });
+        setClientLogContext({ page: '/b' });
+
+        transmitToDevServer('error', makeLogEvent());
+
+        const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+        const merged = body.bindings.reduce(
+            (acc: Record<string, unknown>, b: Record<string, unknown>) => ({
+                ...acc,
+                ...b,
+            }),
+            {}
+        );
+        expect(merged).toMatchObject({ userId: 'user-1', page: '/b' });
+    });
+});

--- a/apps/web/lib/logger/client.test.ts
+++ b/apps/web/lib/logger/client.test.ts
@@ -1,7 +1,11 @@
 import type { LogEvent } from 'pino';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { setClientLogContext, transmitToDevServer } from './client';
+import {
+    resetClientLogContext,
+    setClientLogContext,
+    transmitToDevServer,
+} from './client';
 
 function makeLogEvent(overrides: Partial<LogEvent> = {}): LogEvent {
     return {
@@ -13,15 +17,25 @@ function makeLogEvent(overrides: Partial<LogEvent> = {}): LogEvent {
     };
 }
 
+function getMergedBindings(callIndex = 0): Record<string, unknown> {
+    const body = JSON.parse(String(fetchMock.mock.calls[callIndex]![1]?.body));
+    return body.bindings.reduce(
+        (acc: Record<string, unknown>, b: Record<string, unknown>) => ({
+            ...acc,
+            ...b,
+        }),
+        {}
+    );
+}
+
 const fetchMock = vi.fn(() => Promise.resolve(new Response()));
 
-describe('transmitToDevServer', () => {
+describe('client logger', () => {
     beforeEach(() => {
         vi.stubGlobal('fetch', fetchMock);
         vi.stubEnv('NODE_ENV', 'development');
         fetchMock.mockClear();
-        // Reset context between tests
-        setClientLogContext({ userId: undefined, page: undefined });
+        resetClientLogContext();
     });
 
     afterEach(() => {
@@ -29,52 +43,86 @@ describe('transmitToDevServer', () => {
         vi.unstubAllGlobals();
     });
 
-    it('POSTs the log event to /api/dev-log in development', () => {
-        transmitToDevServer('error', makeLogEvent());
+    describe('transmitToDevServer', () => {
+        it('POSTs the log event to /api/dev-log in development', () => {
+            transmitToDevServer('error', makeLogEvent());
 
-        expect(fetchMock).toHaveBeenCalledOnce();
-        const [url, init] = fetchMock.mock.calls[0]!;
-        expect(url).toBe('/api/dev-log');
-        expect(init?.method).toBe('POST');
-        expect(init?.headers).toMatchObject({
-            'Content-Type': 'application/json',
+            expect(fetchMock).toHaveBeenCalledOnce();
+            const [url, init] = fetchMock.mock.calls[0]!;
+            expect(url).toBe('/api/dev-log');
+            expect(init?.method).toBe('POST');
+            expect(init?.headers).toMatchObject({
+                'Content-Type': 'application/json',
+            });
+        });
+
+        it('does not POST in production', () => {
+            vi.stubEnv('NODE_ENV', 'production');
+
+            transmitToDevServer('error', makeLogEvent());
+
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('appends setClientLogContext bindings to the transmitted event', () => {
+            setClientLogContext({ userId: 'user-123', page: '/dashboard' });
+
+            transmitToDevServer(
+                'error',
+                makeLogEvent({ bindings: [{ a: 1 }] })
+            );
+
+            const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+            expect(body.bindings).toEqual([
+                { a: 1 },
+                { userId: 'user-123', page: '/dashboard' },
+            ]);
+        });
+
+        it('swallows fetch rejections so logging never throws', () => {
+            fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+            expect(() =>
+                transmitToDevServer('error', makeLogEvent())
+            ).not.toThrow();
         });
     });
 
-    it('does not POST in production', () => {
-        vi.stubEnv('NODE_ENV', 'production');
+    describe('setClientLogContext', () => {
+        it('updates context across calls (latest wins per key)', () => {
+            setClientLogContext({ userId: 'user-1', page: '/a' });
+            setClientLogContext({ page: '/b' });
 
-        transmitToDevServer('error', makeLogEvent());
+            transmitToDevServer('error', makeLogEvent());
 
-        expect(fetchMock).not.toHaveBeenCalled();
+            expect(getMergedBindings()).toMatchObject({
+                userId: 'user-1',
+                page: '/b',
+            });
+        });
+
+        it('deletes a key when set to undefined (sign-out flow)', () => {
+            setClientLogContext({ userId: 'user-1', page: '/a' });
+            setClientLogContext({ userId: undefined });
+
+            transmitToDevServer('error', makeLogEvent());
+
+            const merged = getMergedBindings();
+            expect(merged).not.toHaveProperty('userId');
+            expect(merged).toMatchObject({ page: '/a' });
+        });
     });
 
-    it('appends setClientLogContext bindings to the transmitted event', () => {
-        setClientLogContext({ userId: 'user-123', page: '/dashboard' });
+    describe('resetClientLogContext', () => {
+        it('clears all bindings', () => {
+            setClientLogContext({ userId: 'user-1', page: '/a' });
+            resetClientLogContext();
 
-        transmitToDevServer('error', makeLogEvent({ bindings: [{ a: 1 }] }));
+            transmitToDevServer('error', makeLogEvent());
 
-        const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
-        expect(body.bindings).toEqual([
-            { a: 1 },
-            { userId: 'user-123', page: '/dashboard' },
-        ]);
-    });
-
-    it('updates context across calls (latest wins per key)', () => {
-        setClientLogContext({ userId: 'user-1', page: '/a' });
-        setClientLogContext({ page: '/b' });
-
-        transmitToDevServer('error', makeLogEvent());
-
-        const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
-        const merged = body.bindings.reduce(
-            (acc: Record<string, unknown>, b: Record<string, unknown>) => ({
-                ...acc,
-                ...b,
-            }),
-            {}
-        );
-        expect(merged).toMatchObject({ userId: 'user-1', page: '/b' });
+            const merged = getMergedBindings();
+            expect(merged).not.toHaveProperty('userId');
+            expect(merged).not.toHaveProperty('page');
+        });
     });
 });

--- a/apps/web/lib/logger/client.ts
+++ b/apps/web/lib/logger/client.ts
@@ -9,10 +9,9 @@ type ClientLogContext = {
 
 let context: ClientLogContext = {};
 
-// Singleton + setter rather than pino's `child()` because the four call
-// sites (cache.onError, error.tsx, global-error.tsx, window listeners)
-// span render and effect boundaries and can't all hold a React-bound
-// logger reference reaching session/pathname hooks.
+// Singleton + setter rather than pino `child()` so non-React call sites
+// (cache hooks, window listeners) can read context without holding a
+// React-bound logger reference.
 export function setClientLogContext(next: ClientLogContext): void {
     const merged: ClientLogContext = { ...context };
     for (const key of Object.keys(next) as (keyof ClientLogContext)[]) {
@@ -30,9 +29,8 @@ export function resetClientLogContext(): void {
     context = {};
 }
 
-// Exported so tests can drive it directly: pino's `browser` config is ignored
-// when this module is imported under Node (vitest), so we can't observe
-// transmit through the `log` instance.
+// Exported for tests: pino's `browser` config is ignored when this
+// module is imported under Node, so transmit can't be driven via `log`.
 export function transmitToDevServer(_level: string, logEvent: LogEvent): void {
     if (process.env.NODE_ENV !== 'development') return;
 
@@ -54,10 +52,9 @@ export const log = pino({
         transmit: { send: transmitToDevServer },
     },
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
-    // Silences pino's Node transport during SSR / vitest. Under Node,
-    // pino's package.json `browser` redirect doesn't apply, so the server
-    // build is loaded and `log.error(...)` would otherwise write JSON to
-    // stdout. Browser transmit is not affected by this flag — that's
-    // gated by the `NODE_ENV` check inside `transmitToDevServer`.
+    // Silences pino's Node transport (loaded under SSR/vitest because
+    // pino's `browser` redirect only applies in the browser bundle).
+    // Does NOT gate browser transmit — that's handled by the `NODE_ENV`
+    // check inside `transmitToDevServer`.
     enabled: typeof window !== 'undefined',
 });

--- a/apps/web/lib/logger/client.ts
+++ b/apps/web/lib/logger/client.ts
@@ -54,4 +54,10 @@ export const log = pino({
         transmit: { send: transmitToDevServer },
     },
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
+    // Silences pino's Node transport during SSR / vitest. Under Node,
+    // pino's package.json `browser` redirect doesn't apply, so the server
+    // build is loaded and `log.error(...)` would otherwise write JSON to
+    // stdout. Browser transmit is not affected by this flag — that's
+    // gated by the `NODE_ENV` check inside `transmitToDevServer`.
+    enabled: typeof window !== 'undefined',
 });

--- a/apps/web/lib/logger/client.ts
+++ b/apps/web/lib/logger/client.ts
@@ -9,8 +9,25 @@ type ClientLogContext = {
 
 let context: ClientLogContext = {};
 
+// Singleton + setter rather than pino's `child()` because the four call
+// sites (cache.onError, error.tsx, global-error.tsx, window listeners)
+// span render and effect boundaries and can't all hold a React-bound
+// logger reference reaching session/pathname hooks.
 export function setClientLogContext(next: ClientLogContext): void {
-    context = { ...context, ...next };
+    const merged: ClientLogContext = { ...context };
+    for (const key of Object.keys(next) as (keyof ClientLogContext)[]) {
+        const value = next[key];
+        if (value === undefined) {
+            delete merged[key];
+        } else {
+            merged[key] = value;
+        }
+    }
+    context = merged;
+}
+
+export function resetClientLogContext(): void {
+    context = {};
 }
 
 // Exported so tests can drive it directly: pino's `browser` config is ignored
@@ -28,9 +45,7 @@ export function transmitToDevServer(_level: string, logEvent: LogEvent): void {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(enriched),
-    }).catch(() => {
-        // Silently ignore errors - we don't want logging to break the app
-    });
+    }).catch(() => {});
 }
 
 export const log = pino({
@@ -39,5 +54,4 @@ export const log = pino({
         transmit: { send: transmitToDevServer },
     },
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
-    enabled: typeof window !== 'undefined',
 });

--- a/apps/web/lib/logger/client.ts
+++ b/apps/web/lib/logger/client.ts
@@ -2,13 +2,32 @@
 
 import pino, { type LogEvent } from 'pino';
 
-function sendToDevServer(_level: string, logEvent: LogEvent): void {
+type ClientLogContext = {
+    userId?: string;
+    page?: string;
+};
+
+let context: ClientLogContext = {};
+
+export function setClientLogContext(next: ClientLogContext): void {
+    context = { ...context, ...next };
+}
+
+// Exported so tests can drive it directly: pino's `browser` config is ignored
+// when this module is imported under Node (vitest), so we can't observe
+// transmit through the `log` instance.
+export function transmitToDevServer(_level: string, logEvent: LogEvent): void {
     if (process.env.NODE_ENV !== 'development') return;
+
+    const enriched: LogEvent = {
+        ...logEvent,
+        bindings: [...logEvent.bindings, { ...context }],
+    };
 
     fetch('/api/dev-log', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(logEvent),
+        body: JSON.stringify(enriched),
     }).catch(() => {
         // Silently ignore errors - we don't want logging to break the app
     });
@@ -17,9 +36,7 @@ function sendToDevServer(_level: string, logEvent: LogEvent): void {
 export const log = pino({
     browser: {
         asObject: true,
-        transmit: {
-            send: sendToDevServer,
-        },
+        transmit: { send: transmitToDevServer },
     },
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
     enabled: typeof window !== 'undefined',

--- a/apps/web/lib/trpc/query-client.test.ts
+++ b/apps/web/lib/trpc/query-client.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({ logErrorMock: vi.fn() }));
+
+vi.mock('@/lib/logger/client', () => ({
+    log: { error: hoisted.logErrorMock },
+}));
+
+import { QueryClient } from '@tanstack/react-query';
+import { makeQueryClient } from './query-client';
+
+describe('makeQueryClient', () => {
+    it('logs query errors via QueryCache.onError', async () => {
+        hoisted.logErrorMock.mockClear();
+        const client: QueryClient = makeQueryClient();
+
+        const error = new Error('Query data cannot be undefined.');
+        await client
+            .fetchQuery({
+                queryKey: ['foo'],
+                queryFn: () => {
+                    throw error;
+                },
+                retry: false,
+            })
+            .catch(() => {});
+
+        expect(hoisted.logErrorMock).toHaveBeenCalledOnce();
+        const [meta, msg] = hoisted.logErrorMock.mock.calls[0]!;
+        expect(meta).toMatchObject({ err: error, queryKey: ['foo'] });
+        expect(msg).toBe('Query data cannot be undefined.');
+    });
+
+    it('logs mutation errors via MutationCache.onError', async () => {
+        hoisted.logErrorMock.mockClear();
+        const client: QueryClient = makeQueryClient();
+
+        const error = new Error('mutation failed');
+        await client
+            .getMutationCache()
+            .build(client, {
+                mutationKey: ['createThing'],
+                mutationFn: () => {
+                    throw error;
+                },
+                retry: false,
+            })
+            .execute(undefined)
+            .catch(() => {});
+
+        expect(hoisted.logErrorMock).toHaveBeenCalledOnce();
+        const [meta, msg] = hoisted.logErrorMock.mock.calls[0]!;
+        expect(meta).toMatchObject({
+            err: error,
+            mutationKey: ['createThing'],
+        });
+        expect(msg).toBe('mutation failed');
+    });
+});

--- a/apps/web/lib/trpc/query-client.ts
+++ b/apps/web/lib/trpc/query-client.ts
@@ -1,11 +1,29 @@
-import { QueryClient } from '@tanstack/react-query';
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
 
-export function makeQueryClient() {
+import { log } from '@/lib/logger/client';
+
+export function makeQueryClient(): QueryClient {
     return new QueryClient({
         defaultOptions: {
             queries: {
                 staleTime: 60 * 1000,
             },
         },
+        queryCache: new QueryCache({
+            onError(error, query) {
+                log.error(
+                    { err: error, queryKey: query.queryKey },
+                    error.message || 'query error'
+                );
+            },
+        }),
+        mutationCache: new MutationCache({
+            onError(error, _variables, _context, mutation) {
+                log.error(
+                    { err: error, mutationKey: mutation.options.mutationKey },
+                    error.message || 'mutation error'
+                );
+            },
+        }),
     });
 }


### PR DESCRIPTION
## Summary

Wires browser errors into the existing pino dev-log forwarder added in #9 (which explicitly listed error-boundary integration as out of scope). The plumbing was there — `lib/logger/client.ts`, `/api/dev-log` route, `.dev.log` writer — but nothing actually emitted client errors into it. Result: a React Query "Query data cannot be undefined" error printed to the browser console without ever reaching `.dev.log`.

## Coverage

| Layer | Hook | Catches |
|---|---|---|
| React Query | `QueryCache.onError` / `MutationCache.onError` in `query-client.ts` | All query/mutation errors (tRPC and non-tRPC). All tRPC traffic flows through React Query in this app. |
| Route boundary | `app/error.tsx` | Render errors caught by Next.js route boundary |
| Root boundary | `app/global-error.tsx` | Render errors below root layout |
| Window | `<ClientErrorReporter />` | Uncaught `error` events + `unhandledrejection` |

Every forwarded event also carries `userId` (from `useSession`) and `page` (from `usePathname`) bindings so the server-side `.dev.log` line includes session + route context.

## Design notes

- **Why log only at `cache.onError` (not `errorLink`)**: `errorLink` already handles toasts; logging there *and* in cache would double-count every tRPC error. Cache is the broader sink (catches non-tRPC errors too, including the motivating "data undefined" case).
- **Why `transmitToDevServer` is exported**: pino's `browser` config is ignored when the module is imported under Node (vitest), so transmit can't be observed through the `log` instance. Exporting the transmit function lets us drive it directly in tests.
- **Production behavior**: unchanged. `transmitToDevServer` no-ops when `NODE_ENV !== 'development'`; `/api/dev-log` returns 404. When we eventually swap pino → Sentry, only `transmitToDevServer` needs replacing.

## Test plan

- [x] `pnpm check` passes (10/10 tasks)
- [x] `pnpm -F web test` passes (236 tests, 10 new)
- [x] `pnpm -F web test:e2e:smoke` passes (15/15)
- [x] `curl -X POST /api/dev-log` with bindings → `.dev.log` line carries `source: 'client'` + merged `userId` / `page`
- [ ] Reload the settings page on PR #215's branch (with this branch merged in) → confirm "Query data cannot be undefined" appears in `.dev.log` with the right user + page bindings

## Out of Scope

- Source-mapped browser stack traces (server-side already source-maps via the existing patch; client-side requires a separate transport).
- Sentry / production error capture — single-call-site swap when ready.
- Console method monkey-patching for stray `console.error` calls.

No-Issue: follow-up to #9 OOS section