### PR TITLE
feat: send retrieval-ready email on restore completion (#26)

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/files/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/files/page.tsx
@@ -1,6 +1,14 @@
 import { FileBrowser } from '@/components/dashboard/file-browser';
 
-export default function FilesPage() {
+interface FilesPageProps {
+    searchParams: Promise<{ file?: string }>;
+}
+
+// `?file={id}` is the deep-link target used by the retrieval-ready email —
+// FileBrowser scrolls to and highlights that file.
+export default async function FilesPage({ searchParams }: FilesPageProps) {
+    const { file } = await searchParams;
+
     return (
         <div className="mx-auto max-w-6xl space-y-6">
             <div>
@@ -9,7 +17,7 @@ export default function FilesPage() {
                     Browse and manage your archived files
                 </p>
             </div>
-            <FileBrowser />
+            <FileBrowser focusFileId={file} />
         </div>
     );
 }

--- a/apps/web/components/dashboard/file-browser.tsx
+++ b/apps/web/components/dashboard/file-browser.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -261,7 +261,12 @@ function SelectableIcon({
     );
 }
 
-export function FileBrowser() {
+interface FileBrowserProps {
+    /** Deep-link target (`?file={id}`): scroll to and highlight this file. */
+    focusFileId?: string;
+}
+
+export function FileBrowser({ focusFileId }: FileBrowserProps) {
     const trpc = useTRPC();
     const invalidateFileList = useInvalidateFileList();
 
@@ -286,6 +291,30 @@ export function FileBrowser() {
 
     const groups = useMemo(() => groupsData ?? [], [groupsData]);
     const counts = countsData ?? { archived: 0, retrieving: 0, available: 0 };
+
+    // Seeded from the deep-link so the target row is highlighted from first
+    // paint; cleared on a timer once we've scrolled to it.
+    const [highlightedFileId, setHighlightedFileId] = useState<string | null>(
+        focusFileId ?? null
+    );
+    const hasScrolledToFocus = useRef(false);
+
+    // Deep-link focus (retrieval-ready email lands here): once the list loads,
+    // scroll the target file into view. Runs once per mount; batches render
+    // expanded by default so the row is in the DOM.
+    useEffect(() => {
+        if (!focusFileId || hasScrolledToFocus.current) return;
+        if (!groups.some((g) => g.files.some((f) => f.id === focusFileId)))
+            return;
+        hasScrolledToFocus.current = true;
+
+        document
+            .querySelector(`[data-file-id="${CSS.escape(focusFileId)}"]`)
+            ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        // No cleanup: re-runs early-return via the ref, and clearing here would
+        // cancel the fade whenever an unrelated dep change re-fires the effect.
+        setTimeout(() => setHighlightedFileId(null), 2500);
+    }, [focusFileId, groups]);
 
     // Search filters files inside each group and drops groups that empty out.
     // Client-side is fine for the validation cohort; revisit when datasets grow.
@@ -601,6 +630,10 @@ export function FileBrowser() {
                                                         isSelected={selectedFiles.includes(
                                                             file.id
                                                         )}
+                                                        isHighlighted={
+                                                            file.id ===
+                                                            highlightedFileId
+                                                        }
                                                         hasSelection={
                                                             hasSelection
                                                         }
@@ -650,6 +683,10 @@ export function FileBrowser() {
                                                         isSelected={selectedFiles.includes(
                                                             file.id
                                                         )}
+                                                        isHighlighted={
+                                                            file.id ===
+                                                            highlightedFileId
+                                                        }
                                                         hasSelection={
                                                             hasSelection
                                                         }
@@ -900,6 +937,7 @@ function BatchRestoreSlot({ batchId, files }: BatchRestoreSlotProps) {
 interface FileItemProps {
     file: File;
     isSelected: boolean;
+    isHighlighted: boolean;
     hasSelection: boolean;
     onSelect: (shiftKey: boolean) => void;
 }
@@ -944,18 +982,26 @@ function useFileActions(file: File) {
     };
 }
 
-function FileRow({ file, isSelected, hasSelection, onSelect }: FileItemProps) {
+function FileRow({
+    file,
+    isSelected,
+    isHighlighted,
+    hasSelection,
+    onSelect,
+}: FileItemProps) {
     const status = deriveStatus(file);
     const actions = useFileActions(file);
     const ext = getFileExtension(file.name);
 
     return (
         <TableRow
+            data-file-id={file.id}
             data-state={isSelected ? 'selected' : undefined}
             className={cn(
                 'cursor-pointer transition-colors',
                 isSelected &&
-                    'bg-primary/4 hover:bg-primary/6 dark:bg-primary/8 dark:hover:bg-primary/10'
+                    'bg-primary/4 hover:bg-primary/6 dark:bg-primary/8 dark:hover:bg-primary/10',
+                isHighlighted && 'bg-primary/10 dark:bg-primary/15'
             )}
             onClick={(e) => onSelect(e.shiftKey)}
         >
@@ -996,18 +1042,26 @@ function FileRow({ file, isSelected, hasSelection, onSelect }: FileItemProps) {
     );
 }
 
-function FileCard({ file, isSelected, hasSelection, onSelect }: FileItemProps) {
+function FileCard({
+    file,
+    isSelected,
+    isHighlighted,
+    hasSelection,
+    onSelect,
+}: FileItemProps) {
     const status = deriveStatus(file);
     const actions = useFileActions(file);
     const ext = getFileExtension(file.name);
 
     return (
         <Card
+            data-file-id={file.id}
             className={cn(
                 'group relative cursor-pointer py-0 transition-all',
                 isSelected
                     ? 'ring-2 ring-primary/30 bg-primary/2 dark:bg-primary/6'
-                    : 'hover:border-border/80'
+                    : 'hover:border-border/80',
+                isHighlighted && 'ring-2 ring-primary/40'
             )}
             onClick={(e) => onSelect(e.shiftKey)}
         >

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -230,6 +230,12 @@ export const USE_CASES: UseCaseEntry[] = [
         area: 'files',
         routes: ['/dashboard/files'],
     },
+    {
+        id: 'files-deep-link-focus',
+        title: 'Deep-link ?file={id} highlights the target file (retrieval-ready email landing)',
+        area: 'files',
+        routes: ['/dashboard/files'],
+    },
 
     /* ---------------------------------------------------------------- */
     /* Upload                                                            */

--- a/apps/web/e2e/flows/files-browser.spec.ts
+++ b/apps/web/e2e/flows/files-browser.spec.ts
@@ -138,6 +138,24 @@ test.describe('with a seeded library', () => {
     );
 
     test(
+        'deep-link ?file={id} highlights the target file',
+        { tag: ['@uc:files-deep-link-focus'] },
+        async ({ page, seededLibrary }) => {
+            // The retrieval-ready email lands here; the target row should be
+            // in view and visibly highlighted.
+            await page.goto(`${PAGE_URL}?file=${seededLibrary.archivedB.id}`);
+
+            const row = page.locator(
+                `[data-file-id="${seededLibrary.archivedB.id}"]`
+            );
+            await expect(row).toBeInViewport();
+            // The highlight tint is seeded from the query param at first paint
+            // and clears on a timer, so assert it before it fades.
+            await expect(row).toHaveClass(/bg-primary\/10/);
+        }
+    );
+
+    test(
         'search filters files and shows the no-match state',
         { tag: ['@uc:files-search'] },
         async ({ page, seededLibrary }) => {

--- a/apps/web/server/services/s3-restore.test.ts
+++ b/apps/web/server/services/s3-restore.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+    createMockDb,
+    createFileFixture,
+    createRetrievalFixture,
+    TEST_FILE_ID,
+    TEST_RETRIEVAL_ID,
+    TEST_USER_ID,
+} from '@nexus/db/testing';
+import type { S3EventRecord } from '@/lib/sns/types';
+
+const hoisted = await vi.hoisted(async () => {
+    const { createMockLogger } = await import('@/server/lib/logger/testing');
+    return {
+        logger: createMockLogger(),
+        sendRetrievalReadyEmail: vi.fn(),
+    };
+});
+
+vi.mock('@/lib/env', () => ({
+    env: { NEXT_PUBLIC_APP_URL: 'https://test.example' },
+}));
+
+vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
+
+vi.mock('@/server/services/email', () => ({
+    emailService: { sendRetrievalReadyEmail: hoisted.sendRetrievalReadyEmail },
+}));
+
+import { s3RestoreService } from './s3-restore';
+
+const RESTORE_EXPIRY = '2026-07-10T12:00:00.000Z';
+
+function makeRecord(overrides: Partial<S3EventRecord> = {}): S3EventRecord {
+    return {
+        eventName: 's3:ObjectRestore:Completed',
+        s3: {
+            bucket: { name: 'test-bucket' },
+            object: { key: 'uploads/test-file.jpg' },
+        },
+        glacierEventData: {
+            restoreEventData: {
+                lifecycleRestorationExpiryTime: RESTORE_EXPIRY,
+            },
+        },
+        ...overrides,
+    };
+}
+
+describe('s3RestoreService.dispatch', () => {
+    let mockDb: ReturnType<typeof createMockDb>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockDb = createMockDb();
+        mockDb.mocks.files.findFirst.mockResolvedValue(createFileFixture());
+        mockDb.mocks.retrievals.findFirst.mockResolvedValue(
+            createRetrievalFixture()
+        );
+    });
+
+    describe('restore completed', () => {
+        it('sends the retrieval-ready email to the file owner with an app deep-link', async () => {
+            const handled = await s3RestoreService.dispatch(
+                mockDb.db,
+                makeRecord()
+            );
+
+            expect(handled).toBe(true);
+            expect(hoisted.sendRetrievalReadyEmail).toHaveBeenCalledTimes(1);
+            expect(hoisted.sendRetrievalReadyEmail).toHaveBeenCalledWith(
+                mockDb.db,
+                {
+                    userId: TEST_USER_ID,
+                    fileName: createFileFixture().name,
+                    downloadUrl: `https://test.example/dashboard/files?file=${TEST_FILE_ID}`,
+                    expiresAt: new Date(RESTORE_EXPIRY),
+                }
+            );
+        });
+
+        it('does not throw when the email send fails', async () => {
+            hoisted.sendRetrievalReadyEmail.mockRejectedValueOnce(
+                new Error('resend down')
+            );
+
+            await expect(
+                s3RestoreService.dispatch(mockDb.db, makeRecord())
+            ).resolves.toBe(true);
+
+            expect(hoisted.logger.error).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    fileId: TEST_FILE_ID,
+                    retrievalId: TEST_RETRIEVAL_ID,
+                }),
+                'Retrieval-ready notification failed after restore completion'
+            );
+        });
+
+        it('skips the email when the event carries no expiry', async () => {
+            await s3RestoreService.dispatch(
+                mockDb.db,
+                makeRecord({ glacierEventData: undefined })
+            );
+
+            expect(hoisted.sendRetrievalReadyEmail).not.toHaveBeenCalled();
+            expect(hoisted.logger.warn).toHaveBeenCalledWith(
+                expect.objectContaining({ fileId: TEST_FILE_ID }),
+                'Skipping retrieval-ready email: no expiry available'
+            );
+        });
+
+        it('sends no email when the file is unknown', async () => {
+            mockDb.mocks.files.findFirst.mockResolvedValue(undefined);
+
+            const handled = await s3RestoreService.dispatch(
+                mockDb.db,
+                makeRecord()
+            );
+
+            expect(handled).toBe(true);
+            expect(hoisted.sendRetrievalReadyEmail).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('non-completion events', () => {
+        it('sends no email on restore expiry', async () => {
+            const handled = await s3RestoreService.dispatch(
+                mockDb.db,
+                makeRecord({ eventName: 's3:ObjectRestore:Delete' })
+            );
+
+            expect(handled).toBe(true);
+            expect(hoisted.sendRetrievalReadyEmail).not.toHaveBeenCalled();
+        });
+
+        it('sends no email for unhandled event types', async () => {
+            const handled = await s3RestoreService.dispatch(
+                mockDb.db,
+                makeRecord({ eventName: 's3:ObjectCreated:Put' })
+            );
+
+            expect(handled).toBe(false);
+            expect(hoisted.sendRetrievalReadyEmail).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/web/server/services/s3-restore.ts
+++ b/apps/web/server/services/s3-restore.ts
@@ -1,6 +1,8 @@
 import type { DB } from '@nexus/db';
 import { createFileRepo, type File } from '@nexus/db/repo/files';
 import { createRetrievalRepo, type Retrieval } from '@nexus/db/repo/retrievals';
+import { env } from '@/lib/env';
+import { emailService } from '@/server/services/email';
 import { logger } from '@/server/lib/logger';
 import type { S3EventRecord } from '@/lib/sns/types';
 
@@ -72,6 +74,45 @@ async function handleRestoreCompleted(
         { fileId: file.id, retrievalId: retrieval.id, expiresAt },
         'Retrieval marked as ready'
     );
+
+    await sendReadyNotification(db, file, retrieval, expiresAt);
+}
+
+// The email links to the app (login → file focused → Download), not a presigned
+// S3 URL: presigned URLs expire in an hour while the restore stays downloadable
+// until expiresAt, and minting the S3 URL on click keeps it revocable.
+async function sendReadyNotification(
+    db: DB,
+    file: File,
+    retrieval: Retrieval,
+    expiresAt: Date | undefined
+): Promise<void> {
+    // Completed events always carry the restore expiry in practice; a missing
+    // one means a malformed event, and the template needs a date to render.
+    if (!expiresAt) {
+        log.warn(
+            { fileId: file.id, retrievalId: retrieval.id },
+            'Skipping retrieval-ready email: no expiry available'
+        );
+        return;
+    }
+
+    try {
+        await emailService.sendRetrievalReadyEmail(db, {
+            userId: file.userId,
+            fileName: file.name,
+            downloadUrl: `${env.NEXT_PUBLIC_APP_URL}/dashboard/files?file=${file.id}`,
+            expiresAt,
+        });
+    } catch (err) {
+        // The restore completed and status is persisted — a notification
+        // failure must not mark the webhook event as failed. (The email
+        // service swallows send errors itself; this guards its user lookup.)
+        log.error(
+            { err, fileId: file.id, retrievalId: retrieval.id },
+            'Retrieval-ready notification failed after restore completion'
+        );
+    }
 }
 
 async function handleRestoreExpired(


### PR DESCRIPTION
## Summary

Wires the existing `emailService.sendRetrievalReadyEmail` (#34) into the Glacier restore-completion webhook path. When `s3:ObjectRestore:Completed` lands, the file owner gets the retrieval-ready email with a link that stays valid for the whole restore window: an app deep-link (`/dashboard/files?file={id}`) rather than a 1-hour presigned S3 URL. The files page resolves that deep-link by scrolling to and briefly highlighting the target file.

Closes #26

## Changes

- `s3-restore.ts`: `handleRestoreCompleted` now calls `sendReadyNotification` after persisting `ready` status — builds the deep-link from `NEXT_PUBLIC_APP_URL`, passes `userId`/`fileName`/`expiresAt` from records already in scope (no extra queries), and catches + logs any email error so the webhook event stays `processed` (SNS still gets 200 either way). A malformed Completed event with no expiry skips the email with a warn (the template requires a date).
- `files/page.tsx` + `file-browser.tsx`: `?file={id}` seeds a highlight from first paint and scrolls the row/card into view once the list loads; highlight fades after 2.5s. Works in both list and grid views via `data-file-id`.
- Unit tests (`s3-restore.test.ts`): email sent to the owner with the exact deep-link payload; email failure doesn't throw out of the webhook; no email on `expired`/unhandled events or unknown files.
- E2E: `files-deep-link-focus` use-case added to the coverage manifest with a tagged flows test.

## Self-review notes

Three review agents (conventions / quality / reuse) ran pre-commit. Applied: dropped a speculative expiry fallback, differentiated the outer catch's log message from the email service's internal one (the outer catch guards the user lookup, which `emailService` doesn't swallow), added the coverage-manifest entry + flows test. Deliberately skipped as not worth it at 2 call sites: a shared S3-event-record test fixture and a `lib/routes.ts` deep-link helper.

Per the issue: a swallowed email failure is log-only for now (webhook is idempotent, so no retry) — a durable outbox stays a follow-up if we decide we need it.

## Test Plan

- [x] `pnpm check` — 10/10
- [x] `pnpm -F web test:e2e:smoke` — 31/31
- [x] `pnpm -F web test:e2e:flows` — 20/20 (includes new deep-link test)
- [x] `pnpm -F web e2e:coverage --check` — 100% pages + use-cases