### PR TITLE
feat: improve mobile and small screen layout (#100)

### DIFF
--- a/packages/trpc-devtools/src/components/devtools/devtools.tsx
+++ b/packages/trpc-devtools/src/components/devtools/devtools.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import * as React from 'react';
+import { Menu } from 'lucide-react';
+import { Drawer } from '@/components/ui/drawer';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useIsMobile } from '@/lib/use-is-mobile';
 import { cn } from '@/lib/utils';
 import type { HistoryItem } from '@/lib/storage';
 import type { TRPCResponse } from '@/lib/request';
 import type { ProcedureSchema, RouterSchema } from '@/server/types';
-import * as React from 'react';
 import { ProcedureList, ProcedureListSkeleton } from './procedure-list';
 import { ProcedureView, ProcedureViewSkeleton } from './procedure-view';
 import { RequestHistoryPanel } from './request-history';
@@ -35,6 +38,22 @@ export function TRPCDevtools({
         response: TRPCResponse | null;
     } | null>(null);
 
+    const isMobile = useIsMobile();
+    const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
+
+    const closeDrawer = React.useCallback(() => setIsDrawerOpen(false), []);
+
+    // Reset drawer state when the viewport expands past the mobile breakpoint
+    React.useEffect(() => {
+        if (!isMobile) setIsDrawerOpen(false);
+    }, [isMobile]);
+
+    // Selecting a procedure closes the drawer and reveals the procedure view
+    const handleSelect = React.useCallback((path: string) => {
+        setSelectedPath(path);
+        setIsDrawerOpen(false);
+    }, []);
+
     const handleHistoryReplay = React.useCallback((item: HistoryItem) => {
         setSelectedPath(item.request.path);
         setHistoryReplay({
@@ -44,6 +63,7 @@ export function TRPCDevtools({
                     : '',
             response: item.response,
         });
+        setIsDrawerOpen(false);
     }, []);
 
     // Fetch schema on mount
@@ -81,7 +101,7 @@ export function TRPCDevtools({
         return (
             <div
                 className={cn(
-                    'trpc-devtools flex items-center justify-center h-screen bg-background',
+                    'trpc-devtools flex items-center justify-center h-dvh bg-background',
                     className
                 )}
             >
@@ -99,20 +119,25 @@ export function TRPCDevtools({
         return (
             <div
                 className={cn(
-                    'trpc-devtools flex h-screen bg-background text-foreground',
+                    'trpc-devtools flex flex-col md:flex-row h-dvh bg-background text-foreground',
                     className
                 )}
             >
-                {/* Sidebar skeleton */}
-                <div className="w-64 border-r border-border flex flex-col">
-                    <div className="p-4 border-b border-border">
-                        <h1 className="text-lg font-semibold">tRPC Devtools</h1>
-                        <Skeleton className="h-3 w-20 mt-1" />
+                {isMobile ? (
+                    <MobileHeader />
+                ) : (
+                    <div className="w-64 border-r border-border flex flex-col">
+                        <div className="p-4 border-b border-border">
+                            <h1 className="text-lg font-semibold">
+                                tRPC Devtools
+                            </h1>
+                            <Skeleton className="h-3 w-20 mt-1" />
+                        </div>
+                        <div className="flex-1 overflow-hidden">
+                            <ProcedureListSkeleton />
+                        </div>
                     </div>
-                    <div className="flex-1 overflow-hidden">
-                        <ProcedureListSkeleton />
-                    </div>
-                </div>
+                )}
 
                 {/* Main content skeleton */}
                 <div className="flex-1 overflow-hidden">
@@ -122,30 +147,38 @@ export function TRPCDevtools({
         );
     }
 
+    const sidebarContent = (
+        <SidebarContent
+            schema={schema}
+            selectedPath={selectedPath}
+            onSelect={handleSelect}
+            onReplay={handleHistoryReplay}
+        />
+    );
+
     return (
         <div
             className={cn(
-                'trpc-devtools flex h-screen bg-background text-foreground',
+                'trpc-devtools flex flex-col md:flex-row h-dvh bg-background text-foreground',
                 className
             )}
         >
-            {/* Sidebar */}
-            <div className="w-64 border-r border-border flex flex-col">
-                <div className="p-4 border-b border-border">
-                    <h1 className="text-lg font-semibold">tRPC Devtools</h1>
-                    <p className="text-xs text-muted-foreground">
-                        {schema.procedures.length} procedures
-                    </p>
+            {isMobile ? (
+                <>
+                    <MobileHeader onOpenMenu={() => setIsDrawerOpen(true)} />
+                    <Drawer
+                        isOpen={isDrawerOpen}
+                        onClose={closeDrawer}
+                        label="Procedure navigation"
+                    >
+                        {sidebarContent}
+                    </Drawer>
+                </>
+            ) : (
+                <div className="w-64 border-r border-border flex flex-col">
+                    {sidebarContent}
                 </div>
-                <div className="flex-1 overflow-hidden">
-                    <ProcedureList
-                        procedures={schema.procedures}
-                        selectedPath={selectedPath}
-                        onSelect={setSelectedPath}
-                    />
-                </div>
-                <RequestHistoryPanel onReplay={handleHistoryReplay} />
-            </div>
+            )}
 
             {/* Main content */}
             <div className="flex-1 overflow-hidden">
@@ -164,5 +197,63 @@ export function TRPCDevtools({
                 )}
             </div>
         </div>
+    );
+}
+
+interface MobileHeaderProps {
+    onOpenMenu?: () => void;
+}
+
+function MobileHeader({ onOpenMenu }: MobileHeaderProps) {
+    return (
+        <header className="flex items-center gap-1 px-2 py-1 border-b border-border shrink-0">
+            <button
+                type="button"
+                aria-label="Open navigation menu"
+                onClick={onOpenMenu}
+                disabled={!onOpenMenu}
+                className={cn(
+                    'flex h-11 w-11 items-center justify-center rounded-md transition-colors',
+                    'hover:bg-accent/50 disabled:opacity-50',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+                )}
+            >
+                <Menu className="h-5 w-5" />
+            </button>
+            <h1 className="text-base font-semibold">tRPC Devtools</h1>
+        </header>
+    );
+}
+
+interface SidebarContentProps {
+    schema: RouterSchema;
+    selectedPath: string | null;
+    onSelect: (path: string) => void;
+    onReplay: (item: HistoryItem) => void;
+}
+
+function SidebarContent({
+    schema,
+    selectedPath,
+    onSelect,
+    onReplay,
+}: SidebarContentProps) {
+    return (
+        <>
+            <div className="p-4 border-b border-border">
+                <h1 className="text-lg font-semibold">tRPC Devtools</h1>
+                <p className="text-xs text-muted-foreground">
+                    {schema.procedures.length} procedures
+                </p>
+            </div>
+            <div className="flex-1 overflow-hidden">
+                <ProcedureList
+                    procedures={schema.procedures}
+                    selectedPath={selectedPath}
+                    onSelect={onSelect}
+                />
+            </div>
+            <RequestHistoryPanel onReplay={onReplay} />
+        </>
     );
 }

--- a/packages/trpc-devtools/src/components/ui/drawer.tsx
+++ b/packages/trpc-devtools/src/components/ui/drawer.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import * as React from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'textarea:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+export interface DrawerProps {
+    isOpen: boolean;
+    onClose: () => void;
+    /** Accessible name for the drawer dialog */
+    label: string;
+    className?: string;
+    children: React.ReactNode;
+}
+
+/**
+ * Slide-out panel anchored to the left edge with a backdrop overlay.
+ *
+ * While open: Escape closes, Tab focus is trapped inside the panel, and
+ * clicking the backdrop closes. Focus returns to the previously focused
+ * element (e.g. the trigger button) on close.
+ */
+export function Drawer({
+    isOpen,
+    onClose,
+    label,
+    className,
+    children,
+}: DrawerProps) {
+    const panelRef = React.useRef<HTMLDivElement>(null);
+
+    React.useEffect(() => {
+        if (!isOpen) return;
+
+        const previouslyFocused = document.activeElement;
+
+        // Focus the panel itself rather than the first focusable element so
+        // opening the drawer doesn't pop the virtual keyboard via the search
+        // input on touch devices.
+        panelRef.current?.focus();
+
+        function handleKeyDown(e: KeyboardEvent) {
+            if (e.key === 'Escape') {
+                onClose();
+                return;
+            }
+
+            if (e.key !== 'Tab' || !panelRef.current) return;
+
+            const focusable = Array.from(
+                panelRef.current.querySelectorAll<HTMLElement>(
+                    FOCUSABLE_SELECTOR
+                )
+            );
+            if (focusable.length === 0) {
+                e.preventDefault();
+                return;
+            }
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            const active = document.activeElement;
+            const isOutside = !panelRef.current.contains(active);
+
+            if (e.shiftKey && (active === first || isOutside)) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && (active === last || isOutside)) {
+                e.preventDefault();
+                first.focus();
+            }
+        }
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            if (previouslyFocused instanceof HTMLElement) {
+                previouslyFocused.focus();
+            }
+        };
+    }, [isOpen, onClose]);
+
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <>
+                    <motion.div
+                        className="fixed inset-0 z-40 bg-black/60"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.2, ease: 'easeOut' }}
+                        onClick={onClose}
+                        aria-hidden="true"
+                    />
+                    <motion.div
+                        ref={panelRef}
+                        role="dialog"
+                        aria-modal="true"
+                        aria-label={label}
+                        tabIndex={-1}
+                        className={cn(
+                            'fixed inset-y-0 left-0 z-50 flex w-72 max-w-[85vw] flex-col border-r border-border bg-background focus:outline-none',
+                            className
+                        )}
+                        initial={{ x: '-100%' }}
+                        animate={{ x: 0 }}
+                        exit={{ x: '-100%' }}
+                        transition={{ duration: 0.2, ease: 'easeOut' }}
+                    >
+                        {children}
+                    </motion.div>
+                </>
+            )}
+        </AnimatePresence>
+    );
+}

