### PR TITLE
feat: multipart resume primitives (ListParts + subset re-presign) (#233)

### DIFF
--- a/apps/web/lib/storage/multipart.test.ts
+++ b/apps/web/lib/storage/multipart.test.ts
@@ -14,7 +14,14 @@ vi.mock('@aws-sdk/s3-request-presigner', () => ({
     getSignedUrl: mockGetSignedUrl,
 }));
 
-import { create, signParts, complete, abort } from './multipart';
+import {
+    create,
+    signParts,
+    signPartsByNumber,
+    listParts,
+    complete,
+    abort,
+} from './multipart';
 
 describe('multipart storage', () => {
     beforeEach(() => {
@@ -72,6 +79,103 @@ describe('multipart storage', () => {
                 expect.anything(),
                 { expiresIn: 7200 }
             );
+        });
+    });
+
+    describe('signPartsByNumber', () => {
+        it('presigns only the requested part numbers', async () => {
+            mockGetSignedUrl.mockResolvedValue('https://signed-url.test');
+
+            const parts = await signPartsByNumber({
+                key: 'user/file/name.zip',
+                uploadId: 'test-upload-id',
+                partNumbers: [2, 5, 7],
+            });
+
+            expect(parts).toEqual([
+                { partNumber: 2, url: 'https://signed-url.test' },
+                { partNumber: 5, url: 'https://signed-url.test' },
+                { partNumber: 7, url: 'https://signed-url.test' },
+            ]);
+            expect(mockGetSignedUrl).toHaveBeenCalledTimes(3);
+        });
+
+        it('uses custom expiry when provided', async () => {
+            mockGetSignedUrl.mockResolvedValue('https://signed-url.test');
+
+            await signPartsByNumber({
+                key: 'key',
+                uploadId: 'uid',
+                partNumbers: [1],
+                expiresIn: 7200,
+            });
+
+            expect(mockGetSignedUrl).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.anything(),
+                { expiresIn: 7200 }
+            );
+        });
+
+        it('returns an empty array for no part numbers', async () => {
+            const parts = await signPartsByNumber({
+                key: 'key',
+                uploadId: 'uid',
+                partNumbers: [],
+            });
+
+            expect(parts).toEqual([]);
+            expect(mockGetSignedUrl).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('listParts', () => {
+        it('returns uploaded parts from a single page', async () => {
+            mockSend.mockResolvedValue({
+                Parts: [
+                    { PartNumber: 1, ETag: '"abc"', Size: 1000 },
+                    { PartNumber: 2, ETag: '"def"', Size: 1000 },
+                ],
+                IsTruncated: false,
+            });
+
+            const parts = await listParts('key', 'uid');
+
+            expect(parts).toEqual([
+                { partNumber: 1, etag: '"abc"', size: 1000 },
+                { partNumber: 2, etag: '"def"', size: 1000 },
+            ]);
+            expect(mockSend).toHaveBeenCalledOnce();
+        });
+
+        it('pages through truncated results', async () => {
+            mockSend
+                .mockResolvedValueOnce({
+                    Parts: [{ PartNumber: 1, ETag: '"a"', Size: 10 }],
+                    IsTruncated: true,
+                    NextPartNumberMarker: '1',
+                })
+                .mockResolvedValueOnce({
+                    Parts: [{ PartNumber: 2, ETag: '"b"', Size: 10 }],
+                    IsTruncated: false,
+                });
+
+            const parts = await listParts('key', 'uid');
+
+            expect(parts.map((p) => p.partNumber)).toEqual([1, 2]);
+            expect(mockSend).toHaveBeenCalledTimes(2);
+            // Second call must carry the marker from the first response.
+            expect(mockSend.mock.calls[1][0].input).toMatchObject({
+                PartNumberMarker: '1',
+            });
+        });
+
+        it('returns an empty array when no parts have been uploaded', async () => {
+            mockSend.mockResolvedValue({ IsTruncated: false });
+
+            const parts = await listParts('key', 'uid');
+
+            expect(parts).toEqual([]);
         });
     });
 

--- a/apps/web/lib/storage/multipart.ts
+++ b/apps/web/lib/storage/multipart.ts
@@ -3,6 +3,7 @@ import {
     UploadPartCommand,
     CompleteMultipartUploadCommand,
     AbortMultipartUploadCommand,
+    ListPartsCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { client, bucket } from './client';
@@ -21,9 +22,29 @@ interface SignPartsOptions {
     expiresIn?: number;
 }
 
+interface SignPartsByNumberOptions {
+    key: string;
+    uploadId: string;
+    /** Specific part numbers (1-indexed) to presign — used for resume/re-presign */
+    partNumbers: number[];
+    /** URL expiration in seconds (default: 3600 = 1 hour) */
+    expiresIn?: number;
+}
+
+export interface SignedPart {
+    partNumber: number;
+    url: string;
+}
+
 interface CompletePart {
     partNumber: number;
     etag: string;
+}
+
+export interface UploadedPart {
+    partNumber: number;
+    etag: string;
+    size: number;
 }
 
 /** Initiate an S3 multipart upload, returning the upload ID needed for subsequent part operations */
@@ -47,21 +68,81 @@ export async function create(
 
 /** Generate presigned URLs for all parts in a multipart upload (1-indexed) */
 export async function signParts(options: SignPartsOptions): Promise<string[]> {
+    const signed = await signPartsByNumber({
+        key: options.key,
+        uploadId: options.uploadId,
+        partNumbers: Array.from({ length: options.partCount }, (_, i) => i + 1),
+        expiresIn: options.expiresIn,
+    });
+
+    // Callers of the all-parts variant index by position (partNumber - 1).
+    return signed.map((part) => part.url);
+}
+
+/**
+ * Generate presigned URLs for a specific set of part numbers. Used to re-presign
+ * only the remaining parts on resume, and to refresh URLs that expired mid-upload
+ * (part URLs live 1h) — both without restarting the whole multipart upload.
+ */
+export async function signPartsByNumber(
+    options: SignPartsByNumberOptions
+): Promise<SignedPart[]> {
     const expiresIn = options.expiresIn ?? PART_URL_EXPIRY_SECONDS;
 
-    const urls = await Promise.all(
-        Array.from({ length: options.partCount }, (_, i) => {
+    return Promise.all(
+        options.partNumbers.map(async (partNumber) => {
             const command = new UploadPartCommand({
                 Bucket: bucket,
                 Key: options.key,
                 UploadId: options.uploadId,
-                PartNumber: i + 1,
+                PartNumber: partNumber,
             });
-            return getSignedUrl(client, command, { expiresIn });
+            const url = await getSignedUrl(client, command, { expiresIn });
+            return { partNumber, url };
         })
     );
+}
 
-    return urls;
+/**
+ * List the parts S3 has already received for an in-progress multipart upload.
+ * The authoritative source for resume reconciliation: lets the client skip
+ * already-uploaded parts even when its local state is stale or lost. Pages
+ * through results (S3 returns up to 1000 parts per call, 10000 parts max).
+ */
+export async function listParts(
+    key: string,
+    uploadId: string
+): Promise<UploadedPart[]> {
+    const parts: UploadedPart[] = [];
+    let partNumberMarker: string | undefined;
+
+    do {
+        const response = await client.send(
+            new ListPartsCommand({
+                Bucket: bucket,
+                Key: key,
+                UploadId: uploadId,
+                PartNumberMarker: partNumberMarker,
+            })
+        );
+
+        for (const part of response.Parts ?? []) {
+            // S3 always returns PartNumber and ETag for uploaded parts; guard
+            // narrows the SDK's optional types rather than expecting gaps.
+            if (part.PartNumber == null || part.ETag == null) continue;
+            parts.push({
+                partNumber: part.PartNumber,
+                etag: part.ETag,
+                size: part.Size ?? 0,
+            });
+        }
+
+        partNumberMarker = response.IsTruncated
+            ? response.NextPartNumberMarker
+            : undefined;
+    } while (partNumberMarker);
+
+    return parts;
 }
 
 /** Complete a multipart upload — client must provide ETags received from each part PUT */

--- a/apps/web/lib/storage/testing.ts
+++ b/apps/web/lib/storage/testing.ts
@@ -57,6 +57,16 @@ const multipartMocks = {
             { length: options.partCount },
             (_, i) => `${MOCK_HOST}/${MOCK_BUCKET}/part-${i + 1}`
         ),
+    signPartsByNumber: async (options: {
+        partNumbers: number[];
+    }): Promise<{ partNumber: number; url: string }[]> =>
+        options.partNumbers.map((partNumber) => ({
+            partNumber,
+            url: `${MOCK_HOST}/${MOCK_BUCKET}/part-${partNumber}`,
+        })),
+    listParts: async (): Promise<
+        { partNumber: number; etag: string; size: number }[]
+    > => [],
     complete: async (): Promise<void> => {},
     abort: async (): Promise<void> => {},
 };

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -633,6 +633,109 @@ describe('files service', () => {
         });
     });
 
+    describe('listMultipartParts', () => {
+        it('returns parts S3 reports for an uploading file', async () => {
+            const uploadingFile = createFileFixture({ status: 'uploading' });
+            mocks.files.findFirst.mockResolvedValue(uploadingFile);
+            const s3Parts = [
+                { partNumber: 1, etag: '"abc"', size: 1000 },
+                { partNumber: 2, etag: '"def"', size: 1000 },
+            ];
+            const spy = vi
+                .spyOn(mockS3.multipart, 'listParts')
+                .mockResolvedValue(s3Parts);
+
+            const result = await fileService.listMultipartParts(
+                db,
+                TEST_USER_ID,
+                uploadingFile.id,
+                'some-upload-id'
+            );
+
+            expect(result.parts).toEqual(s3Parts);
+            // Reconciliation must query the file's own key + the given uploadId.
+            expect(spy).toHaveBeenCalledWith(
+                uploadingFile.s3Key,
+                'some-upload-id'
+            );
+        });
+
+        it('throws NotFoundError when file does not exist', async () => {
+            mocks.files.findFirst.mockResolvedValue(undefined);
+
+            await expect(
+                fileService.listMultipartParts(
+                    db,
+                    TEST_USER_ID,
+                    'nonexistent',
+                    'some-upload-id'
+                )
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('throws InvalidStateError when file is not uploading', async () => {
+            const availableFile = createFileFixture({ status: 'available' });
+            mocks.files.findFirst.mockResolvedValue(availableFile);
+
+            await expect(
+                fileService.listMultipartParts(
+                    db,
+                    TEST_USER_ID,
+                    availableFile.id,
+                    'some-upload-id'
+                )
+            ).rejects.toThrow(InvalidStateError);
+        });
+    });
+
+    describe('signMultipartParts', () => {
+        it('re-presigns the requested part numbers with an expiry', async () => {
+            const uploadingFile = createFileFixture({ status: 'uploading' });
+            mocks.files.findFirst.mockResolvedValue(uploadingFile);
+
+            const result = await fileService.signMultipartParts(
+                db,
+                TEST_USER_ID,
+                {
+                    fileId: uploadingFile.id,
+                    uploadId: 'some-upload-id',
+                    partNumbers: [2, 4],
+                }
+            );
+
+            expect(result.parts).toEqual([
+                { partNumber: 2, url: expect.stringContaining('part-2') },
+                { partNumber: 4, url: expect.stringContaining('part-4') },
+            ]);
+            expect(result.expiresAt).toBeInstanceOf(Date);
+        });
+
+        it('throws NotFoundError when file does not exist', async () => {
+            mocks.files.findFirst.mockResolvedValue(undefined);
+
+            await expect(
+                fileService.signMultipartParts(db, TEST_USER_ID, {
+                    fileId: 'nonexistent',
+                    uploadId: 'some-upload-id',
+                    partNumbers: [1],
+                })
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('throws InvalidStateError when file is not uploading', async () => {
+            const availableFile = createFileFixture({ status: 'available' });
+            mocks.files.findFirst.mockResolvedValue(availableFile);
+
+            await expect(
+                fileService.signMultipartParts(db, TEST_USER_ID, {
+                    fileId: availableFile.id,
+                    uploadId: 'some-upload-id',
+                    partNumbers: [1],
+                })
+            ).rejects.toThrow(InvalidStateError);
+        });
+    });
+
     describe('abortMultipartUpload', () => {
         it('soft-deletes the file record', async () => {
             const uploadingFile = createFileFixture({ status: 'uploading' });

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -247,6 +247,81 @@ async function completeMultipartUpload(
     });
 }
 
+interface ListMultipartPartsResult {
+    parts: { partNumber: number; etag: string; size: number }[];
+}
+
+interface SignMultipartPartsInput {
+    fileId: string;
+    uploadId: string;
+    partNumbers: number[];
+}
+
+interface SignMultipartPartsResult {
+    parts: { partNumber: number; url: string }[];
+    expiresAt: Date;
+}
+
+// Resume helpers share an ownership + status guard: the caller must own the
+// file and it must still be `uploading`. A file that already reached
+// `available` (completed) or `deleted` (aborted) has no live multipart upload
+// to reconcile against, so resuming it is a client bug, not a recoverable state.
+async function loadResumableFile(
+    db: DB,
+    userId: string,
+    fileId: string
+): Promise<File> {
+    const fileRepo = createFileRepo(db);
+    const file = await fileRepo.findByUserAndId(userId, fileId);
+    if (!file) {
+        throw new NotFoundError('File', fileId);
+    }
+    if (file.status !== 'uploading') {
+        throw new InvalidStateError(
+            `File is not in uploading state: ${file.status}`
+        );
+    }
+    return file;
+}
+
+// Reconcile against S3: report which parts S3 has already received so the
+// client can skip them on resume even when its local (IndexedDB) state is
+// stale or lost. ETags come straight from S3 and feed back into `complete`.
+async function listMultipartParts(
+    db: DB,
+    userId: string,
+    fileId: string,
+    uploadId: string
+): Promise<ListMultipartPartsResult> {
+    const file = await loadResumableFile(db, userId, fileId);
+    const parts = await s3.multipart.listParts(file.s3Key, uploadId);
+    return { parts };
+}
+
+// Re-presign a specific set of part numbers without restarting the upload.
+// Used for the parts left to upload on resume, and to refresh URLs that
+// expired mid-upload (part URLs live 1 hour).
+async function signMultipartParts(
+    db: DB,
+    userId: string,
+    input: SignMultipartPartsInput
+): Promise<SignMultipartPartsResult> {
+    const file = await loadResumableFile(db, userId, input.fileId);
+
+    const parts = await s3.multipart.signPartsByNumber({
+        key: file.s3Key,
+        uploadId: input.uploadId,
+        partNumbers: input.partNumbers,
+        expiresIn: MULTIPART_URL_EXPIRY_SECONDS,
+    });
+
+    const expiresAt = new Date(
+        Date.now() + MULTIPART_URL_EXPIRY_SECONDS * 1000
+    );
+
+    return { parts, expiresAt };
+}
+
 async function abortMultipartUpload(
     db: DB,
     userId: string,
@@ -320,6 +395,8 @@ export const fileService = {
     confirmUpload,
     initiateMultipartUpload,
     completeMultipartUpload,
+    listMultipartParts,
+    signMultipartParts,
     abortMultipartUpload,
     deleteUserFile,
 } as const;

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -224,6 +224,52 @@ export const filesRouter = router({
                 );
             }),
 
+        // Reconcile a resumed upload against S3: returns the parts S3 already
+        // holds so the client skips them even when its local state is stale.
+        // A mutation (not a query) so resume always reconciles fresh — a cached
+        // part list would let the client re-upload or skip the wrong parts.
+        listParts: protectedProcedure
+            .input(
+                z.object({
+                    fileId: z.string().uuid(),
+                    uploadId: z.string().min(1),
+                })
+            )
+            .mutation(({ ctx, input }) => {
+                return fileService.listMultipartParts(
+                    ctx.db,
+                    ctx.session.user.id,
+                    input.fileId,
+                    input.uploadId
+                );
+            }),
+
+        // Re-presign a specific set of part numbers without restarting the
+        // upload — for the parts left on resume and for URLs that expired
+        // mid-upload (part URLs live 1 hour).
+        signParts: protectedProcedure
+            .input(
+                z.object({
+                    fileId: z.string().uuid(),
+                    uploadId: z.string().min(1),
+                    partNumbers: z
+                        .array(z.number().int().min(1).max(10000))
+                        .min(1)
+                        .max(10000),
+                })
+            )
+            .mutation(({ ctx, input }) => {
+                return fileService.signMultipartParts(
+                    ctx.db,
+                    ctx.session.user.id,
+                    {
+                        fileId: input.fileId,
+                        uploadId: input.uploadId,
+                        partNumbers: input.partNumbers,
+                    }
+                );
+            }),
+
         abort: protectedProcedure
             .input(
                 z.object({

--- a/docs/guides/storage.md
+++ b/docs/guides/storage.md
@@ -147,6 +147,54 @@ Delete an object from the bucket. This operation is idempotent—it returns succ
 await s3.objects.remove('user/123/deleted-file.txt');
 ```
 
+### Multipart Uploads
+
+Large files (≥100 MB) upload in parts. The client PUTs each part to a presigned
+URL, collects the ETags, and completes the upload. These operations back the
+resumable-upload flow.
+
+#### `s3.multipart.create(key, contentType?)`
+
+Initiate a multipart upload. Returns `{ uploadId }` — required for every
+subsequent part operation.
+
+#### `s3.multipart.signParts(options)`
+
+Presign URLs for **all** parts at once (`{ key, uploadId, partCount, expiresIn? }`).
+Returns a `string[]` indexed by position (`partNumber - 1`). Used when starting a
+fresh upload. Default expiry: 3600s (1 hour).
+
+#### `s3.multipart.signPartsByNumber(options)`
+
+Presign URLs for a **specific** set of part numbers
+(`{ key, uploadId, partNumbers, expiresIn? }`). Returns `{ partNumber, url }[]`.
+Use this to re-presign only the parts left to upload on resume, and to refresh
+URLs that expired mid-upload — both without restarting the upload.
+
+```typescript
+const signed = await s3.multipart.signPartsByNumber({
+    key,
+    uploadId,
+    partNumbers: [3, 4, 5], // only the missing parts
+});
+```
+
+#### `s3.multipart.listParts(key, uploadId)`
+
+List the parts S3 has already received. Returns
+`{ partNumber, etag, size }[]`, paging through results automatically (S3 caps a
+single response at 1000 parts; 10000 parts max per upload). This is the
+authoritative source for resume reconciliation: it lets the client skip
+already-uploaded parts even when its local state is stale or lost, and the
+returned ETags feed straight back into `complete`.
+
+#### `s3.multipart.complete(key, uploadId, parts)` / `s3.multipart.abort(key, uploadId)`
+
+Finalize the upload with the collected `{ partNumber, etag }[]`, or abort to
+discard all uploaded parts. Incomplete uploads that are never completed or
+aborted are cleaned up by the bucket's `abort-incomplete-multipart` lifecycle
+rule (7 days) — see `docs/infra/aws-manual-setup.md`.
+
 ## Types
 
 All types are re-exported from the main module:


### PR DESCRIPTION
## Summary

Backend groundwork for resumable multipart uploads — **PR1 of 2** for #233. No UI or behavior changes yet; this adds the server primitives the client engine (PR2) needs to resume an interrupted upload instead of restarting from zero.

The current multipart flow presigns **all** parts upfront in `init` and keeps all state in React memory, so any interruption loses everything. Resuming needs two things the server couldn't do before: ask S3 which parts it already has, and presign just the parts that are left.

## What's here

| Layer | Change |
|---|---|
| S3 module | `s3.multipart.listParts(key, uploadId)` — paginated `ListParts`, returns `{partNumber, etag, size}[]`. The authoritative reconciliation source. |
| S3 module | `s3.multipart.signPartsByNumber({partNumbers})` — presign an arbitrary subset of parts (→ `{partNumber, url}[]`). Existing `signParts` now delegates to it; `init` is unchanged. |
| Service | `fileService.listMultipartParts` / `signMultipartParts`, sharing a `loadResumableFile` guard (owner check + must be `uploading`, else `NotFoundError` / `InvalidStateError`). |
| tRPC | `files.multipart.listParts` and `files.multipart.signParts` — both **mutations**, so resume reconciles fresh and re-presign never serves a cached expired URL. |
| Docs | New multipart section in `docs/guides/storage.md`. |

`signPartsByNumber` serves double duty: the remaining parts on resume, and refreshing URLs that expire mid-upload (part URLs live 1h) — both without restarting (AC: re-presign expired URLs).

## Orphan cleanup

The issue calls out dangling S3 multipart sessions. This turned out to be **already handled** — the bucket has a 7-day `abort-incomplete-multipart` lifecycle rule and the IAM policy already grants `s3:ListMultipartUploadParts` (`docs/infra/aws-manual-setup.md:51,84`). No infra change; documented rather than duplicated.

## Test plan

- [x] `pnpm check` — 10/10 tasks green
- [x] 296 unit tests pass (12 new: 6 storage, 6 service) covering pagination, subset presign, empty results, and the owner/status guards
- [x] `test:e2e:smoke` — 30/31; the one failure was the Stripe "provisions a trial" test, green on isolated re-run (pre-existing flake, unrelated to this diff)

## Follow-ups

- PR2: IndexedDB persistence + resumable `useUpload` state machine (same-session pause/resume on network drop, re-presign on expiry, reconcile via `ListParts`) + re-add resume UX
- #235: zero-touch cross-reload resume via File System Access API (Chromium)

Related to #233