### PR TITLE
fix(e2e): run suite against a production build on an ephemeral port

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -44,6 +44,23 @@ jobs:
         needs: migrate
         runs-on: ubuntu-latest
         timeout-minutes: 15
+        # e2e runs against a production build (next build + next start), so the
+        # build step and the test step both need these at build/runtime.
+        env:
+            NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+            NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLIC_KEY }}
+            NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+            DATABASE_URL: ${{ secrets.DATABASE_URL }}
+            SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_REGION: ${{ secrets.AWS_REGION }}
+            S3_BUCKET: ${{ secrets.S3_BUCKET }}
+            SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
+            STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+            STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+            BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
 
         steps:
             - name: Checkout
@@ -83,20 +100,12 @@ jobs:
               timeout-minutes: 5
               run: pnpm -F web exec playwright install chromium
 
+            # Build the production bundle (and workspace deps, including
+            # trpc-devtools) up front so a build failure fails fast here with
+            # full logs. The Playwright webServer rebuilds via the same turbo
+            # task, so this warms the cache and that rebuild is a no-op hit.
+            - name: Build app and workspace packages
+              run: pnpm exec turbo run build --filter=@nexus/web
+
             - name: Run smoke tests
               run: pnpm -F web test:e2e:smoke
-              env:
-                  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-                  NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
-                  NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLIC_KEY }}
-                  NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
-                  DATABASE_URL: ${{ secrets.DATABASE_URL }}
-                  SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
-                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  AWS_REGION: ${{ secrets.AWS_REGION }}
-                  S3_BUCKET: ${{ secrets.S3_BUCKET }}
-                  SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
-                  STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-                  STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
-                  BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -10,6 +10,9 @@ App-specific instructions for working on `apps/web/`.
 
 ## E2E Tests
 
+These run against a production build (`next build` + `next start`) on an
+ephemeral port, so they build before running and coexist with `pnpm dev`.
+
 Pick the smallest tier that covers your change:
 
 | Command                            | Covers                             | Run when you changed                              |