--- a/packages/trpc-devtools/src/components/ui/index.ts
+++ b/packages/trpc-devtools/src/components/ui/index.ts
@@ -10,6 +10,7 @@ export {
     CardContent,
 } from './card';
 export { Badge, type BadgeProps } from './badge';
+export { Drawer, type DrawerProps } from './drawer';
 export { ScrollArea } from './scroll-area';
 export { Skeleton } from './skeleton';
 export { Spinner, type SpinnerProps } from './spinner';

--- a/packages/trpc-devtools/src/components/ui/resizable-panels.tsx
+++ b/packages/trpc-devtools/src/components/ui/resizable-panels.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useIsMobile } from '@/lib/use-is-mobile';
 import { cn } from '@/lib/utils';
 import { loadPanelSizes, savePanelSizes, type PanelSizes } from '@/lib/storage';
 
@@ -22,7 +23,7 @@ export function ResizablePanels({
     const containerRef = React.useRef<HTMLDivElement>(null);
     const sizesRef = React.useRef<PanelSizes>(DEFAULT_SIZES);
     const [sizes, setSizes] = React.useState<PanelSizes>(DEFAULT_SIZES);
-    const [isHorizontal, setIsHorizontal] = React.useState(true);
+    const isHorizontal = !useIsMobile();
     const [isDragging, setIsDragging] = React.useState(false);
 
     // Keep ref in sync for use in pointer up handler
@@ -33,17 +34,6 @@ export function ResizablePanels({
     // Load persisted sizes on mount
     React.useEffect(() => {
         setSizes(loadPanelSizes());
-    }, []);
-
-    // Handle responsive layout switching
-    React.useEffect(() => {
-        const checkWidth = () => {
-            setIsHorizontal(window.innerWidth >= 768);
-        };
-
-        checkWidth();
-        window.addEventListener('resize', checkWidth);
-        return () => window.removeEventListener('resize', checkWidth);
     }, []);
 
     // Get the current size based on layout direction

--- a/packages/trpc-devtools/src/lib/use-is-mobile.ts
+++ b/packages/trpc-devtools/src/lib/use-is-mobile.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import * as React from 'react';
+
+/** Tailwind `md` breakpoint — below this the devtools use the mobile layout. */
+export const MOBILE_BREAKPOINT = 768;
+
+/**
+ * Track whether the viewport is below the mobile breakpoint.
+ *
+ * Defaults to `false` (desktop) until mounted so server rendering stays
+ * deterministic; updates immediately after hydration and on viewport changes.
+ */
+export function useIsMobile(): boolean {
+    const [isMobile, setIsMobile] = React.useState(false);
+
+    React.useEffect(() => {
+        const query = window.matchMedia(
+            `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+        );
+
+        const update = () => setIsMobile(query.matches);
+        update();
+
+        query.addEventListener('change', update);
+        return () => query.removeEventListener('change', update);
+    }, []);
+
+    return isMobile;
+}

--- a/packages/trpc-devtools/src/server/handler.test.ts
+++ b/packages/trpc-devtools/src/server/handler.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { initTRPC } from '@trpc/server';
+import type { NextRequest } from 'next/server';
+import { createTRPCDevtools } from './handler';
+
+// Standalone assets are embedded at build time; stub them so the handler can
+// render HTML from source during tests.
+vi.mock('./assets', () => ({
+    getStandaloneJs: () => 'const html = "<script></script>";',
+    getStandaloneCss: () => '/* standalone css */',
+}));
+
+const t = initTRPC.create();
+const router = t.router({
+    hello: t.procedure.query(() => 'world'),
+});
+
+function makeRequest(url: string): NextRequest {
+    return new Request(url) as unknown as NextRequest;
+}
+
+function makeContext(devtools?: string[]) {
+    return { params: Promise.resolve({ devtools }) };
+}
+
+describe('createTRPCDevtools handler', () => {
+    const handler = createTRPCDevtools({ router, url: '/api/trpc' });
+
+    it('serves the devtools HTML with a mobile viewport meta tag', async () => {
+        const response = await handler(
+            makeRequest('http://localhost/api/trpc-devtools'),
+            makeContext()
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('Content-Type')).toContain('text/html');
+
+        const html = await response.text();
+        expect(html).toContain(
+            '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
+        );
+    });
+
+    it('escapes closing script tags in the embedded bundle', async () => {
+        const response = await handler(
+            makeRequest('http://localhost/api/trpc-devtools'),
+            makeContext()
+        );
+
+        const html = await response.text();
+        // The raw "</script>" from the bundle must not survive embedding,
+        // or the HTML parser terminates the inline script block early.
+        expect(html).toContain('const html = "<script><\\/script>";');
+    });
+
+    it('serves the introspected schema as JSON', async () => {
+        const response = await handler(
+            makeRequest('http://localhost/api/trpc-devtools/schema'),
+            makeContext(['schema'])
+        );
+
+        expect(response.status).toBe(200);
+        const schema = await response.json();
+        expect(schema.procedures).toHaveLength(1);
+        expect(schema.procedures[0].path).toBe('hello');
+    });
+
+    it('returns 404 for unknown routes', async () => {
+        const response = await handler(
+            makeRequest('http://localhost/api/trpc-devtools/nope'),
+            makeContext(['nope'])
+        );
+
+        expect(response.status).toBe(404);
+    });
+});

--- a/packages/trpc-devtools/src/server/handler.ts
+++ b/packages/trpc-devtools/src/server/handler.ts
@@ -24,7 +24,11 @@ function getDevtoolsHtml(config: {
     trpcUrl: string;
     headers?: Record<string, string>;
 }): string {
-    const js = getStandaloneJs();
+    // Escape closing script tags inside the bundle (e.g. react-dom contains
+    // an innerHTML="<script></script>" string) so the HTML parser doesn't
+    // terminate the inline <script> block early. "<\/script" is equivalent
+    // inside JS string literals.
+    const js = getStandaloneJs().replace(/<\/(script)/gi, '<\\/$1');
     const css = getStandaloneCss();
 
     return `<!DOCTYPE html>

--- a/packages/trpc-devtools/src/standalone/app.tsx
+++ b/packages/trpc-devtools/src/standalone/app.tsx
@@ -17,7 +17,7 @@ function App() {
 
     if (!config) {
         return (
-            <div className="trpc-devtools flex items-center justify-center h-screen bg-background text-foreground">
+            <div className="trpc-devtools flex items-center justify-center h-dvh bg-background text-foreground">
                 <p className="text-destructive font-semibold">
                     Missing __TRPC_DEVTOOLS_CONFIG__
                 </p>


### PR DESCRIPTION
Closes #100

## Summary

Makes the trpc-devtools UI responsive below 768px: the fixed 256px sidebar becomes a slide-out drawer behind a hamburger header bar, and all full-height containers switch from `h-screen` to `h-dvh` for mobile browser chrome compatibility.

- **`Drawer` UI primitive** (`components/ui/drawer.tsx`): framer-motion slide-in from the left (200ms ease-out), backdrop overlay with tap-outside close, Escape to close, Tab focus trap, and focus restore to the trigger on close. Focuses the panel itself on open (not the search input) so the virtual keyboard doesn't pop on touch devices.
- **`useIsMobile` hook** (`lib/use-is-mobile.ts`): single source of truth for the 768px breakpoint via `matchMedia`; `ResizablePanels` now uses it too instead of its own resize listener (panel stacking below 768px was already implemented there in #94).
- **`TRPCDevtools` layout**: mobile header with a 44x44px hamburger button; selecting a procedure or replaying a history item closes the drawer; drawer state resets when the viewport expands past 768px. Desktop layout is unchanged.

## Pre-existing bug fix: standalone page was broken

While verifying, I found the standalone route (`/api/trpc-devtools`) renders a blank page **on main as well**: react-dom's bundle contains an `innerHTML="<script></script>"` string, and inlining it unescaped into the `<script type="module">` block makes the HTML parser terminate the script early (SyntaxError). Fixed by escaping `</script` → `<\/script` in the handler, with a regression test. Likely broken since a react-dom upgrade — worth checking whether the published 0.3.0 npm package is affected.

## Verification

Drove the standalone page with Playwright against a local dev server — 21/21 runtime checks pass:
- 1280px / 768px exactly: desktop sidebar, no hamburger (no regression)
- 767px / 640px / 375px: hamburger header, drawer opens with backdrop, procedure select / Escape / backdrop tap all close it, focus restored to hamburger, 30 Tabs stay trapped inside, drawer ≤85vw at 375px
- Expand to 1280px with drawer open → resets; shrink again → stays closed
- `/dev/studio` (component surface) at 640px: drawer works, zero console errors
- Viewport meta tag asserted in handler test (was already present in the HTML template)

`pnpm check` passes (10/10); web smoke suite (18/18) run against the worktree on port 3100.

## Out of scope (per issue)

Gesture/swipe support, PWA, landscape handling, virtual keyboard handling.