### PR TITLE
feat: storage quota enforcement (#22)

### DIFF
--- a/apps/web/server/errors.test.ts
+++ b/apps/web/server/errors.test.ts
@@ -53,7 +53,13 @@ describe('DomainError', () => {
         expect(new NotFoundError('File').name).toBe('NotFoundError');
         expect(new ForbiddenError().name).toBe('ForbiddenError');
         expect(new InvalidStateError('msg').name).toBe('InvalidStateError');
-        expect(new QuotaExceededError().name).toBe('QuotaExceededError');
+        expect(
+            new QuotaExceededError({
+                usedBytes: 0,
+                limitBytes: 0,
+                requestedBytes: 0,
+            }).name
+        ).toBe('QuotaExceededError');
         expect(new TrialExpiredError().name).toBe('TrialExpiredError');
     });
 });
@@ -130,27 +136,34 @@ describe('InvalidStateError', () => {
 });
 
 describe('QuotaExceededError', () => {
+    const details = {
+        usedBytes: 1000,
+        limitBytes: 2000,
+        requestedBytes: 1500,
+    };
+
     it('declares a static code matching the registry', () => {
         expect(QuotaExceededError.code).toBe(DOMAIN_ERROR_CODES.QUOTA_EXCEEDED);
     });
 
     it('maps to PRECONDITION_FAILED tRPC code and QUOTA_EXCEEDED domain code', () => {
-        const error = new QuotaExceededError();
+        const error = new QuotaExceededError(details);
 
         expect(error.trpcCode).toBe('PRECONDITION_FAILED');
         expect(error.code).toBe('QUOTA_EXCEEDED');
     });
 
-    it('uses default message when none provided', () => {
-        const error = new QuotaExceededError();
+    it('exposes the QuotaDetails as a structured field', () => {
+        const error = new QuotaExceededError(details);
 
-        expect(error.message).toBe('Quota exceeded');
+        expect(error.details).toEqual(details);
     });
 
-    it('uses custom message when provided', () => {
-        const error = new QuotaExceededError('Storage quota exceeded');
+    it('renders a message containing all three byte counts', () => {
+        const error = new QuotaExceededError(details);
 
-        expect(error.message).toBe('Storage quota exceeded');
+        expect(error.message).toContain('1000/2000');
+        expect(error.message).toContain('1500');
     });
 });
 
@@ -184,7 +197,15 @@ describe('isDomainError', () => {
         expect(isDomainError(new NotFoundError('File'))).toBe(true);
         expect(isDomainError(new ForbiddenError())).toBe(true);
         expect(isDomainError(new InvalidStateError('msg'))).toBe(true);
-        expect(isDomainError(new QuotaExceededError())).toBe(true);
+        expect(
+            isDomainError(
+                new QuotaExceededError({
+                    usedBytes: 0,
+                    limitBytes: 0,
+                    requestedBytes: 0,
+                })
+            )
+        ).toBe(true);
         expect(isDomainError(new TrialExpiredError())).toBe(true);
     });
 

--- a/apps/web/server/errors.ts
+++ b/apps/web/server/errors.ts
@@ -51,12 +51,25 @@ export class InvalidStateError extends DomainError {
     }
 }
 
-/** Quota or limit exceeded. */
+/** Quota or limit exceeded. Carries the bytes context the client uses to
+ *  render usage state (e.g. "1.05 TB of 1 TB"). */
+export interface QuotaDetails {
+    usedBytes: number;
+    limitBytes: number;
+    requestedBytes: number;
+}
+
 export class QuotaExceededError extends DomainError {
     static readonly code = DOMAIN_ERROR_CODES.QUOTA_EXCEEDED;
     readonly code = QuotaExceededError.code;
-    constructor(message = 'Quota exceeded') {
-        super(message, 'PRECONDITION_FAILED');
+    readonly details: QuotaDetails;
+
+    constructor(details: QuotaDetails) {
+        super(
+            `Storage quota exceeded: ${details.usedBytes}/${details.limitBytes} used, ${details.requestedBytes} requested`,
+            'PRECONDITION_FAILED'
+        );
+        this.details = details;
     }
 }
 

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -4,6 +4,7 @@ import {
     type MockDb,
     type MockDbMocks,
     createFileFixture,
+    createStorageUsageFixture,
     TEST_USER_ID,
 } from '@nexus/db/testing';
 import { mockS3 } from '@/lib/storage/testing';
@@ -30,11 +31,15 @@ describe('files service', () => {
         mocks = mockDb.mocks;
     });
 
+    function mockUsage(usedBytes = 0) {
+        mocks.storageUsage.findFirst.mockResolvedValue(
+            createStorageUsageFixture({ usedBytes })
+        );
+    }
+
     describe('initiateUpload', () => {
         it('returns fileId, uploadUrl, and expiresAt on success', async () => {
-            // Mock sumStorageBytesByUser to return 0 (under quota)
-            mocks.where.mockResolvedValue([{ total: 0 }]);
-            // Mock insertFile to succeed
+            mockUsage(0);
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
@@ -61,7 +66,8 @@ describe('files service', () => {
         // Smoke test that quota rejection wires through — full branch
         // coverage lives in quota.test.ts.
         it('surfaces QuotaExceededError from the quota check', async () => {
-            mocks.where.mockResolvedValue([{ total: PLAN_LIMITS.starter }]);
+            // Already at 110% of the starter limit — well past the 105% soft cap.
+            mockUsage(Math.floor(PLAN_LIMITS.starter * 1.1));
 
             await expect(
                 fileService.initiateUpload(
@@ -77,7 +83,7 @@ describe('files service', () => {
         });
 
         it('creates file record with status uploading', async () => {
-            mocks.where.mockResolvedValue([{ total: 0 }]);
+            mockUsage(0);
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
@@ -105,7 +111,7 @@ describe('files service', () => {
         });
 
         it('generates S3 key in correct format', async () => {
-            mocks.where.mockResolvedValue([{ total: 0 }]);
+            mockUsage(0);
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
@@ -133,11 +139,22 @@ describe('files service', () => {
     });
 
     describe('confirmUpload', () => {
-        it('returns file with status available', async () => {
-            const uploadingFile = createFileFixture({ status: 'uploading' });
-            const availableFile = createFileFixture({ status: 'available' });
+        it('returns file with status available and increments usage', async () => {
+            const uploadingFile = createFileFixture({
+                status: 'uploading',
+                size: 4096,
+            });
+            const availableFile = createFileFixture({
+                ...uploadingFile,
+                status: 'available',
+            });
             mocks.files.findFirst.mockResolvedValue(uploadingFile);
-            mocks.returning.mockResolvedValue([availableFile]);
+            // Two .returning() calls: file update, then usage upsert.
+            mocks.returning
+                .mockResolvedValueOnce([availableFile])
+                .mockResolvedValueOnce([
+                    createStorageUsageFixture({ usedBytes: 4096 }),
+                ]);
 
             const result = await fileService.confirmUpload(
                 db,
@@ -147,6 +164,30 @@ describe('files service', () => {
 
             expect(result.file).toEqual(availableFile);
             expect(mocks.set).toHaveBeenCalledWith({ status: 'available' });
+            // Increment usage upserts via `insert + onConflictDoUpdate`.
+            expect(mocks.onConflictDoUpdate).toHaveBeenCalledOnce();
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: TEST_USER_ID,
+                    usedBytes: 4096,
+                    fileCount: 1,
+                })
+            );
+        });
+
+        it('is a no-op when the file is already available (no double-count)', async () => {
+            const availableFile = createFileFixture({ status: 'available' });
+            mocks.files.findFirst.mockResolvedValue(availableFile);
+
+            const result = await fileService.confirmUpload(
+                db,
+                TEST_USER_ID,
+                availableFile.id
+            );
+
+            expect(result.file).toEqual(availableFile);
+            expect(mocks.update).not.toHaveBeenCalled();
+            expect(mocks.onConflictDoUpdate).not.toHaveBeenCalled();
         });
 
         it('throws NotFoundError when file does not exist', async () => {
@@ -158,7 +199,7 @@ describe('files service', () => {
         });
 
         it('throws NotFoundError when file belongs to different user', async () => {
-            // findUserFile returns undefined when user doesn't own file
+            // findByUserAndId scopes by both ids, so a wrong user returns undefined
             mocks.files.findFirst.mockResolvedValue(undefined);
 
             await expect(
@@ -169,13 +210,23 @@ describe('files service', () => {
 
     describe('deleteUserFile', () => {
         describe('single file', () => {
-            it('returns soft-deleted file on success', async () => {
+            it('returns soft-deleted file and decrements usage', async () => {
+                const file = createFileFixture({
+                    status: 'available',
+                    size: 2048,
+                });
                 const deletedFile = createFileFixture({
+                    ...file,
                     status: 'deleted',
                     deletedAt: new Date(),
                 });
 
-                mocks.returning.mockResolvedValue([deletedFile]);
+                mocks.files.findMany.mockResolvedValue([file]);
+                mocks.returning
+                    .mockResolvedValueOnce([deletedFile])
+                    .mockResolvedValueOnce([
+                        createStorageUsageFixture({ usedBytes: 0 }),
+                    ]);
 
                 const result = await fileService.deleteUserFile(
                     db,
@@ -184,7 +235,7 @@ describe('files service', () => {
                 );
 
                 expect(result.status).toBe('deleted');
-                expect(mocks.update).toHaveBeenCalledOnce();
+                expect(mocks.update).toHaveBeenCalledTimes(2); // file + usage
                 expect(mocks.set).toHaveBeenCalledWith(
                     expect.objectContaining({
                         status: 'deleted',
@@ -193,7 +244,32 @@ describe('files service', () => {
                 );
             });
 
+            it('skips usage decrement for files still in `uploading`', async () => {
+                const uploadingFile = createFileFixture({
+                    status: 'uploading',
+                    size: 2048,
+                });
+                const deletedFile = createFileFixture({
+                    ...uploadingFile,
+                    status: 'deleted',
+                    deletedAt: new Date(),
+                });
+
+                mocks.files.findMany.mockResolvedValue([uploadingFile]);
+                mocks.returning.mockResolvedValueOnce([deletedFile]);
+
+                await fileService.deleteUserFile(
+                    db,
+                    TEST_USER_ID,
+                    deletedFile.id
+                );
+
+                // Only the file update — no usage decrement.
+                expect(mocks.update).toHaveBeenCalledTimes(1);
+            });
+
             it('throws NotFoundError when file does not exist', async () => {
+                mocks.files.findMany.mockResolvedValue([]);
                 mocks.returning.mockResolvedValue([]);
 
                 await expect(
@@ -206,6 +282,7 @@ describe('files service', () => {
             });
 
             it('throws NotFoundError when user does not own file', async () => {
+                mocks.files.findMany.mockResolvedValue([]);
                 mocks.returning.mockResolvedValue([]);
 
                 await expect(
@@ -215,6 +292,7 @@ describe('files service', () => {
 
             it('throws NotFoundError when file is already deleted', async () => {
                 // WHERE clause excludes status='deleted', so update returns 0 rows
+                mocks.files.findMany.mockResolvedValue([]);
                 mocks.returning.mockResolvedValue([]);
 
                 await expect(
@@ -229,11 +307,26 @@ describe('files service', () => {
 
         describe('multiple files', () => {
             it('returns soft-deleted files on success', async () => {
-                const deletedFiles = [
-                    createFileFixture({ id: 'file1', status: 'deleted' }),
-                    createFileFixture({ id: 'file2', status: 'deleted' }),
+                const beforeFiles = [
+                    createFileFixture({
+                        id: 'file1',
+                        status: 'available',
+                        size: 100,
+                    }),
+                    createFileFixture({
+                        id: 'file2',
+                        status: 'available',
+                        size: 200,
+                    }),
                 ];
-                mocks.returning.mockResolvedValue(deletedFiles);
+                const deletedFiles = beforeFiles.map((f) =>
+                    createFileFixture({ ...f, status: 'deleted' })
+                );
+
+                mocks.files.findMany.mockResolvedValue(beforeFiles);
+                mocks.returning
+                    .mockResolvedValueOnce(deletedFiles)
+                    .mockResolvedValueOnce([createStorageUsageFixture()]);
 
                 const result = await fileService.deleteUserFile(
                     db,
@@ -244,7 +337,8 @@ describe('files service', () => {
                 expect(result).toHaveLength(2);
                 expect(result[0].status).toBe('deleted');
                 expect(result[1].status).toBe('deleted');
-                expect(mocks.update).toHaveBeenCalledOnce();
+                // softDelete + a single batched usage decrement.
+                expect(mocks.update).toHaveBeenCalledTimes(2);
             });
 
             it('returns empty array when given empty ids', async () => {
@@ -259,11 +353,15 @@ describe('files service', () => {
             });
 
             it('throws NotFoundError when any file is not owned by user', async () => {
-                // Only file1 is deleted (file2 not owned by user)
-                const deletedFiles = [
+                // Only file1 was deleted (file2 not owned by user)
+                const file1 = createFileFixture({
+                    id: 'file1',
+                    status: 'available',
+                });
+                mocks.files.findMany.mockResolvedValue([file1]);
+                mocks.returning.mockResolvedValue([
                     createFileFixture({ id: 'file1', status: 'deleted' }),
-                ];
-                mocks.returning.mockResolvedValue(deletedFiles);
+                ]);
 
                 await expect(
                     fileService.deleteUserFile(db, TEST_USER_ID, [
@@ -274,6 +372,7 @@ describe('files service', () => {
             });
 
             it('throws NotFoundError when any file does not exist', async () => {
+                mocks.files.findMany.mockResolvedValue([]);
                 mocks.returning.mockResolvedValue([]);
 
                 await expect(
@@ -287,7 +386,7 @@ describe('files service', () => {
 
     describe('initiateMultipartUpload', () => {
         it('returns fileId, uploadId, partUrls, chunkSize, and expiresAt', async () => {
-            mocks.where.mockResolvedValue([{ total: 0 }]);
+            mockUsage(0);
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
@@ -311,7 +410,7 @@ describe('files service', () => {
 
         // Smoke test — quota logic itself is covered in quota.test.ts.
         it('surfaces QuotaExceededError from the quota check', async () => {
-            mocks.where.mockResolvedValue([{ total: PLAN_LIMITS.starter }]);
+            mockUsage(Math.floor(PLAN_LIMITS.starter * 1.1));
 
             await expect(
                 fileService.initiateMultipartUpload(
@@ -327,7 +426,7 @@ describe('files service', () => {
         });
 
         it('creates file record with status uploading', async () => {
-            mocks.where.mockResolvedValue([{ total: 0 }]);
+            mockUsage(0);
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
@@ -352,7 +451,7 @@ describe('files service', () => {
         });
 
         it('calculates correct part count for exact chunk boundary', async () => {
-            mocks.where.mockResolvedValue([{ total: 0 }]);
+            mockUsage(0);
             const insertedFile = createFileFixture({ status: 'uploading' });
             mocks.returning.mockResolvedValue([insertedFile]);
 
@@ -371,11 +470,21 @@ describe('files service', () => {
     });
 
     describe('completeMultipartUpload', () => {
-        it('transitions file to available status', async () => {
-            const uploadingFile = createFileFixture({ status: 'uploading' });
-            const availableFile = createFileFixture({ status: 'available' });
+        it('transitions file to available status and increments usage', async () => {
+            const uploadingFile = createFileFixture({
+                status: 'uploading',
+                size: 1000,
+            });
+            const availableFile = createFileFixture({
+                ...uploadingFile,
+                status: 'available',
+            });
             mocks.files.findFirst.mockResolvedValue(uploadingFile);
-            mocks.returning.mockResolvedValue([availableFile]);
+            mocks.returning
+                .mockResolvedValueOnce([availableFile])
+                .mockResolvedValueOnce([
+                    createStorageUsageFixture({ usedBytes: 1000 }),
+                ]);
 
             const result = await fileService.completeMultipartUpload(
                 db,
@@ -389,6 +498,7 @@ describe('files service', () => {
 
             expect(result.file.status).toBe('available');
             expect(mocks.set).toHaveBeenCalledWith({ status: 'available' });
+            expect(mocks.onConflictDoUpdate).toHaveBeenCalledOnce();
         });
 
         it('throws NotFoundError when file does not exist', async () => {

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -1,9 +1,10 @@
 import type { DB } from '@nexus/db';
 import { createFileRepo, type File } from '@nexus/db/repo/files';
+import { createStorageUsageRepo } from '@nexus/db/repo/storage-usage';
 import type { Subscription } from '@nexus/db/repo/subscriptions';
 import { NotFoundError, InvalidStateError } from '@/server/errors';
 import { s3 } from '@/lib/storage';
-import { assertUploadAllowed } from './quota';
+import { quotaService } from './quota';
 
 const PRESIGNED_URL_EXPIRY_SECONDS = 900; // 15 minutes
 const MULTIPART_CHUNK_SIZE = 10 * 1024 * 1024; // 10MB
@@ -43,27 +44,13 @@ interface ConfirmUploadResult {
     file: File;
 }
 
-async function assertWithinQuota(
-    db: DB,
-    userId: string,
-    additionalBytes: number,
-    sub: Subscription | undefined
-): Promise<void> {
-    const fileRepo = createFileRepo(db);
-    const currentUsage = await fileRepo.sumStorageByUser(userId);
-    assertUploadAllowed(
-        { currentUsage, subscription: sub ?? null },
-        additionalBytes
-    );
-}
-
 async function initiateUpload(
     db: DB,
     userId: string,
     input: UploadInput,
     sub: Subscription | undefined
 ): Promise<InitiateUploadResult> {
-    await assertWithinQuota(db, userId, input.sizeBytes, sub);
+    await quotaService.checkQuota(db, userId, input.sizeBytes, sub);
 
     const fileRepo = createFileRepo(db);
     const fileId = crypto.randomUUID();
@@ -101,21 +88,31 @@ async function confirmUpload(
     userId: string,
     fileId: string
 ): Promise<ConfirmUploadResult> {
-    const fileRepo = createFileRepo(db);
-    const file = await fileRepo.findByUserAndId(userId, fileId);
-    if (!file) {
-        throw new NotFoundError('File', fileId);
-    }
+    return db.transaction(async (tx) => {
+        const fileRepo = createFileRepo(tx);
+        const usageRepo = createStorageUsageRepo(tx);
 
-    const updated = await fileRepo.update(fileId, {
-        status: 'available',
+        const file = await fileRepo.findByUserAndId(userId, fileId);
+        if (!file) {
+            throw new NotFoundError('File', fileId);
+        }
+        // Idempotency: a duplicate confirm shouldn't double-count usage.
+        // Only flip state and increment when the file is still uploading.
+        if (file.status !== 'uploading') {
+            return { file };
+        }
+
+        const updated = await fileRepo.update(fileId, {
+            status: 'available',
+        });
+        if (!updated) {
+            throw new NotFoundError('File', fileId);
+        }
+
+        await usageRepo.incrementUsage(userId, file.size);
+
+        return { file: updated };
     });
-
-    if (!updated) {
-        throw new NotFoundError('File', fileId);
-    }
-
-    return { file: updated };
 }
 
 async function initiateMultipartUpload(
@@ -124,7 +121,7 @@ async function initiateMultipartUpload(
     input: UploadInput,
     sub: Subscription | undefined
 ): Promise<InitiateMultipartResult> {
-    await assertWithinQuota(db, userId, input.sizeBytes, sub);
+    await quotaService.checkQuota(db, userId, input.sizeBytes, sub);
 
     const fileRepo = createFileRepo(db);
     const fileId = crypto.randomUUID();
@@ -179,17 +176,37 @@ async function completeMultipartUpload(
         );
     }
 
+    // S3 completion happens outside the transaction because it's slow,
+    // network-bound, and not rollback-friendly. The DB write that follows
+    // covers status flip and usage bump atomically.
     await s3.multipart.complete(file.s3Key, input.uploadId, input.parts);
 
-    const updated = await fileRepo.update(input.fileId, {
-        status: 'available',
+    return db.transaction(async (tx) => {
+        const txFileRepo = createFileRepo(tx);
+        const txUsageRepo = createStorageUsageRepo(tx);
+
+        // Idempotency guard inside the txn: a retry after S3 success could
+        // re-enter here with the file already 'available'. Re-fetch under the
+        // tx and short-circuit so we don't double-increment usage.
+        const current = await txFileRepo.findByUserAndId(userId, input.fileId);
+        if (!current) {
+            throw new NotFoundError('File', input.fileId);
+        }
+        if (current.status !== 'uploading') {
+            return { file: current };
+        }
+
+        const updated = await txFileRepo.update(input.fileId, {
+            status: 'available',
+        });
+        if (!updated) {
+            throw new NotFoundError('File', input.fileId);
+        }
+
+        await txUsageRepo.incrementUsage(userId, file.size);
+
+        return { file: updated };
     });
-
-    if (!updated) {
-        throw new NotFoundError('File', input.fileId);
-    }
-
-    return { file: updated };
 }
 
 async function abortMultipartUpload(
@@ -206,6 +223,8 @@ async function abortMultipartUpload(
 
     await s3.multipart.abort(file.s3Key, uploadId);
 
+    // Aborted uploads never made it to `available`, so usage was never
+    // incremented — no decrement needed here.
     await fileRepo.update(fileId, {
         status: 'deleted',
         deletedAt: new Date(),
@@ -228,6 +247,13 @@ async function deleteUserFile(
 
     const deleted = await db.transaction(async (tx) => {
         const fileRepo = createFileRepo(tx);
+        const usageRepo = createStorageUsageRepo(tx);
+
+        // Pre-fetch so we know each file's pre-delete status. Only files that
+        // ever reached `available` (or beyond) were counted in storage_usage —
+        // decrementing for `uploading` files would drift usage negative.
+        const before = await fileRepo.findManyByUserAndIds(userId, fileIds);
+
         const result = await fileRepo.softDeleteForUser(userId, fileIds);
 
         // If count doesn't match, some files were missing or not owned
@@ -235,6 +261,14 @@ async function deleteUserFile(
             const deletedIds = new Set(result.map((f) => f.id));
             const missingId = fileIds.find((id) => !deletedIds.has(id));
             throw new NotFoundError('File', missingId!);
+        }
+
+        // Aggregate counted bytes/count and issue a single UPDATE so a
+        // batch delete (up to 100 files) doesn't fan out into N round-trips.
+        const counted = before.filter((f) => f.status !== 'uploading');
+        if (counted.length > 0) {
+            const totalBytes = counted.reduce((sum, f) => sum + f.size, 0);
+            await usageRepo.decrementUsage(userId, totalBytes, counted.length);
         }
 
         return result;

--- a/apps/web/server/services/quota.test.ts
+++ b/apps/web/server/services/quota.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+    createMockDb,
+    createStorageUsageFixture,
+    type MockDb,
+    type MockDbMocks,
+    TEST_USER_ID,
+} from '@nexus/db/testing';
 import { QuotaExceededError, TrialExpiredError } from '@/server/errors';
 import { PLAN_LIMITS } from './constants';
-import { assertUploadAllowed, type QuotaContext } from './quota';
+import { quotaService, type QuotaContext } from './quota';
 
+const { assertUploadAllowed, checkQuota } = quotaService;
 const oneGB = 1024 ** 3;
 const NOW = new Date('2026-04-18T00:00:00Z');
 
@@ -17,30 +25,26 @@ function ctx(overrides: Partial<QuotaContext> = {}): QuotaContext {
 describe('assertUploadAllowed', () => {
     describe('without a subscription', () => {
         it('falls back to the starter plan limit', () => {
+            // Push past the 105% soft cap to force rejection.
+            const overSoftCap = Math.floor(PLAN_LIMITS.starter * 1.05) + oneGB;
             expect(() =>
-                assertUploadAllowed(
-                    ctx({ currentUsage: PLAN_LIMITS.starter - 1 }),
-                    2,
-                    NOW
-                )
+                assertUploadAllowed(ctx({ currentUsage: overSoftCap }), 1, NOW)
             ).toThrow(QuotaExceededError);
         });
 
         it('allows an upload that lands exactly at the starter limit', () => {
-            expect(() =>
-                assertUploadAllowed(
-                    ctx({ currentUsage: PLAN_LIMITS.starter - oneGB }),
-                    oneGB,
-                    NOW
-                )
-            ).not.toThrow();
+            const result = assertUploadAllowed(
+                ctx({ currentUsage: PLAN_LIMITS.starter - oneGB }),
+                oneGB,
+                NOW
+            );
+            expect(result.allowed).toBe(true);
+            expect(result.limitBytes).toBe(PLAN_LIMITS.starter);
         });
     });
 
     describe('with an active subscription', () => {
         it('uses the subscription storageLimit, not PLAN_LIMITS', () => {
-            // Custom limit below the starter default — proves we honor the
-            // subscription's value rather than falling back to PLAN_LIMITS.
             const customLimit = 100 * oneGB;
             const subscription = {
                 storageLimit: customLimit,
@@ -48,10 +52,12 @@ describe('assertUploadAllowed', () => {
                 trialEnd: null,
             };
 
+            // 110% of the limit blows past the 105% soft cap.
+            const overSoftCap = Math.floor(customLimit * 1.1);
             expect(() =>
                 assertUploadAllowed(
-                    ctx({ currentUsage: customLimit - 1, subscription }),
-                    2,
+                    ctx({ currentUsage: overSoftCap, subscription }),
+                    1,
                     NOW
                 )
             ).toThrow(QuotaExceededError);
@@ -71,6 +77,80 @@ describe('assertUploadAllowed', () => {
                     NOW
                 )
             ).not.toThrow();
+        });
+    });
+
+    describe('soft limit (105%)', () => {
+        const subscription = {
+            storageLimit: 100 * oneGB,
+            status: 'active' as const,
+            trialEnd: null,
+        };
+
+        it('allows an upload that lands within the 5% overage band', () => {
+            // 100% used + 4% upload = 104% projected, under 105% cap.
+            const result = assertUploadAllowed(
+                ctx({ currentUsage: 100 * oneGB, subscription }),
+                4 * oneGB,
+                NOW
+            );
+
+            expect(result.allowed).toBe(true);
+            expect(result.nearLimit).toBe(true);
+        });
+
+        it('rejects when the projected usage exceeds 105% of the limit', () => {
+            // 100% used + 6% upload = 106% projected, over cap.
+            expect(() =>
+                assertUploadAllowed(
+                    ctx({ currentUsage: 100 * oneGB, subscription }),
+                    6 * oneGB,
+                    NOW
+                )
+            ).toThrow(QuotaExceededError);
+        });
+
+        it('attaches structured details on rejection', () => {
+            try {
+                assertUploadAllowed(
+                    ctx({ currentUsage: 100 * oneGB, subscription }),
+                    6 * oneGB,
+                    NOW
+                );
+            } catch (error) {
+                expect(error).toBeInstanceOf(QuotaExceededError);
+                expect((error as QuotaExceededError).details).toEqual({
+                    usedBytes: 100 * oneGB,
+                    limitBytes: 100 * oneGB,
+                    requestedBytes: 6 * oneGB,
+                });
+            }
+        });
+    });
+
+    describe('nearLimit flag', () => {
+        const subscription = {
+            storageLimit: 100 * oneGB,
+            status: 'active' as const,
+            trialEnd: null,
+        };
+
+        it('is false when projected usage is well under 90%', () => {
+            const result = assertUploadAllowed(
+                ctx({ currentUsage: 50 * oneGB, subscription }),
+                10 * oneGB,
+                NOW
+            );
+            expect(result.nearLimit).toBe(false);
+        });
+
+        it('is true when projected usage exceeds 90% of the limit', () => {
+            const result = assertUploadAllowed(
+                ctx({ currentUsage: 80 * oneGB, subscription }),
+                15 * oneGB,
+                NOW
+            );
+            expect(result.nearLimit).toBe(true);
         });
     });
 
@@ -141,5 +221,55 @@ describe('assertUploadAllowed', () => {
                 )
             ).not.toThrow();
         });
+    });
+});
+
+describe('checkQuota', () => {
+    let db: MockDb;
+    let mocks: MockDbMocks;
+
+    beforeEach(() => {
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+    });
+
+    it('reads usage from storage_usage and allows when under limit', async () => {
+        mocks.storageUsage.findFirst.mockResolvedValue(
+            createStorageUsageFixture({ usedBytes: 100, fileCount: 1 })
+        );
+
+        const result = await checkQuota(db, TEST_USER_ID, oneGB, undefined);
+
+        expect(result.allowed).toBe(true);
+        expect(result.usedBytes).toBe(100);
+        expect(result.limitBytes).toBe(PLAN_LIMITS.starter);
+    });
+
+    it('treats a missing usage row as zero usage', async () => {
+        mocks.storageUsage.findFirst.mockResolvedValue(undefined);
+
+        const result = await checkQuota(db, TEST_USER_ID, oneGB, undefined);
+
+        expect(result.allowed).toBe(true);
+        expect(result.usedBytes).toBe(0);
+    });
+
+    it('throws QuotaExceededError with details when over the soft cap', async () => {
+        mocks.storageUsage.findFirst.mockResolvedValue(
+            createStorageUsageFixture({
+                usedBytes: PLAN_LIMITS.starter,
+                fileCount: 100,
+            })
+        );
+
+        await expect(
+            checkQuota(
+                db,
+                TEST_USER_ID,
+                Math.floor(PLAN_LIMITS.starter * 0.1),
+                undefined
+            )
+        ).rejects.toThrow(QuotaExceededError);
     });
 });

--- a/apps/web/server/services/quota.ts
+++ b/apps/web/server/services/quota.ts
@@ -1,25 +1,48 @@
+import type { DB } from '@nexus/db';
+import { createStorageUsageRepo } from '@nexus/db/repo/storage-usage';
 import type { Subscription } from '@nexus/db/repo/subscriptions';
 import { QuotaExceededError, TrialExpiredError } from '@/server/errors';
 import { PLAN_LIMITS } from './constants';
 
+// Optimistic concurrency: pre-checks pass at 100%, but we accept up to 105%
+// of the plan limit so a burst of concurrent uploads (each individually
+// passing the check before any have written) can land without rejection.
+// The 5% bound also covers small drift between storage_usage and reality.
+const SOFT_LIMIT_MULTIPLIER = 1.05;
+// Threshold for surfacing a "near limit" warning to the client (e.g. banner).
+const NEAR_LIMIT_RATIO = 0.9;
+
 export interface QuotaContext {
     currentUsage: number;
+    // Narrow Pick so tests can supply minimal fixtures without constructing
+    // the full Subscription object.
     subscription: Pick<
         Subscription,
         'storageLimit' | 'status' | 'trialEnd'
     > | null;
 }
 
+export interface QuotaCheckResult {
+    allowed: true;
+    usedBytes: number;
+    limitBytes: number;
+    remainingBytes: number;
+    nearLimit: boolean;
+}
+
 /**
  * Pure check: given the current usage snapshot and (optional) subscription,
  * decide whether `additionalBytes` can be accepted. Trial expiry is checked
  * before quota so an expired-trial user doesn't see a misleading quota error.
+ *
+ * Throws on rejection; returns the structured result on success so callers
+ * can surface usage and warning state in the same call.
  */
-export function assertUploadAllowed(
+function assertUploadAllowed(
     ctx: QuotaContext,
     additionalBytes: number,
     now: Date = new Date()
-): void {
+): QuotaCheckResult {
     const { subscription, currentUsage } = ctx;
 
     if (
@@ -30,8 +53,47 @@ export function assertUploadAllowed(
         throw new TrialExpiredError();
     }
 
-    const quotaBytes = subscription?.storageLimit ?? PLAN_LIMITS.starter;
-    if (currentUsage + additionalBytes > quotaBytes) {
-        throw new QuotaExceededError('Storage quota exceeded');
+    const limitBytes = subscription?.storageLimit ?? PLAN_LIMITS.starter;
+    const projectedUsage = currentUsage + additionalBytes;
+    const softCap = Math.floor(limitBytes * SOFT_LIMIT_MULTIPLIER);
+
+    if (projectedUsage > softCap) {
+        throw new QuotaExceededError({
+            usedBytes: currentUsage,
+            limitBytes,
+            requestedBytes: additionalBytes,
+        });
     }
+
+    return {
+        allowed: true,
+        usedBytes: currentUsage,
+        limitBytes,
+        remainingBytes: Math.max(limitBytes - currentUsage, 0),
+        nearLimit: projectedUsage > limitBytes * NEAR_LIMIT_RATIO,
+    };
 }
+
+/**
+ * Loads the current usage from `storage_usage` and runs the pure quota check.
+ * Use this from upload entry points; the bare `assertUploadAllowed` is for
+ * tests and callers that already have a usage snapshot.
+ */
+async function checkQuota(
+    db: DB,
+    userId: string,
+    requestedBytes: number,
+    sub: Subscription | undefined
+): Promise<QuotaCheckResult> {
+    const usageRepo = createStorageUsageRepo(db);
+    const { usedBytes } = await usageRepo.getUsage(userId);
+    return assertUploadAllowed(
+        { currentUsage: usedBytes, subscription: sub ?? null },
+        requestedBytes
+    );
+}
+
+export const quotaService = {
+    assertUploadAllowed,
+    checkQuota,
+} as const;

--- a/apps/web/server/services/storage.ts
+++ b/apps/web/server/services/storage.ts
@@ -4,6 +4,7 @@ import {
     type StorageByCategory,
     type DailyUploadVolume,
 } from '@nexus/db/repo/files';
+import { createStorageUsageRepo } from '@nexus/db/repo/storage-usage';
 import type { Subscription } from '@nexus/db/repo/subscriptions';
 import { resolvePlan, type PlanTier } from './constants';
 
@@ -20,12 +21,10 @@ async function getUsage(
     userId: string,
     sub: Subscription | undefined
 ): Promise<StorageUsage> {
-    const fileRepo = createFileRepo(db);
-
-    const [usedBytes, fileCount] = await Promise.all([
-        fileRepo.sumStorageByUser(userId),
-        fileRepo.countByUser(userId),
-    ]);
+    const usageRepo = createStorageUsageRepo(db);
+    // Reads from the storage_usage table (the single source of truth used by
+    // checkQuota); falls back to a zero snapshot for users with no row yet.
+    const { usedBytes, fileCount } = await usageRepo.getUsage(userId);
 
     const { quotaBytes, planTier } = resolvePlan(sub);
     const percentage = quotaBytes > 0 ? (usedBytes / quotaBytes) * 100 : 0;

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -191,7 +191,7 @@ async function createPortalSession(
 
 /**
  * Provisions a local-only trial: creates a Stripe Customer but no Stripe
- * Subscription. Expiry is enforced soft by `assertWithinQuota` in files.ts —
+ * Subscription. Expiry is enforced soft by `quotaService.checkQuota` —
  * the row stays `status: 'trialing'` until a real subscription replaces it.
  */
 async function provisionTrialSubscription(

--- a/apps/web/server/trpc/middleware/errorHandler.test.ts
+++ b/apps/web/server/trpc/middleware/errorHandler.test.ts
@@ -105,7 +105,11 @@ describe('errorHandlerMiddleware', () => {
     it('maps QuotaExceededError to PRECONDITION_FAILED TRPCError', async () => {
         const router = t.router({
             test: baseProcedure.query(() => {
-                throw new QuotaExceededError('Storage quota exceeded');
+                throw new QuotaExceededError({
+                    usedBytes: 100,
+                    limitBytes: 50,
+                    requestedBytes: 10,
+                });
             }),
         });
 
@@ -117,7 +121,9 @@ describe('errorHandlerMiddleware', () => {
         } catch (error) {
             expect(error).toBeInstanceOf(TRPCError);
             expect((error as TRPCError).code).toBe('PRECONDITION_FAILED');
-            expect((error as TRPCError).message).toBe('Storage quota exceeded');
+            expect((error as TRPCError).message).toContain(
+                'Storage quota exceeded'
+            );
         }
     });
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -29,6 +29,11 @@
             "import": "./src/repositories/retrievals.ts",
             "default": "./src/repositories/retrievals.ts"
         },
+        "./repo/storage-usage": {
+            "types": "./src/repositories/storage-usage.ts",
+            "import": "./src/repositories/storage-usage.ts",
+            "default": "./src/repositories/storage-usage.ts"
+        },
         "./repo/subscriptions": {
             "types": "./src/repositories/subscriptions.ts",
             "import": "./src/repositories/subscriptions.ts",

--- a/packages/db/src/migrations/0010_storage_usage_backfill.sql
+++ b/packages/db/src/migrations/0010_storage_usage_backfill.sql
@@ -1,0 +1,18 @@
+-- Backfill storage_usage from live files data so the table becomes the
+-- authoritative source for quota checks. Without this, users with files but
+-- no usage row would read as 0 bytes and bypass enforcement until their next
+-- upload. Aggregates exclude `deleted` and `uploading` rows to match the
+-- read filter used in fileRepo.sumStorageByUser.
+INSERT INTO "storage_usage" ("id", "user_id", "used_bytes", "file_count")
+SELECT
+    gen_random_uuid()::text,
+    "files"."user_id",
+    COALESCE(SUM("files"."size"), 0)::bigint,
+    COUNT(*)::int
+FROM "files"
+WHERE "files"."status" NOT IN ('deleted', 'uploading')
+GROUP BY "files"."user_id"
+ON CONFLICT ("user_id") DO UPDATE SET
+    "used_bytes" = EXCLUDED."used_bytes",
+    "file_count" = EXCLUDED."file_count",
+    "updated_at" = now();

--- a/packages/db/src/migrations/meta/0010_snapshot.json
+++ b/packages/db/src/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1249 @@
+{
+  "id": "9d440dc2-5a0f-4ce5-aa11-adda8fc38475",
+  "prevId": "8a03580e-d643-4f1b-96c2-4c8532bbb674",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.background_jobs": {
+      "name": "background_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "background_jobs_status_created_at_idx": {
+          "name": "background_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "storage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'glacier'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_user_id_idx": {
+          "name": "files_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "files_status_idx": {
+          "name": "files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "files_storage_tier_idx": {
+          "name": "files_storage_tier_idx",
+          "columns": [
+            {
+              "expression": "storage_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "files_user_id_created_at_idx": {
+          "name": "files_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_user_id_fk": {
+          "name": "files_user_id_user_id_fk",
+          "tableFrom": "files",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_s3_key_unique": {
+          "name": "files_s3_key_unique",
+          "columns": [
+            "s3_key"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrievals": {
+      "name": "retrievals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "retrieval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "retrieval_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retrievals_file_id_idx": {
+          "name": "retrievals_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "retrievals_user_id_idx": {
+          "name": "retrievals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "retrievals_status_idx": {
+          "name": "retrievals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "retrievals_expires_at_idx": {
+          "name": "retrievals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "retrievals_file_id_files_id_fk": {
+          "name": "retrievals_file_id_files_id_fk",
+          "tableFrom": "retrievals",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "tableTo": "files",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "retrievals_user_id_user_id_fk": {
+          "name": "retrievals_user_id_user_id_fk",
+          "tableFrom": "retrievals",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_usage": {
+      "name": "storage_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_bytes": {
+          "name": "used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_usage_user_id_idx": {
+          "name": "storage_usage_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "storage_usage_user_id_user_id_fk": {
+          "name": "storage_usage_user_id_user_id_fk",
+          "tableFrom": "storage_usage",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_usage_user_id_unique": {
+          "name": "storage_usage_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "plan_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starter'"
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trialing'"
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_user_id_unique": {
+          "name": "subscriptions_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "columns": [
+            "stripe_subscription_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "webhook_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_source_external_id_idx": {
+          "name": "webhook_events_source_external_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "webhook_events_status_created_at_idx": {
+          "name": "webhook_events_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "available",
+        "restoring",
+        "deleted"
+      ]
+    },
+    "public.retrieval_status": {
+      "name": "retrieval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "ready",
+        "expired",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.retrieval_tier": {
+      "name": "retrieval_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "bulk",
+        "expedited"
+      ]
+    },
+    "public.storage_tier": {
+      "name": "storage_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "glacier",
+        "deep_archive"
+      ]
+    },
+    "public.plan_tier": {
+      "name": "plan_tier",
+      "schema": "public",
+      "values": [
+        "starter",
+        "pro",
+        "max",
+        "enterprise"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "incomplete"
+      ]
+    },
+    "public.webhook_source": {
+      "name": "webhook_source",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "sns"
+      ]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776562429200,
       "tag": "0009_tiny_warstar",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1778230002462,
+      "tag": "0010_storage_usage_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repositories/mocks.ts
+++ b/packages/db/src/repositories/mocks.ts
@@ -32,6 +32,7 @@ export function createMockDb() {
     const files = createQueryMock();
     const backgroundJobs = createQueryMock();
     const retrievals = createQueryMock();
+    const storageUsage = createQueryMock();
     const subscriptions = createQueryMock();
     const webhookEvents = createQueryMock();
 
@@ -40,6 +41,7 @@ export function createMockDb() {
             files,
             backgroundJobs,
             retrievals,
+            storageUsage,
             subscriptions,
             webhookEvents,
         },
@@ -70,6 +72,7 @@ export function createMockDb() {
             files,
             backgroundJobs,
             retrievals,
+            storageUsage,
             subscriptions,
             webhookEvents,
         },

--- a/packages/db/src/repositories/storage-usage.test.ts
+++ b/packages/db/src/repositories/storage-usage.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createMockDb, type MockDbMocks } from './mocks';
+import { createStorageUsageFixture, TEST_USER_ID } from './fixtures';
+import { createStorageUsageRepo, type StorageUsageRepo } from './storage-usage';
+
+describe('storage-usage repository', () => {
+    let mocks: MockDbMocks;
+    let repo: StorageUsageRepo;
+
+    beforeEach(() => {
+        const mockDb = createMockDb();
+        mocks = mockDb.mocks;
+        repo = createStorageUsageRepo(mockDb.db);
+    });
+
+    describe('getUsage', () => {
+        it('returns usedBytes and fileCount when row exists', async () => {
+            const row = createStorageUsageFixture({
+                usedBytes: 1024,
+                fileCount: 3,
+            });
+            mocks.storageUsage.findFirst.mockResolvedValue(row);
+
+            const result = await repo.getUsage(TEST_USER_ID);
+
+            expect(result).toEqual({ usedBytes: 1024, fileCount: 3 });
+        });
+
+        it('returns zero snapshot when no row exists for the user', async () => {
+            mocks.storageUsage.findFirst.mockResolvedValue(undefined);
+
+            const result = await repo.getUsage(TEST_USER_ID);
+
+            expect(result).toEqual({ usedBytes: 0, fileCount: 0 });
+        });
+    });
+
+    describe('incrementUsage', () => {
+        it('upserts and returns the new snapshot', async () => {
+            const updated = createStorageUsageFixture({
+                usedBytes: 2048,
+                fileCount: 2,
+            });
+            mocks.returning.mockResolvedValue([updated]);
+
+            const result = await repo.incrementUsage(TEST_USER_ID, 1024);
+
+            expect(result).toEqual({ usedBytes: 2048, fileCount: 2 });
+            expect(mocks.insert).toHaveBeenCalledOnce();
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: TEST_USER_ID,
+                    usedBytes: 1024,
+                    fileCount: 1,
+                })
+            );
+            expect(mocks.onConflictDoUpdate).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('decrementUsage', () => {
+        it('returns the updated snapshot', async () => {
+            const updated = createStorageUsageFixture({
+                usedBytes: 500,
+                fileCount: 1,
+            });
+            mocks.returning.mockResolvedValue([updated]);
+
+            const result = await repo.decrementUsage(TEST_USER_ID, 100);
+
+            expect(result).toEqual({ usedBytes: 500, fileCount: 1 });
+            expect(mocks.update).toHaveBeenCalledOnce();
+            expect(mocks.set).toHaveBeenCalledOnce();
+        });
+
+        it('accepts a fileCount for batched deletes', async () => {
+            const updated = createStorageUsageFixture({
+                usedBytes: 0,
+                fileCount: 0,
+            });
+            mocks.returning.mockResolvedValue([updated]);
+
+            const result = await repo.decrementUsage(TEST_USER_ID, 5000, 5);
+
+            expect(result).toEqual({ usedBytes: 0, fileCount: 0 });
+            expect(mocks.update).toHaveBeenCalledOnce();
+        });
+
+        it('returns zero snapshot when no row exists', async () => {
+            mocks.returning.mockResolvedValue([]);
+
+            const result = await repo.decrementUsage(TEST_USER_ID, 100);
+
+            expect(result).toEqual({ usedBytes: 0, fileCount: 0 });
+        });
+    });
+});

--- a/packages/db/src/repositories/storage-usage.ts
+++ b/packages/db/src/repositories/storage-usage.ts
@@ -1,0 +1,80 @@
+import { eq, sql } from 'drizzle-orm';
+import type { DB } from '../connection';
+import * as schema from '../schema';
+import { createRepository } from './create';
+
+export type StorageUsage = typeof schema.storageUsage.$inferSelect;
+
+export interface UsageSnapshot {
+    usedBytes: number;
+    fileCount: number;
+}
+
+const ZERO_USAGE: UsageSnapshot = { usedBytes: 0, fileCount: 0 };
+
+async function getUsage(db: DB, userId: string): Promise<UsageSnapshot> {
+    const row = await db.query.storageUsage.findFirst({
+        where: eq(schema.storageUsage.userId, userId),
+    });
+    if (!row) return ZERO_USAGE;
+    return { usedBytes: Number(row.usedBytes), fileCount: row.fileCount };
+}
+
+// Atomic upsert: increments usage in-place when a row exists, inserts a fresh
+// row at `bytes` for first-time uploaders. Postgres handles concurrent calls
+// without read-modify-write races thanks to the `+ EXCLUDED.*` set clause.
+async function incrementUsage(
+    db: DB,
+    userId: string,
+    bytes: number
+): Promise<UsageSnapshot> {
+    const [row] = await db
+        .insert(schema.storageUsage)
+        .values({
+            id: crypto.randomUUID(),
+            userId,
+            usedBytes: bytes,
+            fileCount: 1,
+        })
+        .onConflictDoUpdate({
+            target: schema.storageUsage.userId,
+            set: {
+                usedBytes: sql`${schema.storageUsage.usedBytes} + ${bytes}`,
+                fileCount: sql`${schema.storageUsage.fileCount} + 1`,
+                updatedAt: new Date(),
+            },
+        })
+        .returning();
+    return { usedBytes: Number(row.usedBytes), fileCount: row.fileCount };
+}
+
+// Decrement clamps at 0 to defend against drift (decrement without a prior
+// increment would otherwise produce a negative value, which the bigint column
+// would happily store but no caller can interpret meaningfully). Accepts
+// fileCount so a multi-file delete can issue a single UPDATE.
+async function decrementUsage(
+    db: DB,
+    userId: string,
+    bytes: number,
+    fileCount: number = 1
+): Promise<UsageSnapshot> {
+    const [row] = await db
+        .update(schema.storageUsage)
+        .set({
+            usedBytes: sql`GREATEST(${schema.storageUsage.usedBytes} - ${bytes}, 0)`,
+            fileCount: sql`GREATEST(${schema.storageUsage.fileCount} - ${fileCount}, 0)`,
+            updatedAt: new Date(),
+        })
+        .where(eq(schema.storageUsage.userId, userId))
+        .returning();
+    if (!row) return ZERO_USAGE;
+    return { usedBytes: Number(row.usedBytes), fileCount: row.fileCount };
+}
+
+export const createStorageUsageRepo = createRepository({
+    getUsage,
+    incrementUsage,
+    decrementUsage,
+});
+
+export type StorageUsageRepo = ReturnType<typeof createStorageUsageRepo>;

--- a/packages/db/src/seed/builders.ts
+++ b/packages/db/src/seed/builders.ts
@@ -1,4 +1,4 @@
-import { eq, sum, count } from 'drizzle-orm';
+import { and, eq, notInArray, sum, count } from 'drizzle-orm';
 import * as schema from '../schema';
 import type { DB } from '../connection';
 import type {
@@ -195,13 +195,22 @@ export async function buildStorageUsage(
     db: DB,
     userId: string
 ): Promise<StorageUsage> {
+    // Match the runtime "what counts toward usage" filter so seed-derived
+    // snapshots agree with what `confirmUpload`/`deleteUserFile` and the
+    // 0010_storage_usage_backfill migration produce. Excludes `uploading`
+    // (not yet confirmed) and `deleted` (already subtracted).
     const [stats] = await db
         .select({
             totalBytes: sum(schema.files.size).mapWith(Number),
             fileCount: count(schema.files.id),
         })
         .from(schema.files)
-        .where(eq(schema.files.userId, userId));
+        .where(
+            and(
+                eq(schema.files.userId, userId),
+                notInArray(schema.files.status, ['uploading', 'deleted'])
+            )
+        );
 
     const [usage] = await db
         .insert(schema.storageUsage)


### PR DESCRIPTION
## Summary

Implements storage quota enforcement: pre-upload checks against a 105% soft cap (so concurrent-upload bursts don't get rejected), and `storage_usage` is now the source of truth — atomically incremented on confirm and decremented on delete. The dashboard usage card reads from the same table so it can't drift from the value that gates uploads.

Closes #22

## Changes

- **Domain error**: `QuotaExceededError` now carries `{ usedBytes, limitBytes, requestedBytes }` so the client can render precise overage state.
- **Repository**: New `storage-usage` repo with `getUsage`, `incrementUsage` (atomic upsert), `decrementUsage` (clamped at 0; accepts a `fileCount` so batch deletes use a single UPDATE).
- **Service**: New `quotaService` with a pure `assertUploadAllowed` (now enforces the 105% soft cap and returns a `nearLimit` flag at >90%) and a `checkQuota` wrapper that loads usage and runs the check.
- **Wire-up**: `initiateUpload` / `initiateMultipartUpload` call `checkQuota`; `confirmUpload` and `completeMultipartUpload` increment usage in a transaction with an idempotency guard so retries don't double-count; `deleteUserFile` decrements in a single batched UPDATE for `available`/`restoring` files (skipping `uploading` rows that were never counted).
- **Backfill migration** (`0010_storage_usage_backfill.sql`): one-shot `INSERT ... ON CONFLICT DO UPDATE` so existing users get a `storage_usage` row matching their current files. Filter matches the runtime "what counts" semantic (`status NOT IN ('deleted','uploading')`).
- **Dashboard alignment**: `storageService.getUsage` now reads from `storage_usage` (the same source `checkQuota` enforces against); the seed builder's filter is aligned with the migration to keep dev/prod in lockstep.

## Test Plan

- [x] `pnpm check` passes (lint + typecheck + unit tests across 10 turbo tasks)
- [x] `pnpm -F web test:e2e:smoke` passes (17/17, including upload/files/dashboard pages)
- [x] New unit tests cover: storage-usage repo (get/increment/decrement, including the missing-row case), quota soft-cap and `nearLimit` boundaries, `checkQuota` reading from the table, `confirmUpload` idempotency, batched delete decrement, skipping decrement for `uploading` files
- [ ] Run the migration against a non-empty DB and confirm `storage_usage` rows match the per-user `SUM(size)` aggregate
- [ ] Manual: upload past the 105% soft cap → see `QuotaExceededError`; verify the dashboard usage % now matches what the upload check sees

## Notes

- Wire-transport of `QuotaDetails` to the client (so the UI can render "1.05 TB of 1 TB") is deferred — the error formatter currently only surfaces `domainCode`. The structured fields are on the server-side error class and ready to be plumbed when the upload UI grows a richer overage screen.
- Out-of-scope per the issue: reconciliation/drift detection job, pessimistic reservations, usage-based billing, downgrade-after-overage handling, file-size mismatch handling.