--- a/apps/web/app/api/dev/coverage/route.ts
+++ b/apps/web/app/api/dev/coverage/route.ts
@@ -26,7 +26,10 @@ function findRoot(): string {
 }
 
 export async function GET(): Promise<NextResponse> {
-    if (process.env.NODE_ENV !== 'development') {
+    // Dev-only by default. E2E runs against a production build (next start),
+    // so the `E2E` flag re-enables this route for the /dev/coverage and
+    // /dev/report smoke specs; the real Vercel deploy never sets it.
+    if (process.env.NODE_ENV !== 'development' && !process.env.E2E) {
         return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -46,7 +46,11 @@ export default function RootLayout({
                     </TRPCReactProvider>
                 </ThemeProvider>
                 <Toaster />
-                <Analytics />
+                {/* Vercel injects /_vercel/insights/script.js only on its edge;
+                    off-Vercel (local/CI production builds, e.g. e2e) that script
+                    404s and pollutes the zero-console-error assertions, so only
+                    mount it when actually deployed on Vercel. */}
+                {process.env.VERCEL ? <Analytics /> : null}
             </body>
         </html>
     );

--- a/apps/web/e2e/helpers/auth.ts
+++ b/apps/web/e2e/helpers/auth.ts
@@ -6,8 +6,12 @@ import {
     ensureTrialSubscription,
     deleteUserData,
 } from '@nexus/db/test-db';
+import { E2E_BASE_URL } from './server-url';
 
-const BASE_URL = 'http://localhost:3000';
+// Shared with playwright.config.ts so the Origin header and the request
+// context's baseURL track the ephemeral server port (BetterAuth trusts the
+// request's own origin, so these must match the server we actually started).
+const BASE_URL = E2E_BASE_URL;
 const AUTH_HEADERS = { Origin: BASE_URL };
 
 export interface TestUser {

--- a/apps/web/e2e/helpers/server-url.ts
+++ b/apps/web/e2e/helpers/server-url.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * The e2e suite runs against a production server (next build + next start). It
+ * binds an ephemeral free port rather than a fixed one so it never collides
+ * with a running `pnpm dev` (or anything else) — the dev server is exactly the
+ * thing we're avoiding, so we must not reuse it or fight it for a port.
+ *
+ * The port is chosen once, in the Playwright main process during config
+ * evaluation, and published on PLAYWRIGHT_E2E_PORT. The webServer child and the
+ * test workers inherit that env var (and re-read it here instead of picking a
+ * new port), so every process agrees on the same URL. Set PLAYWRIGHT_E2E_PORT
+ * yourself to pin a specific port.
+ */
+function resolvePort(): number {
+    const existing = process.env.PLAYWRIGHT_E2E_PORT;
+    if (existing) return Number(existing);
+
+    // Let the OS hand back a free port via listen(0). Done in a short-lived
+    // child so it stays synchronous — Playwright evaluates the config (and this
+    // module) synchronously, before the server or workers start.
+    const out = execFileSync(
+        process.execPath,
+        [
+            '-e',
+            "const s=require('net').createServer();s.listen(0,()=>{process.stdout.write(String(s.address().port));s.close();});",
+        ],
+        { encoding: 'utf8' }
+    );
+
+    const port = Number(out.trim());
+    if (!Number.isInteger(port) || port <= 0) {
+        throw new Error(`Could not resolve a free e2e port (got "${out}")`);
+    }
+
+    // Publish for the webServer child and test workers spawned after this.
+    process.env.PLAYWRIGHT_E2E_PORT = String(port);
+    return port;
+}
+
+export const E2E_PORT = resolvePort();
+export const E2E_BASE_URL = `http://localhost:${E2E_PORT}`;

--- a/apps/web/e2e/smoke/auth-flows.spec.ts
+++ b/apps/web/e2e/smoke/auth-flows.spec.ts
@@ -76,8 +76,12 @@ test.describe('auth flows', () => {
 
             // BetterAuth returns "Invalid email or password" — assert the
             // semantic alert rather than exact copy so wording tweaks don't
-            // break the test.
-            await expect(page.getByRole('alert')).toBeVisible({
+            // break the test. Filter to the text-bearing alert: a production
+            // build also renders Next's empty role="alert" route announcer,
+            // which would otherwise make getByRole('alert') ambiguous.
+            await expect(
+                page.getByRole('alert').filter({ hasText: /\S/ })
+            ).toBeVisible({
                 timeout: 10_000,
             });
             await expect(page).toHaveURL(/\/sign-in/);

--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -14,12 +14,19 @@ const devLanOrigins =
         ? ['http://192.168.*:3000', 'http://10.*:3000', 'http://172.*:3000']
         : [];
 
+// better-auth enables rate limiting in production by default. The e2e suite
+// runs against a production build and signs in many times concurrently, which
+// trips the limiter ("Too many requests"). Disable it only under the E2E flag;
+// real production keeps the default limiter.
+const rateLimit = process.env.E2E ? { enabled: false } : undefined;
+
 export const auth = betterAuth({
     database: drizzleAdapter(db, {
         provider: 'pg',
         schema,
     }),
     trustedOrigins: devLanOrigins,
+    rateLimit,
     emailAndPassword: {
         enabled: true,
     },

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,10 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
+// E2E runs its own production server on an ephemeral free port (see the module
+// for why), so it never collides with a running `pnpm dev` on 3000.
+import { E2E_PORT, E2E_BASE_URL } from './e2e/helpers/server-url';
 
-// Honor PORT so each `claude --worktree` checkout (which sets a per-worktree
-// PORT) runs its dev server and e2e on the same port. Falls back to 3000, so
-// CI and the main checkout are unchanged.
-const PORT = process.env.PORT ?? 3000;
-const BASE_URL = `http://localhost:${PORT}`;
+const BASE_URL = E2E_BASE_URL;
 
 const adminChrome = {
     ...devices['Desktop Chrome'],
@@ -94,9 +93,27 @@ export default defineConfig({
               ]
             : []),
     ],
+    // Run e2e against a production build (next build + next start), never the
+    // dev server. `next dev`'s on-demand Turbopack compilation deadlocks under
+    // Playwright's parallel load — routes hang and every goto fails with
+    // net::ERR_ABORTED at the 30s timeout — and it also never builds the
+    // `trpc-devtools` workspace package (its dist/ is gitignored), so CI saw
+    // "Module not found: trpc-devtools". A production build sidesteps both: the
+    // build runs through turbo so workspace deps (trpc-devtools, db) compile
+    // first, and `next start` serves pre-compiled routes with no per-request
+    // compilation to stall.
+    //
+    // The server binds an ephemeral free port (E2E_PORT), so it coexists with a
+    // running `pnpm dev` instead of fighting it for 3000; reuseExistingServer is
+    // off because each run gets a fresh port anyway. E2E=1 re-enables the
+    // dev-only coverage API and admin dev-tools procedures for the /dev/* specs.
     webServer: {
-        command: 'pnpm dev',
+        command: `pnpm exec turbo run build --filter=@nexus/web && pnpm exec next start --port ${E2E_PORT}`,
         url: BASE_URL,
-        reuseExistingServer: !process.env.CI,
+        reuseExistingServer: false,
+        timeout: 240_000,
+        env: { E2E: '1' },
+        stdout: 'pipe',
+        stderr: 'pipe',
     },
 });

--- a/apps/web/server/trpc/init.ts
+++ b/apps/web/server/trpc/init.ts
@@ -125,9 +125,12 @@ export const adminProcedure = protectedProcedure.use(({ ctx, next }) => {
     return next({ ctx });
 });
 
-// Dev tools procedure - admin-only and blocked in production
+// Dev tools procedure - admin-only and blocked in production. The e2e suite
+// runs against a production build, so the `E2E` flag re-enables these for the
+// admin dev-tools specs (seed/cleanup scenarios); the real Vercel deploy never
+// sets it, so dev tools stay blocked there.
 export const devToolsProcedure = adminProcedure.use(({ next }) => {
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV === 'production' && !process.env.E2E) {
         throw new TRPCError({
             code: 'FORBIDDEN',
             message: 'Dev tools are not available in production',


### PR DESCRIPTION
## Why

The e2e suite was failing in CI and locally, mostly with timeouts. Two distinct root causes, both from running against `next dev`:

- **Local:** `next dev`'s on-demand Turbopack compilation deadlocked under Playwright's parallel load — routes hung and every `goto` failed with `net::ERR_ABORTED` at the 30s timeout. A stale `.next` cache poisoned the dev server, so failures persisted across runs (`rm -rf .next` → green, run again → broken).
- **CI:** the dev server never builds the `trpc-devtools` workspace package (its `dist/` is gitignored and the smoke job ran no build), so Turbopack threw `Module not found: trpc-devtools`, which cascaded into console-error and navigation failures across the suite.

## What

Run e2e against a **production build** (`next build` + `next start`) instead of the dev server. The build goes through turbo so workspace deps (`trpc-devtools`, `db`) compile first, and `next start` serves pre-compiled routes — no per-request compilation to stall.

The server binds an **ephemeral free port**, shared across the Playwright main process, webServer, and workers via `PLAYWRIGHT_E2E_PORT`, so it coexists with a running `pnpm dev` (no port to free up).

Production mode surfaced behaviors `next dev` had masked, each handled so **real prod is unchanged**:

- Gate `<Analytics/>` to Vercel only — `/_vercel/insights/script.js` 404s off-Vercel and tripped the zero-console-error checks.
- `E2E=1` re-enables the dev-only coverage API and admin dev-tools tRPC procedures (blocked in production) for the `/dev/*` and admin specs.
- Disable better-auth's rate limiter under `E2E` (on by default in prod) so concurrent sign-ins don't hit "Too many requests".
- Filter the empty `role="alert"` route announcer that prod builds render (strict-mode ambiguity).

CI builds explicitly before the smoke step (fail-fast logs; the webServer rebuild is a turbo cache hit), with env hoisted to job level.

## Test plan

- `pnpm -F web test:e2e` → **59/59** across all tiers (smoke + flows + admin)
- Ran the smoke suite with `pnpm dev` occupying 3000 → **31/31**, dev still serving, no `EADDRINUSE` (coexistence + cross-process port consistency)
- `pnpm -F web typecheck` clean; `pnpm -F web test:run` → 278/278 unit tests

No-Issue: test/CI infrastructure fix
