### PR TITLE
feat: zero-touch cross-reload upload resume via File System Access API (#235)

### DIFF
--- a/apps/web/components/dashboard/upload-zone.tsx
+++ b/apps/web/components/dashboard/upload-zone.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type React from 'react';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
@@ -15,9 +15,15 @@ import {
     RotateCcw,
     PauseCircle,
     History,
+    Play,
 } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { formatBytes } from '@/lib/format';
+import {
+    isFileSystemAccessSupported,
+    pickFilesWithHandles,
+    pickedFilesFromDataTransfer,
+} from '@/lib/upload/fileSystemAccess';
 import { useUpload } from './useUpload';
 
 export function UploadZone() {
@@ -30,18 +36,36 @@ export function UploadZone() {
         startUpload,
         cancelFile,
         retryFile,
+        resumeWithHandle,
+        resumeAllWithHandles,
     } = useUpload();
 
     const [isDragOver, setIsDragOver] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
 
     const handleDrop = useCallback(
         (e: React.DragEvent) => {
             e.preventDefault();
             setIsDragOver(false);
-            void addFiles(e.dataTransfer.files);
+            // Read the DataTransfer synchronously — its items are only live
+            // during the event — then queue the files (with handles when present).
+            void pickedFilesFromDataTransfer(e.dataTransfer).then(addFiles);
         },
         [addFiles]
     );
+
+    // On Chromium the picker captures persistable handles for zero-touch resume;
+    // elsewhere it falls through to the plain file input (the re-add path). Decided
+    // at click time so there's no SSR/client mismatch and no render-time state.
+    const handleBrowse = useCallback(() => {
+        if (isFileSystemAccessSupported()) {
+            void pickFilesWithHandles().then((picked) => {
+                if (picked.length > 0) void addFiles(picked);
+            });
+        } else {
+            inputRef.current?.click();
+        }
+    }, [addFiles]);
 
     const handleDragOver = (e: React.DragEvent) => {
         e.preventDefault();
@@ -56,6 +80,9 @@ export function UploadZone() {
     const estimatedCost = (totalSize / (1024 * 1024 * 1024)) * 0.01; // $0.01 per GB per month
     const pendingFiles = files.filter((f) => f.status === 'pending');
     const hasCompletedFiles = files.some((f) => f.status === 'complete');
+    const quickResumable = files.filter(
+        (f) => f.status === 'resumable' && f.isQuickResumable
+    );
 
     return (
         <div className="space-y-6">
@@ -81,23 +108,32 @@ export function UploadZone() {
                         <p className="mb-4 text-sm text-muted-foreground">
                             or click to browse your computer
                         </p>
-                        <label>
-                            <input
-                                type="file"
-                                multiple
-                                className="hidden"
-                                onChange={(e) => void addFiles(e.target.files)}
-                                disabled={isUploading}
-                            />
-                            <Button
-                                variant="outline"
-                                disabled={isUploading}
-                                nativeButton={false}
-                                render={<span />}
-                            >
-                                Browse files
-                            </Button>
-                        </label>
+                        {/* Always rendered (hidden) as the non-Chromium fallback
+                            and the programmatic seam for tests; the picker path
+                            below is what captures resumable handles. */}
+                        <input
+                            ref={inputRef}
+                            type="file"
+                            multiple
+                            className="hidden"
+                            onChange={(e) => {
+                                const picked = Array.from(
+                                    e.target.files ?? []
+                                ).map((file) => ({ file }));
+                                void addFiles(picked);
+                                // Allow re-selecting the same file (e.g. to re-add
+                                // an interrupted upload) to fire onChange again.
+                                e.target.value = '';
+                            }}
+                            disabled={isUploading}
+                        />
+                        <Button
+                            variant="outline"
+                            disabled={isUploading}
+                            onClick={handleBrowse}
+                        >
+                            Browse files
+                        </Button>
                     </div>
                 </CardContent>
             </Card>
@@ -119,6 +155,31 @@ export function UploadZone() {
                                 </Button>
                             )}
                         </div>
+                        {quickResumable.length > 0 && (
+                            <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3">
+                                <div className="flex items-center gap-2 text-sm">
+                                    <History className="h-4 w-4 shrink-0 text-amber-500" />
+                                    <span>
+                                        <span className="font-medium">
+                                            {quickResumable.length}
+                                        </span>{' '}
+                                        interrupted{' '}
+                                        {quickResumable.length === 1
+                                            ? 'upload'
+                                            : 'uploads'}{' '}
+                                        ready to resume — no re-selecting
+                                    </span>
+                                </div>
+                                <Button
+                                    size="sm"
+                                    onClick={resumeAllWithHandles}
+                                    disabled={isUploading}
+                                >
+                                    <Play className="mr-2 h-4 w-4" />
+                                    Resume all
+                                </Button>
+                            </div>
+                        )}
                         <div className="space-y-3">
                             {files.map((file) => (
                                 <div
@@ -163,8 +224,9 @@ export function UploadZone() {
                                         )}
                                         {file.status === 'resumable' && (
                                             <p className="mt-1 text-xs text-amber-600">
-                                                Interrupted — re-add this file
-                                                to resume
+                                                {file.isQuickResumable
+                                                    ? 'Interrupted — resume in one click'
+                                                    : 'Interrupted — re-add this file to resume'}
                                             </p>
                                         )}
                                         {file.status === 'error' &&
@@ -187,6 +249,19 @@ export function UploadZone() {
                                                 <span className="sr-only">
                                                     Remove
                                                 </span>
+                                            </Button>
+                                        )}
+                                    {file.status === 'resumable' &&
+                                        file.isQuickResumable && (
+                                            <Button
+                                                size="sm"
+                                                onClick={() =>
+                                                    resumeWithHandle(file.id)
+                                                }
+                                                disabled={isUploading}
+                                            >
+                                                <Play className="mr-2 h-4 w-4" />
+                                                Resume
                                             </Button>
                                         )}
                                     {(file.status === 'uploading' ||

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -24,6 +24,11 @@ import {
     toFileIdentity,
 } from '@/lib/upload/parts';
 import {
+    isFileSystemAccessSupported,
+    reacquireMatchingFile,
+    type PickedFile,
+} from '@/lib/upload/fileSystemAccess';
+import {
     isAbortError,
     isExpiredUrlError,
     isNetworkError,
@@ -55,12 +60,21 @@ export interface UploadFile {
     progress: number;
     status: UploadStatus;
     error?: string;
+    // A `resumable` row whose persisted handle can be reopened in one click,
+    // rather than requiring the user to re-add the file (Chromium only).
+    isQuickResumable?: boolean;
 }
 
 interface InternalUploadFile extends UploadFile {
     // Null for an interrupted upload detected on reload — the bytes are gone
-    // until the user re-adds the file, at which point we reattach and resume.
+    // until the user re-adds the file (or one-click reopens its handle), at
+    // which point we reattach and resume.
     file: File | null;
+    // Persisted File System Access handle; lets us silently reopen the bytes on
+    // reload. Carried from the picker/drop and written into the IndexedDB record.
+    fileHandle?: FileSystemFileHandle;
+    // Identity field a reopened handle must match before we trust it to resume.
+    lastModified?: number;
     fileId?: string;
     uploadId?: string;
     chunkSize?: number;
@@ -221,6 +235,9 @@ export function useUpload() {
                         completedParts: [],
                         createdAt: now,
                         updatedAt: now,
+                        // Persist the handle (when we have one) so an interruption
+                        // is zero-touch resumable, not just re-add resumable.
+                        fileHandle: uploadFile.fileHandle,
                     });
                     updateFile(uploadFile.id, {
                         fileId,
@@ -431,13 +448,16 @@ export function useUpload() {
     }, [runUpload]);
 
     // Surface interrupted uploads found in IndexedDB on mount as `resumable`
-    // rows. The bytes are gone, so they show until the user re-adds the file.
+    // rows. Records that persisted a File System Access handle (and run on a
+    // browser that supports it) are marked `isQuickResumable` — the bytes can be
+    // reopened in one click. The rest show until the user re-adds the file.
     // Runs once per mount; the setFiles dedupe (by fileId) keeps it idempotent
     // under React StrictMode's double-invoked effects, so no cancel flag needed.
     const hydratedRef = useRef(false);
     useEffect(() => {
         if (hydratedRef.current) return;
         hydratedRef.current = true;
+        const hasFileSystemAccess = isFileSystemAccessSupported();
         void (async () => {
             const records = await listUploads();
             const resumable = records.filter(isResumable);
@@ -455,7 +475,10 @@ export function useUpload() {
                             r.totalParts
                         ),
                         status: 'resumable' as const,
+                        isQuickResumable: hasFileSystemAccess && !!r.fileHandle,
                         file: null,
+                        fileHandle: r.fileHandle,
+                        lastModified: r.lastModified,
                         fileId: r.fileId,
                         uploadId: r.uploadId,
                         chunkSize: r.chunkSize,
@@ -508,23 +531,22 @@ export function useUpload() {
         };
     }, [uploadMultipartFile]);
 
-    const addFiles = useCallback(async (fileList: FileList | null) => {
-        if (!fileList) return;
+    const addFiles = useCallback(async (picked: PickedFile[]) => {
+        if (picked.length === 0) return;
 
-        const incoming = Array.from(fileList);
         // Match each file against a persisted interrupted upload so a re-add
         // resumes from where S3 left off instead of starting over.
         const matches = await Promise.all(
-            incoming.map((file) => findUploadByIdentity(toFileIdentity(file)))
+            picked.map(({ file }) => findUploadByIdentity(toFileIdentity(file)))
         );
 
         setFiles((prev) => {
             // Reattach re-added files to their resumable rows (immutably), then
             // append rows for everything that didn't match an existing row.
-            const reattach = new Map<string, File>();
+            const reattach = new Map<string, PickedFile>();
             const appended: InternalUploadFile[] = [];
 
-            incoming.forEach((file, i) => {
+            picked.forEach(({ file, handle }, i) => {
                 const match = matches[i];
                 const existing =
                     match && isResumable(match)
@@ -534,7 +556,7 @@ export function useUpload() {
                 if (match && isResumable(match) && existing) {
                     // Re-add of an interrupted upload: queue it as resumable;
                     // clicking Upload continues from the last completed part.
-                    reattach.set(existing.id, file);
+                    reattach.set(existing.id, { file, handle });
                     return;
                 }
                 if (match && isResumable(match)) {
@@ -548,6 +570,7 @@ export function useUpload() {
                         ),
                         status: 'pending',
                         file,
+                        fileHandle: handle,
                         fileId: match.fileId,
                         uploadId: match.uploadId,
                         chunkSize: match.chunkSize,
@@ -563,15 +586,18 @@ export function useUpload() {
                     progress: 0,
                     status: 'pending',
                     file,
+                    fileHandle: handle,
                 });
             });
 
             const updated = prev.map((f) => {
-                const file = reattach.get(f.id);
-                return file
+                const reattached = reattach.get(f.id);
+                return reattached
                     ? {
                           ...f,
-                          file,
+                          file: reattached.file,
+                          // Keep any handle we already had if the re-add lacked one.
+                          fileHandle: reattached.handle ?? f.fileHandle,
                           status: 'pending' as const,
                           progress: partsProgress(
                               f.completedParts?.length ?? 0,
@@ -644,15 +670,80 @@ export function useUpload() {
         [updateFile, runUpload]
     );
 
+    // Reopen interrupted uploads from their persisted handles and resume them
+    // through the same multipart engine. Handles are reopened up front (in
+    // parallel) so the permission prompts ride the single click that triggered
+    // this, then resumed serially like the normal queue. A row whose handle
+    // can't be reopened (permission denied, file moved/changed) loses its
+    // quick-resume affordance and falls back to the manual re-add flow.
+    const resumeRows = useCallback(
+        async (rows: InternalUploadFile[]) => {
+            if (rows.length === 0) return;
+            setIsUploading(true);
+            try {
+                const reopened = await Promise.all(
+                    rows.map(async (row) => ({
+                        row,
+                        file: await reacquireRowFile(row),
+                    }))
+                );
+                let hasResumedAny = false;
+                for (const { row, file } of reopened) {
+                    if (!file) {
+                        updateFile(row.id, { isQuickResumable: false });
+                        continue;
+                    }
+                    hasResumedAny = true;
+                    updateFile(row.id, {
+                        file,
+                        status: 'pending',
+                        error: undefined,
+                    });
+                    await uploadMultipartFile({
+                        ...row,
+                        file,
+                        status: 'pending',
+                    });
+                }
+                if (!hasResumedAny) {
+                    toast.error(
+                        rows.length > 1
+                            ? "Couldn't reopen the files — re-add them to resume"
+                            : "Couldn't reopen the file — re-add it to resume"
+                    );
+                }
+            } finally {
+                setIsUploading(false);
+            }
+        },
+        [updateFile, uploadMultipartFile]
+    );
+
+    const resumeWithHandle = useCallback(
+        (id: string) => {
+            const row = filesRef.current.find((f) => f.id === id);
+            if (row) void resumeRows([row]);
+        },
+        [resumeRows]
+    );
+
+    const resumeAllWithHandles = useCallback(() => {
+        const rows = filesRef.current.filter(
+            (f) => f.status === 'resumable' && f.isQuickResumable
+        );
+        void resumeRows(rows);
+    }, [resumeRows]);
+
     // Expose only the public UploadFile shape (strip internal fields)
     const publicFiles: UploadFile[] = files.map(
-        ({ id, name, size, progress, status, error }) => ({
+        ({ id, name, size, progress, status, error, isQuickResumable }) => ({
             id,
             name,
             size,
             progress,
             status,
             error,
+            isQuickResumable,
         })
     );
 
@@ -665,7 +756,21 @@ export function useUpload() {
         startUpload: processQueue,
         cancelFile,
         retryFile,
+        resumeWithHandle,
+        resumeAllWithHandles,
     };
+}
+
+// Reopen the bytes behind a resumable row's persisted handle, verifying identity.
+// Resolves to null (so the caller falls back to re-add) when there's no handle or
+// it can't be reopened. Lives at module scope since it touches no reactive state.
+function reacquireRowFile(row: InternalUploadFile): Promise<File | null> {
+    if (!row.fileHandle) return Promise.resolve(null);
+    return reacquireMatchingFile(row.fileHandle, {
+        name: row.name,
+        size: row.size,
+        lastModified: row.lastModified ?? 0,
+    });
 }
 
 // Wrapped so it's easy to reason about in non-browser test contexts; the engine

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -295,6 +295,12 @@ export const USE_CASES: UseCaseEntry[] = [
             'Full resume needs a real >100MB multipart upload + S3 ListParts reconciliation; resume primitives and store/part logic are covered by unit tests, detection by upload-resume-detect',
         routes: ['/dashboard/upload'],
     },
+    {
+        id: 'upload-resume-one-click',
+        title: 'Interrupted upload with a persisted handle is shown as one-click resumable',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
 
     /* ---------------------------------------------------------------- */
     /* Billing & subscription                                            */

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -8,6 +8,7 @@
 import { test, expect } from '../fixtures';
 import { type TestUser } from '../helpers/auth';
 import { interceptTrpcCalls } from '../helpers/trpc';
+import { seedResumableUpload } from '../helpers/uploadStore';
 
 const UPLOAD_USER: TestUser = {
     email: 'upload-flows-e2e@test.local',
@@ -80,41 +81,9 @@ test(
         // Wait for the app to open the IndexedDB store before seeding it.
         await expect(page.getByText('Drop files here to upload')).toBeVisible();
 
-        // Seed a half-finished multipart upload directly into IndexedDB, as if a
-        // prior session had been interrupted (5 of 10 parts done).
-        await page.evaluate(async () => {
-            const open = indexedDB.open('nexus-uploads', 1);
-            const db: IDBDatabase = await new Promise((res, rej) => {
-                open.onupgradeneeded = () =>
-                    open.result.createObjectStore('uploads', {
-                        keyPath: 'fileId',
-                    });
-                open.onsuccess = () => res(open.result);
-                open.onerror = () => rej(open.error);
-            });
-            await new Promise<void>((res, rej) => {
-                const tx = db.transaction('uploads', 'readwrite');
-                tx.objectStore('uploads').put({
-                    fileId: '11111111-1111-1111-1111-111111111111',
-                    uploadId: 'seeded-upload-id',
-                    name: 'big-shoot.zip',
-                    size: 1_048_576_000,
-                    lastModified: 1700000000000,
-                    mimeType: 'application/zip',
-                    chunkSize: 104_857_600,
-                    totalParts: 10,
-                    completedParts: Array.from({ length: 5 }, (_, i) => ({
-                        partNumber: i + 1,
-                        etag: `"part-${i + 1}"`,
-                    })),
-                    createdAt: 1700000000000,
-                    updatedAt: 1700000000000,
-                });
-                tx.oncomplete = () => res();
-                tx.onerror = () => rej(tx.error);
-            });
-            db.close();
-        });
+        // Seed a half-finished multipart upload (5 of 10 parts) with no persisted
+        // handle, as if a prior session had been interrupted before this feature.
+        await seedResumableUpload(page);
 
         await page.reload();
 
@@ -129,6 +98,50 @@ test(
         ).toBeVisible();
         await expect(
             page.getByRole('button', { name: 'Retry upload' })
+        ).toBeHidden();
+
+        expect(consoleErrors).toEqual([]);
+    }
+);
+
+test(
+    'an interrupted upload with a persisted handle is shown as one-click resumable',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-resume-one-click'] },
+    async ({ page, consoleErrors }) => {
+        await page.goto(PAGE_URL);
+        await expect(page.getByText('Drop files here to upload')).toBeVisible();
+
+        // Seed an interrupted upload that captured a File System Access handle.
+        // A plain stand-in is enough for the surfacing: the app keys the
+        // one-click affordance on the handle's presence + browser support
+        // (Chromium, which Playwright runs). The actual reopen/permission flow
+        // can't be driven from a script, so it's covered by unit tests.
+        await seedResumableUpload(page, {
+            fileId: '22222222-2222-2222-2222-222222222222',
+            uploadId: 'seeded-handle-upload-id',
+            name: 'handle-shoot.zip',
+            size: 2_097_152_000,
+            totalParts: 20,
+            completedCount: 7,
+            fileHandle: { kind: 'file', name: 'handle-shoot.zip' },
+        });
+
+        await page.reload();
+
+        // The row offers one-click resume (not the re-add prompt), with both a
+        // per-row Resume button and a Resume-all affordance.
+        await expect(page.getByText('handle-shoot.zip')).toBeVisible();
+        await expect(
+            page.getByText('Interrupted — resume in one click')
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Resume', exact: true })
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Resume all' })
+        ).toBeVisible();
+        await expect(
+            page.getByText('Interrupted — re-add this file to resume')
         ).toBeHidden();
 
         expect(consoleErrors).toEqual([]);

--- a/apps/web/e2e/helpers/uploadStore.ts
+++ b/apps/web/e2e/helpers/uploadStore.ts
@@ -1,0 +1,74 @@
+import type { Page } from '@playwright/test';
+
+export interface SeedResumableUploadOptions {
+    fileId?: string;
+    uploadId?: string;
+    name?: string;
+    size?: number;
+    lastModified?: number;
+    mimeType?: string;
+    chunkSize?: number;
+    totalParts?: number;
+    completedCount?: number;
+    /** Plain stand-in for a persisted File System Access handle (one-click resume). */
+    fileHandle?: { kind: 'file'; name: string };
+}
+
+/**
+ * Seed a half-finished multipart upload straight into the browser's IndexedDB,
+ * as if a prior session had been interrupted. Mirrors the `nexus-uploads` store
+ * shape from `lib/upload/uploadStore.ts`, kept in one place so the resume tests
+ * don't each hand-roll (and drift on) the open/upgrade/put dance.
+ */
+export async function seedResumableUpload(
+    page: Page,
+    options: SeedResumableUploadOptions = {}
+): Promise<void> {
+    const {
+        fileId = '11111111-1111-1111-1111-111111111111',
+        uploadId = 'seeded-upload-id',
+        name = 'big-shoot.zip',
+        size = 1_048_576_000,
+        lastModified = 1700000000000,
+        mimeType = 'application/zip',
+        chunkSize = 104_857_600,
+        totalParts = 10,
+        completedCount = 5,
+        fileHandle,
+    } = options;
+
+    const record = {
+        fileId,
+        uploadId,
+        name,
+        size,
+        lastModified,
+        mimeType,
+        chunkSize,
+        totalParts,
+        completedParts: Array.from({ length: completedCount }, (_, i) => ({
+            partNumber: i + 1,
+            etag: `"part-${i + 1}"`,
+        })),
+        createdAt: lastModified,
+        updatedAt: lastModified,
+        ...(fileHandle ? { fileHandle } : {}),
+    };
+
+    await page.evaluate(async (seeded) => {
+        const open = indexedDB.open('nexus-uploads', 1);
+        const db: IDBDatabase = await new Promise((res, rej) => {
+            open.onupgradeneeded = () =>
+                open.result.createObjectStore('uploads', { keyPath: 'fileId' });
+            open.onsuccess = () => res(open.result);
+            open.onerror = () => rej(open.error);
+        });
+        await new Promise<void>((res, rej) => {
+            const tx = db.transaction('uploads', 'readwrite');
+            tx.objectStore('uploads').put(seeded);
+            tx.oncomplete = () => res();
+            tx.onerror = () => rej(tx.error);
+        });
+        db.close();
+    }, record);
+}

--- a/apps/web/lib/upload/fileSystemAccess.test.ts
+++ b/apps/web/lib/upload/fileSystemAccess.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+    isFileSystemAccessSupported,
+    pickFilesWithHandles,
+    pickedFilesFromDataTransfer,
+    reacquireMatchingFile,
+} from './fileSystemAccess';
+
+function makeFile(name: string, size: number, lastModified: number): File {
+    return new File([new Uint8Array(size)], name, { lastModified });
+}
+
+const IDENTITY = { name: 'shoot.zip', size: 8, lastModified: 1700000000000 };
+
+interface HandleStub {
+    query?: PermissionState;
+    request?: PermissionState;
+    file?: File;
+    throwOn?: 'query' | 'request' | 'getFile';
+}
+
+function stubHandle(opts: HandleStub = {}): FileSystemFileHandle {
+    const guard = (key: HandleStub['throwOn']) => {
+        if (opts.throwOn === key) throw new Error(`boom: ${key}`);
+    };
+    return {
+        kind: 'file',
+        name: IDENTITY.name,
+        queryPermission: vi.fn(async () => {
+            guard('query');
+            return opts.query ?? 'granted';
+        }),
+        requestPermission: vi.fn(async () => {
+            guard('request');
+            return opts.request ?? 'granted';
+        }),
+        getFile: vi.fn(async () => {
+            guard('getFile');
+            return (
+                opts.file ??
+                makeFile(IDENTITY.name, IDENTITY.size, IDENTITY.lastModified)
+            );
+        }),
+    } as unknown as FileSystemFileHandle;
+}
+
+afterEach(() => {
+    delete (window as { showOpenFilePicker?: unknown }).showOpenFilePicker;
+    vi.restoreAllMocks();
+});
+
+describe('isFileSystemAccessSupported', () => {
+    it('is false when the picker is absent (Firefox/Safari/jsdom)', () => {
+        expect(isFileSystemAccessSupported()).toBe(false);
+    });
+
+    it('is true when the picker exists (Chromium)', () => {
+        (window as { showOpenFilePicker?: unknown }).showOpenFilePicker =
+            () => {};
+        expect(isFileSystemAccessSupported()).toBe(true);
+    });
+});
+
+describe('reacquireMatchingFile', () => {
+    it('returns the file when permission is already granted and identity matches', async () => {
+        const handle = stubHandle({ query: 'granted' });
+        const file = await reacquireMatchingFile(handle, IDENTITY);
+        expect(file?.name).toBe(IDENTITY.name);
+        expect(handle.requestPermission).not.toHaveBeenCalled();
+    });
+
+    it('requests permission when not yet granted, then returns the file', async () => {
+        const handle = stubHandle({ query: 'prompt', request: 'granted' });
+        const file = await reacquireMatchingFile(handle, IDENTITY);
+        expect(file?.name).toBe(IDENTITY.name);
+        expect(handle.requestPermission).toHaveBeenCalled();
+    });
+
+    it('returns null when permission is denied', async () => {
+        const handle = stubHandle({ query: 'prompt', request: 'denied' });
+        expect(await reacquireMatchingFile(handle, IDENTITY)).toBeNull();
+    });
+
+    it('returns null when the reopened file no longer matches identity', async () => {
+        const handle = stubHandle({
+            file: makeFile(
+                IDENTITY.name,
+                IDENTITY.size + 1,
+                IDENTITY.lastModified
+            ),
+        });
+        expect(await reacquireMatchingFile(handle, IDENTITY)).toBeNull();
+    });
+
+    it('returns null (not throws) when a handle method throws', async () => {
+        expect(
+            await reacquireMatchingFile(
+                stubHandle({ throwOn: 'getFile' }),
+                IDENTITY
+            )
+        ).toBeNull();
+        expect(
+            await reacquireMatchingFile(
+                stubHandle({ throwOn: 'query' }),
+                IDENTITY
+            )
+        ).toBeNull();
+    });
+});
+
+describe('pickFilesWithHandles', () => {
+    it('returns [] when unsupported', async () => {
+        expect(await pickFilesWithHandles()).toEqual([]);
+    });
+
+    it('pairs each chosen file with its handle', async () => {
+        const handle = stubHandle();
+        (window as { showOpenFilePicker?: unknown }).showOpenFilePicker = vi.fn(
+            async () => [handle]
+        );
+        const picked = await pickFilesWithHandles();
+        expect(picked).toHaveLength(1);
+        expect(picked[0].handle).toBe(handle);
+        expect(picked[0].file.name).toBe(IDENTITY.name);
+    });
+
+    it('returns [] when the user dismisses the dialog (AbortError)', async () => {
+        (window as { showOpenFilePicker?: unknown }).showOpenFilePicker = vi.fn(
+            async () => {
+                throw new DOMException('cancelled', 'AbortError');
+            }
+        );
+        expect(await pickFilesWithHandles()).toEqual([]);
+    });
+});
+
+describe('pickedFilesFromDataTransfer', () => {
+    it('falls back to plain files when unsupported', async () => {
+        const file = makeFile(
+            IDENTITY.name,
+            IDENTITY.size,
+            IDENTITY.lastModified
+        );
+        const dataTransfer = {
+            files: [file],
+            items: [],
+        } as unknown as DataTransfer;
+
+        const picked = await pickedFilesFromDataTransfer(dataTransfer);
+        expect(picked).toEqual([{ file }]);
+    });
+
+    it('captures a handle per dropped item when supported', async () => {
+        (window as { showOpenFilePicker?: unknown }).showOpenFilePicker =
+            () => {};
+        const file = makeFile(
+            IDENTITY.name,
+            IDENTITY.size,
+            IDENTITY.lastModified
+        );
+        const handle = stubHandle();
+        const dataTransfer = {
+            files: [file],
+            items: [
+                {
+                    kind: 'file',
+                    getAsFile: () => file,
+                    getAsFileSystemHandle: async () => handle,
+                },
+            ],
+        } as unknown as DataTransfer;
+
+        const picked = await pickedFilesFromDataTransfer(dataTransfer);
+        expect(picked).toEqual([{ file, handle }]);
+    });
+});

--- a/apps/web/lib/upload/fileSystemAccess.ts
+++ b/apps/web/lib/upload/fileSystemAccess.ts
@@ -1,0 +1,109 @@
+import { isFileMatch, toFileIdentity, type FileIdentity } from './parts';
+import { isAbortError } from './errors';
+
+/**
+ * Thin, feature-detected wrapper over the File System Access API. On Chromium a
+ * picked file yields a `FileSystemFileHandle` that's structured-cloneable into
+ * IndexedDB, so after a reload we can re-acquire the bytes with a single
+ * permission click instead of asking the user to find and re-select the file.
+ * Everywhere else (Firefox, Safari) the helpers degrade to plain `File`s and the
+ * existing re-add flow takes over.
+ */
+
+/** A picked file plus the handle that makes it zero-touch resumable, when available. */
+export interface PickedFile {
+    file: File;
+    handle?: FileSystemFileHandle;
+}
+
+/** True when the browser exposes the picker + persistable handles (Chromium). */
+export function isFileSystemAccessSupported(): boolean {
+    return typeof window !== 'undefined' && 'showOpenFilePicker' in window;
+}
+
+/**
+ * Open the native picker and pair each chosen file with its persistable handle.
+ * Returns `[]` when unsupported or when the user dismisses the dialog (the API
+ * rejects with an AbortError, which isn't a real failure).
+ */
+export async function pickFilesWithHandles(): Promise<PickedFile[]> {
+    if (!isFileSystemAccessSupported()) return [];
+    let handles: FileSystemFileHandle[];
+    try {
+        handles = await window.showOpenFilePicker({ multiple: true });
+    } catch (error) {
+        if (isAbortError(error)) return [];
+        throw error;
+    }
+    return Promise.all(
+        handles.map(async (handle) => ({
+            file: await handle.getFile(),
+            handle,
+        }))
+    );
+}
+
+/**
+ * Read a drop's files, capturing a `FileSystemFileHandle` per item on Chromium so
+ * a dragged file is zero-touch resumable just like a picked one. The synchronous
+ * `getAsFile()` / `getAsFileSystemHandle()` reads happen before the first await,
+ * since the DataTransferItems are only live during the drop event.
+ */
+export async function pickedFilesFromDataTransfer(
+    dataTransfer: DataTransfer
+): Promise<PickedFile[]> {
+    if (!isFileSystemAccessSupported()) {
+        return Array.from(dataTransfer.files).map((file) => ({ file }));
+    }
+    const captured = Array.from(dataTransfer.items)
+        .filter((item) => item.kind === 'file')
+        .map((item) => ({
+            file: item.getAsFile(),
+            handlePromise: item.getAsFileSystemHandle(),
+        }));
+    const picked = await Promise.all(
+        captured.map(
+            async ({ file, handlePromise }): Promise<PickedFile | null> => {
+                if (!file) return null;
+                const handle = await handlePromise.catch(() => null);
+                return handle && handle.kind === 'file'
+                    ? { file, handle: handle as FileSystemFileHandle }
+                    : { file };
+            }
+        )
+    );
+    return picked.filter((p): p is PickedFile => p !== null);
+}
+
+/**
+ * Re-request read access to a persisted handle. Must run inside a user gesture
+ * (the click on "Resume") — after a reload the permission reverts to `prompt`,
+ * and `requestPermission` needs a gesture to show its prompt.
+ */
+async function ensureReadPermission(
+    handle: FileSystemFileHandle
+): Promise<boolean> {
+    const descriptor = { mode: 'read' } as const;
+    if ((await handle.queryPermission(descriptor)) === 'granted') return true;
+    return (await handle.requestPermission(descriptor)) === 'granted';
+}
+
+/**
+ * Re-acquire the File behind a persisted handle and confirm it still matches the
+ * upload's identity. Returns `null` if permission is denied, the file is gone, or
+ * it changed since it was picked — callers then fall back to the manual re-add
+ * flow. Defensive against any handle method throwing (older API shapes, revoked
+ * access), so a single click can't crash the resume.
+ */
+export async function reacquireMatchingFile(
+    handle: FileSystemFileHandle,
+    identity: FileIdentity
+): Promise<File | null> {
+    try {
+        if (!(await ensureReadPermission(handle))) return null;
+        const file = await handle.getFile();
+        return isFileMatch(identity, toFileIdentity(file)) ? file : null;
+    } catch {
+        return null;
+    }
+}

--- a/apps/web/lib/upload/uploadStore.test.ts
+++ b/apps/web/lib/upload/uploadStore.test.ts
@@ -47,6 +47,18 @@ describe('uploadStore', () => {
         expect(await getUpload('nope')).toBeUndefined();
     });
 
+    it('round-trips a persisted file handle', async () => {
+        // A real FileSystemFileHandle is structured-cloneable in Chromium; here a
+        // plain stand-in proves the optional field survives put/get unchanged.
+        const fileHandle = {
+            kind: 'file',
+            name: 'shoot.zip',
+        } as unknown as FileSystemFileHandle;
+        await putUpload(makeRecord({ fileHandle }));
+
+        expect((await getUpload('file-1'))?.fileHandle).toEqual(fileHandle);
+    });
+
     it('lists all records', async () => {
         await putUpload(makeRecord({ fileId: 'a' }));
         await putUpload(makeRecord({ fileId: 'b' }));

--- a/apps/web/lib/upload/uploadStore.ts
+++ b/apps/web/lib/upload/uploadStore.ts
@@ -33,6 +33,10 @@ export interface ResumableUpload {
     completedParts: CompletedPart[];
     createdAt: number;
     updatedAt: number;
+    // Chromium-only: the File System Access handle for zero-touch resume. It's
+    // structured-cloneable, so IndexedDB persists it directly — no schema bump.
+    // Absent on other browsers and pre-handle records, which fall back to re-add.
+    fileHandle?: FileSystemFileHandle;
 }
 
 interface UploadDBSchema extends DBSchema {

--- a/apps/web/types/file-system-access.d.ts
+++ b/apps/web/types/file-system-access.d.ts
@@ -1,0 +1,31 @@
+// File System Access API surface that TypeScript's lib.dom (5.9) still omits:
+// the permission methods on handles, the global picker, and the drag-drop handle
+// accessor. Chromium-only at runtime — every call site feature-detects first.
+
+interface FileSystemHandlePermissionDescriptor {
+    mode?: 'read' | 'readwrite';
+}
+
+interface FileSystemHandle {
+    queryPermission(
+        descriptor?: FileSystemHandlePermissionDescriptor
+    ): Promise<PermissionState>;
+    requestPermission(
+        descriptor?: FileSystemHandlePermissionDescriptor
+    ): Promise<PermissionState>;
+}
+
+interface OpenFilePickerOptions {
+    multiple?: boolean;
+    excludeAcceptAllOption?: boolean;
+}
+
+interface Window {
+    showOpenFilePicker(
+        options?: OpenFilePickerOptions
+    ): Promise<FileSystemFileHandle[]>;
+}
+
+interface DataTransferItem {
+    getAsFileSystemHandle(): Promise<FileSystemHandle | null>;
+}


### PR DESCRIPTION
## Summary

Follow-up to #233. Resumable uploads there use the **re-add-the-file** mechanism: after a reload/crash the browser has lost the file's bytes, so the user must re-select the same file to continue. This adds the **zero-touch** path on Chromium via the [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API).

When a file is picked (or dropped) on Chromium, the returned `FileSystemFileHandle` is structured-cloneable and persisted alongside the #233 IndexedDB record. On return, an interrupted upload with a persisted handle shows a one-click **Resume** (per row) and **Resume all** — a single gesture re-requests read permission, reopens the bytes, verifies identity, and continues through the existing multipart engine. Firefox/Safari and pre-handle records fall through to the unchanged re-add flow.

Closes #235

## Changes

- **`lib/upload/fileSystemAccess.ts`** (new): feature-detected wrapper — `isFileSystemAccessSupported`, `pickFilesWithHandles` (picker), `pickedFilesFromDataTransfer` (drop, captures a handle per item), and `reacquireMatchingFile` (re-request read permission, reopen, verify identity; fully defensive → returns `null` to trigger re-add fallback).
- **`lib/upload/uploadStore.ts`**: added optional `fileHandle` to `ResumableUpload` (structured-cloneable, no schema/version bump).
- **`components/dashboard/useUpload.ts`**: capture the handle from picker/drop, persist it at multipart init, hydrate interrupted uploads as `isQuickResumable`, and add `resumeWithHandle` / `resumeAllWithHandles` (reopen handles up front so the permission prompts ride the single click, then resume serially through the existing engine + S3 ListParts reconciliation).
- **`components/dashboard/upload-zone.tsx`**: "Browse files" uses the picker on Chromium (decided at click time, input kept as fallback), drag-drop captures handles, per-row **Resume** button + a **Resume all** banner. Distinct copy for one-click-resumable vs re-add rows.
- **`types/file-system-access.d.ts`** (new): ambient types for the FSA bits lib.dom (TS 5.9) still omits.
- **Tests**: unit tests for the FSA wrapper and the store round-trip; an e2e test asserting the one-click affordances surface; shared `seedResumableUpload` e2e helper (de-dupes the IndexedDB seeding across both resume tests); coverage-manifest entry `upload-resume-one-click`.

## Test Plan

- [x] `pnpm check` (lint + build + unit — 45 upload unit tests pass)
- [x] `pnpm -F web test:e2e:flows` (19/19, incl. new one-click-resume surfacing test)
- [x] `pnpm -F web test:e2e:smoke` (31/31)
- [ ] Manual (Chromium): pick a >100MB file, interrupt mid-upload, reload → **Resume** reopens without re-selecting; deny permission or swap the file → falls back to re-add. Note: **Resume all** across N files fires one click but Chromium may surface one permission prompt per file (copy says "ready to resume — no re-selecting" rather than promising a single prompt).
- [ ] Manual (Firefox/Safari): confirm the existing re-add flow is unchanged.

## Notes

Self-reviewed via conventions / code-quality / reuse agents; applied fixes (naming, dead-field removal, redundant filter, shared e2e seed helper, honest banner copy). Scope is multipart-only, matching #233 (single-PUT uploads aren't resumable server-side). Directory/folder handles are out of scope.