### PR TITLE
feat: add auth guard for dashboard routes, preserve deep-links (#243)

### DIFF
--- a/apps/web/app/(auth)/sign-in/page.tsx
+++ b/apps/web/app/(auth)/sign-in/page.tsx
@@ -1,7 +1,23 @@
 import Link from 'next/link';
 import { SignInForm } from '@/components/auth/sign-in-form';
+import {
+    DEFAULT_REDIRECT,
+    sanitizeRedirect,
+} from '@/lib/auth/sanitizeRedirect';
 
-export default function SignInPage() {
+interface SignInPageProps {
+    searchParams: Promise<{ redirect?: string }>;
+}
+
+export default async function SignInPage({ searchParams }: SignInPageProps) {
+    const { redirect } = await searchParams;
+    const redirectTo = sanitizeRedirect(redirect);
+    // Carry the redirect across to sign-up so switching forms keeps the target.
+    const signUpHref =
+        redirectTo === DEFAULT_REDIRECT
+            ? '/sign-up'
+            : `/sign-up?redirect=${encodeURIComponent(redirectTo)}`;
+
     return (
         <div className="mx-auto w-full max-w-md">
             <div className="mb-8 text-center">
@@ -10,11 +26,11 @@ export default function SignInPage() {
                     Sign in to access your files
                 </p>
             </div>
-            <SignInForm />
+            <SignInForm redirectTo={redirectTo} />
             <p className="mt-6 text-center text-sm text-muted-foreground">
                 Don&apos;t have an account?{' '}
                 <Link
-                    href="/sign-up"
+                    href={signUpHref}
                     className="font-medium text-primary hover:underline"
                 >
                     Sign up

--- a/apps/web/app/(auth)/sign-up/page.tsx
+++ b/apps/web/app/(auth)/sign-up/page.tsx
@@ -1,8 +1,24 @@
 import Link from 'next/link';
-import { SignUpForm } from '@/components/auth/sign-up-form';
 import { Shield, DollarSign, Archive } from 'lucide-react';
+import { SignUpForm } from '@/components/auth/sign-up-form';
+import {
+    DEFAULT_REDIRECT,
+    sanitizeRedirect,
+} from '@/lib/auth/sanitizeRedirect';
 
-export default function SignUpPage() {
+interface SignUpPageProps {
+    searchParams: Promise<{ redirect?: string }>;
+}
+
+export default async function SignUpPage({ searchParams }: SignUpPageProps) {
+    const { redirect } = await searchParams;
+    const redirectTo = sanitizeRedirect(redirect);
+    // Carry the redirect across to sign-in so switching forms keeps the target.
+    const signInHref =
+        redirectTo === DEFAULT_REDIRECT
+            ? '/sign-in'
+            : `/sign-in?redirect=${encodeURIComponent(redirectTo)}`;
+
     return (
         <div className="mx-auto w-full max-w-md">
             <div className="mb-8 text-center">
@@ -11,11 +27,11 @@ export default function SignUpPage() {
                     Start storing your files securely for less
                 </p>
             </div>
-            <SignUpForm />
+            <SignUpForm redirectTo={redirectTo} />
             <p className="mt-6 text-center text-sm text-muted-foreground">
                 Already have an account?{' '}
                 <Link
-                    href="/sign-in"
+                    href={signInHref}
                     className="font-medium text-primary hover:underline"
                 >
                     Sign in

--- a/apps/web/components/auth/sign-in-form.tsx
+++ b/apps/web/components/auth/sign-in-form.tsx
@@ -5,15 +5,21 @@ import type React from 'react';
 import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { GoogleIcon } from '@/components/icons/google-icon';
 import { OAuthDivider } from '@/components/auth/oauth-divider';
 import { signIn } from '@/lib/auth/client';
-import { Loader2 } from 'lucide-react';
+import { DEFAULT_REDIRECT } from '@/lib/auth/sanitizeRedirect';
 
-export function SignInForm() {
+interface SignInFormProps {
+    /** Sanitized path to land on after a successful sign-in. */
+    redirectTo?: string;
+}
+
+export function SignInForm({ redirectTo = DEFAULT_REDIRECT }: SignInFormProps) {
     const router = useRouter();
     const [isLoading, setIsLoading] = useState(false);
     const [isGoogleLoading, setIsGoogleLoading] = useState(false);
@@ -38,7 +44,7 @@ export function SignInForm() {
             return;
         }
 
-        router.push('/dashboard');
+        router.push(redirectTo);
     }
 
     async function onGoogleSignIn() {

--- a/apps/web/components/auth/sign-up-form.tsx
+++ b/apps/web/components/auth/sign-up-form.tsx
@@ -6,15 +6,21 @@ import type React from 'react';
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { GoogleIcon } from '@/components/icons/google-icon';
 import { OAuthDivider } from '@/components/auth/oauth-divider';
 import { signUp } from '@/lib/auth/client';
-import { Loader2 } from 'lucide-react';
+import { DEFAULT_REDIRECT } from '@/lib/auth/sanitizeRedirect';
 
-export function SignUpForm() {
+interface SignUpFormProps {
+    /** Sanitized path to land on after a successful sign-up. */
+    redirectTo?: string;
+}
+
+export function SignUpForm({ redirectTo = DEFAULT_REDIRECT }: SignUpFormProps) {
     const router = useRouter();
     const [isLoading, setIsLoading] = useState(false);
     const [isGoogleLoading, setIsGoogleLoading] = useState(false);
@@ -41,7 +47,7 @@ export function SignUpForm() {
             return;
         }
 
-        router.push('/dashboard');
+        router.push(redirectTo);
     }
 
     async function onGoogleSignUp() {

--- a/apps/web/e2e/admin/jobs.spec.ts
+++ b/apps/web/e2e/admin/jobs.spec.ts
@@ -18,7 +18,7 @@ test.describe(
     'auth guards',
     { tag: ['@page:/dashboard/admin/jobs', '@uc:auth-guard-admin'] },
     () => {
-        test('unauthenticated user is redirected to dashboard', async ({
+        test('unauthenticated user is redirected to sign-in', async ({
             browser,
         }) => {
             const context = await browser.newContext({
@@ -28,8 +28,11 @@ test.describe(
 
             await page.goto(PAGE_URL);
 
-            // Admin layout redirects unauthenticated users to /dashboard
-            await expect(page).toHaveURL(/\/dashboard$/);
+            // The proxy guard catches signed-out users before the admin layout
+            // runs and sends them to sign-in with the original path preserved.
+            await expect(page).toHaveURL(/\/sign-in\?redirect=/);
+            const redirect = new URL(page.url()).searchParams.get('redirect');
+            expect(redirect).toBe(PAGE_URL);
             await context.close();
         });
 

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -119,6 +119,24 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/admin/jobs'],
     },
     {
+        id: 'auth-guard-dashboard',
+        title: 'Signed-out visitors to dashboard routes are redirected to sign-in with the original path preserved',
+        area: 'auth',
+        routes: ['/dashboard/files', '/sign-in'],
+    },
+    {
+        id: 'auth-guard-deep-link-round-trip',
+        title: 'Signing in from a preserved deep-link lands back on the original URL',
+        area: 'auth',
+        routes: ['/sign-in', '/dashboard/files'],
+    },
+    {
+        id: 'auth-guard-signed-in-redirect',
+        title: 'Signed-in visitors to /sign-in or /sign-up are forwarded to the dashboard',
+        area: 'auth',
+        routes: ['/sign-in', '/sign-up'],
+    },
+    {
         id: 'sign-in-google',
         title: 'Sign in / sign up with Google OAuth',
         area: 'auth',

--- a/apps/web/e2e/smoke/auth-guard.spec.ts
+++ b/apps/web/e2e/smoke/auth-guard.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Dashboard auth guard (proxy.ts). Runs on the bare smoke project (no
+ * storageState) so the signed-out cases start genuinely unauthenticated; the
+ * inverse-guard case opens its own context off the shared user state. Signing
+ * in through the UI creates a fresh session, so it never invalidates the
+ * shared `e2e/.auth/*.json` states other specs rely on.
+ */
+import { test, expect } from '@playwright/test';
+import { REGULAR_USER, USER_STATE_PATH } from '../helpers/auth';
+
+// A file id that need not exist — the guard/redirect is what's under test, not
+// the row highlight (covered by @uc:files-deep-link-focus).
+const DEEP_LINK = '/dashboard/files?file=deep-link-target';
+
+test.describe('dashboard auth guard', () => {
+    test(
+        'signed-out visitor to a dashboard deep-link is redirected to sign-in with the path preserved',
+        { tag: ['@page:/dashboard/files', '@uc:auth-guard-dashboard'] },
+        async ({ page }) => {
+            await page.goto(DEEP_LINK);
+
+            await expect(page).toHaveURL(/\/sign-in\?redirect=/);
+            const redirect = new URL(page.url()).searchParams.get('redirect');
+            expect(redirect).toBe(DEEP_LINK);
+        }
+    );
+
+    test(
+        'signing in from a preserved deep-link lands back on the original URL',
+        { tag: ['@page:/sign-in', '@uc:auth-guard-deep-link-round-trip'] },
+        async ({ page }) => {
+            await page.goto(DEEP_LINK);
+            await expect(page).toHaveURL(/\/sign-in\?redirect=/);
+
+            await page.getByLabel('Email').fill(REGULAR_USER.email);
+            await page.getByLabel('Password').fill(REGULAR_USER.password);
+            await page.getByRole('button', { name: 'Sign in' }).click();
+
+            await expect(page).toHaveURL(
+                /\/dashboard\/files\?file=deep-link-target$/,
+                {
+                    timeout: 15_000,
+                }
+            );
+        }
+    );
+
+    test(
+        'signed-in visitor to an auth page is forwarded to the dashboard',
+        { tag: ['@page:/sign-in', '@uc:auth-guard-signed-in-redirect'] },
+        async ({ browser }) => {
+            const context = await browser.newContext({
+                storageState: USER_STATE_PATH,
+            });
+            const page = await context.newPage();
+
+            await page.goto('/sign-in');
+            await expect(page).toHaveURL(/\/dashboard$/);
+
+            await page.goto('/sign-up');
+            await expect(page).toHaveURL(/\/dashboard$/);
+
+            await context.close();
+        }
+    );
+});

--- a/apps/web/e2e/smoke/error-handling.spec.ts
+++ b/apps/web/e2e/smoke/error-handling.spec.ts
@@ -1,13 +1,26 @@
 import { test, expect } from '@playwright/test';
+import { E2E_BASE_URL } from '../helpers/server-url';
 
 test.describe('Error Handling Infrastructure', () => {
     test(
         'tRPC error shows toast notification',
         { tag: ['@uc:trpc-error-toast'] },
-        async ({ page }) => {
-            // /dashboard/files calls trpc.files.list (protectedProcedure),
-            // which throws UNAUTHORIZED without auth. The errorLink should
-            // surface this as a toast. React Query retries 3x (~7s).
+        async ({ context, page }) => {
+            // A forged session cookie slips past the optimistic proxy guard
+            // (presence-only, no DB hit) but fails tRPC's protectedProcedure —
+            // the "forged cookie sees the shell and 401s" invariant
+            // (docs/ai/conventions.md § Auth Enforcement). /dashboard/files
+            // then calls trpc.files.list, which throws UNAUTHORIZED; the
+            // errorLink should surface it as a toast. React Query retries 3x
+            // (~7s). Without the cookie the proxy would redirect to /sign-in
+            // and no tRPC call would fire.
+            await context.addCookies([
+                {
+                    name: 'better-auth.session_token',
+                    value: 'forged-invalid-session',
+                    url: E2E_BASE_URL,
+                },
+            ]);
 
             await page.goto('/dashboard/files');
 

--- a/apps/web/lib/auth/sanitizeRedirect.test.ts
+++ b/apps/web/lib/auth/sanitizeRedirect.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_REDIRECT, sanitizeRedirect } from './sanitizeRedirect';
+
+describe('sanitizeRedirect', () => {
+    it('passes through same-origin relative paths, query and all', () => {
+        expect(sanitizeRedirect('/dashboard/files')).toBe('/dashboard/files');
+        expect(sanitizeRedirect('/dashboard/files?file=abc123')).toBe(
+            '/dashboard/files?file=abc123'
+        );
+    });
+
+    it('falls back when no target is supplied', () => {
+        expect(sanitizeRedirect(undefined)).toBe(DEFAULT_REDIRECT);
+        expect(sanitizeRedirect(null)).toBe(DEFAULT_REDIRECT);
+        expect(sanitizeRedirect('')).toBe(DEFAULT_REDIRECT);
+    });
+
+    it('rejects off-site targets (open-redirect guard)', () => {
+        expect(sanitizeRedirect('https://evil.com')).toBe(DEFAULT_REDIRECT);
+        expect(sanitizeRedirect('//evil.com')).toBe(DEFAULT_REDIRECT);
+        expect(sanitizeRedirect('/\\evil.com')).toBe(DEFAULT_REDIRECT);
+        expect(sanitizeRedirect('javascript:alert(1)')).toBe(DEFAULT_REDIRECT);
+        expect(sanitizeRedirect('dashboard')).toBe(DEFAULT_REDIRECT);
+    });
+});

--- a/apps/web/lib/auth/sanitizeRedirect.ts
+++ b/apps/web/lib/auth/sanitizeRedirect.ts
@@ -1,0 +1,20 @@
+/** Where signed-in users land when no valid redirect target is supplied. */
+export const DEFAULT_REDIRECT = '/dashboard';
+
+/**
+ * Validate a `redirect` query param before we navigate to it. Only same-origin
+ * relative paths are honored — anything that could point off-site is dropped in
+ * favor of {@link DEFAULT_REDIRECT}, closing the open-redirect hole an
+ * attacker-supplied `?redirect=` would otherwise open.
+ *
+ * Rejected: absolute URLs (`https://evil.com`), protocol-relative (`//evil.com`)
+ * and the backslash variant (`/\evil.com`, which some browsers treat as
+ * protocol-relative), and anything not rooted at `/`.
+ */
+export function sanitizeRedirect(target: string | null | undefined): string {
+    if (!target || !target.startsWith('/')) return DEFAULT_REDIRECT;
+    if (target.startsWith('//') || target.startsWith('/\\')) {
+        return DEFAULT_REDIRECT;
+    }
+    return target;
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,0 +1,39 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getSessionCookie } from 'better-auth/cookies';
+import { sanitizeRedirect } from '@/lib/auth/sanitizeRedirect';
+
+const AUTH_ROUTES = ['/sign-in', '/sign-up'];
+
+/**
+ * Optimistic auth guard (UX layer only). It reads the session cookie's
+ * presence — no DB hit — to keep signed-out users out of the dashboard shell
+ * and signed-in users out of the auth pages. Real enforcement stays in tRPC's
+ * `protectedProcedure`; a forged cookie gets past here but sees an empty shell
+ * and 401s. See docs/ai/conventions.md § Auth Enforcement.
+ */
+export function proxy(req: NextRequest): NextResponse {
+    const { nextUrl } = req;
+    const { pathname } = nextUrl;
+    const hasSession = Boolean(getSessionCookie(req));
+
+    // Signed-out visitor to a dashboard route → sign-in, preserving the full
+    // path+query so email deep-links (e.g. ?file=<id>) survive the round trip.
+    if (!hasSession && pathname.startsWith('/dashboard')) {
+        const signInUrl = new URL('/sign-in', req.url);
+        signInUrl.searchParams.set('redirect', pathname + nextUrl.search);
+        return NextResponse.redirect(signInUrl);
+    }
+
+    // Signed-in visitor to an auth page → forward to their redirect target
+    // (sanitized) or the dashboard, so they never see a stale sign-in form.
+    if (hasSession && AUTH_ROUTES.includes(pathname)) {
+        const target = sanitizeRedirect(nextUrl.searchParams.get('redirect'));
+        return NextResponse.redirect(new URL(target, req.url));
+    }
+
+    return NextResponse.next();
+}
+
+export const config = {
+    matcher: ['/dashboard/:path*', '/sign-in', '/sign-up'],
+};

--- a/docs/ai/conventions.md
+++ b/docs/ai/conventions.md
@@ -87,6 +87,12 @@ Terse reference for AI agents. Detailed examples with code: [[../conventions/nam
 
 See [[../guides/server-architecture|Server Architecture Guide]] for the full layered pattern.
 
+## Auth Enforcement
+
+- `apps/web/proxy.ts` guards `/dashboard/*` with an **optimistic** cookie-presence check (no DB hit) — a UX layer only. It redirects signed-out users to `/sign-in?redirect=<path>` and signed-in users away from the auth pages.
+- The proxy is **not** real protection: a forged cookie gets past it, sees an empty shell, and 401s. Real enforcement is tRPC's `protectedProcedure`.
+- Any dashboard page that fetches data in a **server component** must do its own `auth.api.getSession` check (precedent: `app/(dashboard)/dashboard/admin/layout.tsx`) — the proxy does not cover it.
+
 ## Issue-Driven Development
 
 All non-trivial work requires a GitHub Issue with scope, acceptance criteria, and out-of-scope.


### PR DESCRIPTION
## Summary

Adds an auth guard for the `(dashboard)` route group. Previously a signed-out user opening any `/dashboard/*` URL got the full shell, an UNAUTHORIZED toast, a spinner, then an empty state — no redirect, no way forward. This became a real problem with #242's retrieval-ready emails, which deep-link to `/dashboard/files?file={id}`: clicked days later while signed out, the `?file=` param was silently lost.

The guard lives once in `apps/web/proxy.ts` (Next 16's `middleware.ts` successor) as an optimistic cookie-presence check — no DB hit per request. Signed-out users hitting `/dashboard/*` are redirected to `/sign-in?redirect=<path+query>`; after signing in (or up) they land back on the original URL, so email deep-links survive end to end. The inverse guard forwards signed-in users off the auth pages.

Closes #243

## Changes

- **`apps/web/proxy.ts`** (new) — optimistic `getSessionCookie` guard: no cookie on `/dashboard/*` → `/sign-in?redirect=<path>`; session cookie on `/sign-in`|`/sign-up` → forward to the (sanitized) redirect target or `/dashboard`.
- **`lib/auth/sanitizeRedirect.ts`** (new) — open-redirect guard: only same-origin relative paths honored; rejects absolute, `//`, and `/\` targets. Unit-tested.
- **Sign-in/sign-up pages + forms** — pages read and sanitize the `redirect` param server-side, pass it to the form (pushed on success) and carry it across the sign-in↔sign-up cross-link.
- **`docs/ai/conventions.md`** — new § Auth Enforcement documenting the invariant: the proxy is UX-only; real enforcement stays in tRPC `protectedProcedure`, and server-component data fetches must do their own `getSession` check.
- **E2E** — new `smoke/auth-guard.spec.ts` (signed-out redirect w/ path preserved, deep-link round-trip via UI sign-in, inverse guard) + 3 manifest use-cases. Reworked `error-handling.spec.ts` to trigger the tRPC error toast via a forged cookie (which now slips past the optimistic proxy but 401s at tRPC — exactly the documented invariant), since the old "unauthenticated → shell + toast" premise is the bug this PR fixes. Updated `admin/jobs.spec.ts` unauthenticated case to expect the sign-in redirect.

## Test Plan

- [x] `pnpm check` (lint + build + unit) green
- [x] `pnpm -F web test:e2e` — all 65 e2e pass (smoke + flows + admin)
- [x] `pnpm -F web e2e:coverage --check` — 100% pages/use-cases
- [x] Manual: signed out, open an email deep-link `/dashboard/files?file=<id>` → land on sign-in → sign in → land back on the file, highlighted

## Self-review notes

Three review agents ran (conventions, code-quality, reuse). Applied: dropped a speculative `fallback` param, tidied import order. Deliberately left inline (2 call sites each, out of #243's strict scope) as possible follow-ups: extract the auth-page redirect-carry href builder into a helper, and extract shared e2e helpers (`signInThroughUi`, `expectRedirectedToSignIn`) reusable by `auth-flows.spec`/`jobs.spec`.

## Out of scope

- `/dev/*` and `/design` page routes remain publicly reachable in prod (their tRPC procedures are gated); known and deliberately not addressed here.