### PR TITLE
feat: sponsored-access backend — status, invites, provisioning (#239)

### DIFF
--- a/apps/web/components/dashboard/subscriptionPlans.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.ts
@@ -73,6 +73,8 @@ const STATUS_BADGES: Record<Subscription['status'], StatusBadge> = {
     canceled: { label: 'Canceled', variant: 'destructive' },
     unpaid: { label: 'Unpaid', variant: 'destructive' },
     incomplete: { label: 'Incomplete', variant: 'secondary' },
+    // Minimal badge for comped alpha testers; richer sponsored UI is #246
+    sponsored: { label: 'Sponsored', variant: 'default' },
 };
 
 const UNKNOWN_STATUS_BADGE: StatusBadge = {

--- a/apps/web/lib/auth/inviteCookie.ts
+++ b/apps/web/lib/auth/inviteCookie.ts
@@ -1,0 +1,8 @@
+/**
+ * Cookie carrying an invite token from the `/invite/[token]` redemption page
+ * (#246) to the signup create-hook in `lib/auth/server.ts`, where a valid
+ * pending invite provisions a sponsored subscription instead of a trial.
+ * Lives outside `server.ts` so the client-side page can import it without
+ * pulling in the server auth instance.
+ */
+export const INVITE_TOKEN_COOKIE = 'nexus_invite_token';

--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import * as schema from '@nexus/db/schema';
+import { INVITE_TOKEN_COOKIE } from '@/lib/auth/inviteCookie';
 import { db } from '@/server/db';
 import { subscriptionService } from '@/server/services/subscriptions';
 import { logger } from '@/server/lib/logger';
@@ -50,18 +51,28 @@ export const auth = betterAuth({
                 // failure. The user row may persist as an orphan if the hook
                 // throws — the `backfill-trial-subscriptions` script
                 // recovers those by inserting the missing subscription.
-                after: async (user) => {
+                // (Sponsored-path failures never reach here: the service
+                // falls back to a trial internally; only trial-provisioning
+                // failure rethrows.)
+                after: async (user, context) => {
+                    // Set by the /invite/[token] redemption page (#246);
+                    // absent for normal signups.
+                    const inviteToken =
+                        context?.getCookie(INVITE_TOKEN_COOKIE) ?? null;
                     try {
-                        await subscriptionService.provisionTrialSubscription(
+                        await subscriptionService.provisionSignupSubscription(
                             db,
-                            user.id,
-                            user.email,
-                            user.name
+                            {
+                                id: user.id,
+                                email: user.email,
+                                name: user.name,
+                            },
+                            inviteToken
                         );
                     } catch (err) {
                         log.error(
                             { err, userId: user.id },
-                            'Failed to provision trial subscription on signup'
+                            'Failed to provision subscription on signup'
                         );
                         throw err;
                     }

--- a/apps/web/server/services/constants.ts
+++ b/apps/web/server/services/constants.ts
@@ -8,6 +8,13 @@ export type { CheckoutTier, BillingInterval } from '@/lib/stripe/types';
 export const TRIAL_DURATION_DAYS = 30;
 
 /**
+ * Default storage cap for sponsored (comped alpha-tester) subscriptions.
+ * An invite may carry a per-tester `storageLimit` override; this is the
+ * fallback when it doesn't.
+ */
+export const SPONSORED_DEFAULT_STORAGE_LIMIT = PLAN_LIMITS.max;
+
+/**
  * Resolves the effective plan (limit + tier) for a user, falling back to
  * starter when no subscription exists. Centralizes the starter-default so
  * callers don't duplicate the null-coalesce across services.

--- a/apps/web/server/services/invites.test.ts
+++ b/apps/web/server/services/invites.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+    createMockDb,
+    createInviteFixture,
+    TEST_ADMIN_USER_ID,
+    TEST_INVITE_ID,
+    TEST_INVITE_TOKEN,
+    type MockDb,
+    type MockDbMocks,
+} from '@nexus/db/testing';
+
+const hoisted = await vi.hoisted(async () => {
+    const { createMockLogger } = await import('@/server/lib/logger/testing');
+    return { logger: createMockLogger() };
+});
+
+vi.mock('@/lib/env', () => ({
+    env: { NEXT_PUBLIC_APP_URL: 'https://test.example' },
+}));
+
+vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
+
+import { NotFoundError, InvalidStateError } from '@/server/errors';
+import { inviteService } from './invites';
+
+describe('inviteService.createInvite', () => {
+    let db: MockDb;
+    let mocks: MockDbMocks;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+        mocks.returning.mockResolvedValue([createInviteFixture()]);
+    });
+
+    function insertedRow(callIndex = 0): Record<string, unknown> {
+        return mocks.values.mock.calls[callIndex][0];
+    }
+
+    it('generates a base64url token with 32 bytes of entropy', async () => {
+        await inviteService.createInvite(db, {
+            createdBy: TEST_ADMIN_USER_ID,
+        });
+
+        // 32 random bytes → exactly 43 base64url chars, no padding
+        expect(insertedRow().token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    });
+
+    it('generates a distinct token per invite', async () => {
+        await inviteService.createInvite(db, {
+            createdBy: TEST_ADMIN_USER_ID,
+        });
+        await inviteService.createInvite(db, {
+            createdBy: TEST_ADMIN_USER_ID,
+        });
+
+        expect(insertedRow(0).token).not.toBe(insertedRow(1).token);
+    });
+
+    it('defaults email, storageLimit, and expiresAt to null', async () => {
+        await inviteService.createInvite(db, {
+            createdBy: TEST_ADMIN_USER_ID,
+        });
+
+        expect(mocks.values).toHaveBeenCalledWith(
+            expect.objectContaining({
+                createdBy: TEST_ADMIN_USER_ID,
+                email: null,
+                storageLimit: null,
+                expiresAt: null,
+            })
+        );
+    });
+
+    it('passes optional email binding, storage override, and expiry through', async () => {
+        const expiresAt = new Date('2026-08-01T00:00:00Z');
+
+        await inviteService.createInvite(db, {
+            createdBy: TEST_ADMIN_USER_ID,
+            email: 'tester@example.com',
+            storageLimit: 20 * 1024 ** 4,
+            expiresAt,
+        });
+
+        expect(mocks.values).toHaveBeenCalledWith(
+            expect.objectContaining({
+                email: 'tester@example.com',
+                storageLimit: 20 * 1024 ** 4,
+                expiresAt,
+            })
+        );
+    });
+
+    it('returns the redemption link for the created invite', async () => {
+        const { url } = await inviteService.createInvite(db, {
+            createdBy: TEST_ADMIN_USER_ID,
+        });
+
+        expect(url).toBe(`https://test.example/invite/${TEST_INVITE_TOKEN}`);
+    });
+});
+
+describe('inviteService.revokeInvite', () => {
+    let db: MockDb;
+    let mocks: MockDbMocks;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+    });
+
+    it('revokes a pending invite', async () => {
+        const revoked = createInviteFixture({ status: 'revoked' });
+        mocks.returning.mockResolvedValue([revoked]);
+
+        const result = await inviteService.revokeInvite(db, TEST_INVITE_ID);
+
+        expect(mocks.set).toHaveBeenCalledWith({ status: 'revoked' });
+        expect(result).toBe(revoked);
+    });
+
+    it('throws NotFoundError when the invite does not exist', async () => {
+        mocks.returning.mockResolvedValue([]);
+        mocks.invites.findFirst.mockResolvedValue(undefined);
+
+        await expect(inviteService.revokeInvite(db, 'missing')).rejects.toThrow(
+            NotFoundError
+        );
+    });
+
+    it('throws InvalidStateError when the invite is already redeemed', async () => {
+        mocks.returning.mockResolvedValue([]);
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ status: 'redeemed' })
+        );
+
+        await expect(
+            inviteService.revokeInvite(db, TEST_INVITE_ID)
+        ).rejects.toThrow(InvalidStateError);
+    });
+});

--- a/apps/web/server/services/invites.ts
+++ b/apps/web/server/services/invites.ts
@@ -1,0 +1,70 @@
+import { randomBytes } from 'node:crypto';
+import type { DB } from '@nexus/db';
+import { createInviteRepo, type Invite } from '@nexus/db/repo/invites';
+import { env } from '@/lib/env';
+import { InvalidStateError, NotFoundError } from '@/server/errors';
+import { logger } from '@/server/lib/logger';
+
+const log = logger.child({ service: 'invites' });
+
+export interface CreateInviteInput {
+    createdBy: string;
+    email?: string;
+    storageLimit?: number;
+    expiresAt?: Date;
+}
+
+/** 32 bytes → 43-char base64url; ≥128 bits of entropy per the token decision in #239. */
+function generateInviteToken(): string {
+    return randomBytes(32).toString('base64url');
+}
+
+async function createInvite(
+    db: DB,
+    input: CreateInviteInput
+): Promise<{ invite: Invite; url: string }> {
+    const repo = createInviteRepo(db);
+    const invite = await repo.insert({
+        id: crypto.randomUUID(),
+        token: generateInviteToken(),
+        email: input.email ?? null,
+        storageLimit: input.storageLimit ?? null,
+        expiresAt: input.expiresAt ?? null,
+        createdBy: input.createdBy,
+    });
+
+    log.info(
+        {
+            inviteId: invite.id,
+            createdBy: invite.createdBy,
+            email: invite.email,
+            storageLimit: invite.storageLimit,
+            expiresAt: invite.expiresAt,
+        },
+        'Invite created'
+    );
+
+    return { invite, url: `${env.NEXT_PUBLIC_APP_URL}/invite/${invite.token}` };
+}
+
+async function revokeInvite(db: DB, id: string): Promise<Invite> {
+    const repo = createInviteRepo(db);
+    const revoked = await repo.revoke(id);
+    if (revoked) {
+        log.info({ inviteId: id }, 'Invite revoked');
+        return revoked;
+    }
+
+    // The conditional update matched nothing — distinguish missing from
+    // already-redeemed/revoked for a useful admin-facing error.
+    const existing = await repo.findById(id);
+    if (!existing) throw new NotFoundError('Invite', id);
+    throw new InvalidStateError(
+        `Only pending invites can be revoked (invite is ${existing.status})`
+    );
+}
+
+export const inviteService = {
+    createInvite,
+    revokeInvite,
+} as const;

--- a/apps/web/server/services/quota.test.ts
+++ b/apps/web/server/services/quota.test.ts
@@ -222,6 +222,65 @@ describe('assertUploadAllowed', () => {
             ).not.toThrow();
         });
     });
+
+    // Sponsored rows are good-standing by construction: no Stripe
+    // subscription, no trial expiry — only storageLimit is enforced (#239).
+    describe('with a sponsored subscription', () => {
+        it('never throws TrialExpiredError, even with a stale trialEnd set', () => {
+            const subscription = {
+                storageLimit: PLAN_LIMITS.max,
+                status: 'sponsored' as const,
+                trialEnd: new Date(NOW.getTime() - 1),
+            };
+
+            expect(() =>
+                assertUploadAllowed(
+                    ctx({ currentUsage: 0, subscription }),
+                    oneGB,
+                    NOW
+                )
+            ).not.toThrow();
+        });
+
+        it('allows uploads up to the sponsored storage limit', () => {
+            const subscription = {
+                storageLimit: PLAN_LIMITS.max,
+                status: 'sponsored' as const,
+                trialEnd: null,
+            };
+
+            const result = assertUploadAllowed(
+                ctx({
+                    currentUsage: PLAN_LIMITS.max - oneGB,
+                    subscription,
+                }),
+                oneGB,
+                NOW
+            );
+
+            expect(result.allowed).toBe(true);
+            expect(result.limitBytes).toBe(PLAN_LIMITS.max);
+        });
+
+        it('still enforces the storage limit with QuotaExceededError', () => {
+            const subscription = {
+                storageLimit: PLAN_LIMITS.max,
+                status: 'sponsored' as const,
+                trialEnd: null,
+            };
+
+            expect(() =>
+                assertUploadAllowed(
+                    ctx({
+                        currentUsage: Math.floor(PLAN_LIMITS.max * 1.05),
+                        subscription,
+                    }),
+                    oneGB,
+                    NOW
+                )
+            ).toThrow(QuotaExceededError);
+        });
+    });
 });
 
 describe('checkQuota', () => {

--- a/apps/web/server/services/quota.ts
+++ b/apps/web/server/services/quota.ts
@@ -45,6 +45,10 @@ function assertUploadAllowed(
 ): QuotaCheckResult {
     const { subscription, currentUsage } = ctx;
 
+    // Only `trialing` rows can expire. Every other status — including
+    // `sponsored` (comped alpha testers, no Stripe subscription, no trialEnd)
+    // — is enforced on storageLimit alone. If #199 tightens enforcement to a
+    // good-standing allowlist, `sponsored` belongs in that allowlist.
     if (
         subscription?.status === 'trialing' &&
         subscription.trialEnd &&

--- a/apps/web/server/services/subscriptions.test.ts
+++ b/apps/web/server/services/subscriptions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest';
 import type Stripe from 'stripe';
 import {
     createMockDb,
+    createInviteFixture,
     createSubscriptionFixture,
     TEST_STRIPE_CUSTOMER_ID,
 } from '@nexus/db/testing';
@@ -27,7 +28,7 @@ vi.mock('@/lib/stripe', () => ({
 }));
 
 import { subscriptionService } from './subscriptions';
-import { PLAN_LIMITS } from './constants';
+import { PLAN_LIMITS, SPONSORED_DEFAULT_STORAGE_LIMIT } from './constants';
 
 const productsRetrieve = hoisted.stripeClient.products.retrieve;
 
@@ -436,6 +437,306 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
 
         expect(mocks.subscriptions.findFirst).not.toHaveBeenCalled();
         expect(mocks.insert).not.toHaveBeenCalled();
+    });
+});
+
+describe('subscriptionService.provisionSignupSubscription', () => {
+    let db: ReturnType<typeof createMockDb>['db'];
+    let mocks: ReturnType<typeof createMockDb>['mocks'];
+
+    const user = {
+        id: 'user_new',
+        email: 'tester@example.com',
+        name: 'Tester',
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+        hoisted.stripeClient.customers.create.mockResolvedValue({
+            id: 'cus_new_test',
+        });
+    });
+
+    /** All rows passed to `.values()` across the test, for path assertions. */
+    function insertedRows(): Array<Record<string, unknown>> {
+        return mocks.values.mock.calls.map((call) => call[0]);
+    }
+
+    it('provisions a trial when no invite token is present', async () => {
+        await subscriptionService.provisionSignupSubscription(db, user, null);
+
+        expect(mocks.invites.findFirst).not.toHaveBeenCalled();
+        expect(insertedRows()).toEqual([
+            expect.objectContaining({
+                userId: user.id,
+                status: 'trialing',
+                storageLimit: PLAN_LIMITS.starter,
+            }),
+        ]);
+    });
+
+    it('provisions a sponsored subscription from a valid pending invite', async () => {
+        const invite = createInviteFixture();
+        mocks.invites.findFirst.mockResolvedValue(invite);
+        // First `.returning()` is the claim UPDATE — it must yield the row
+        mocks.returning.mockResolvedValueOnce([invite]);
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            invite.token
+        );
+
+        // Invite atomically claimed for this user...
+        expect(mocks.set).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: 'redeemed',
+                redeemedByUserId: user.id,
+                redeemedAt: expect.any(Date),
+            })
+        );
+        // ...and the row is sponsored, capped at the default, with no expiry
+        expect(insertedRows()).toEqual([
+            expect.objectContaining({
+                userId: user.id,
+                status: 'sponsored',
+                storageLimit: SPONSORED_DEFAULT_STORAGE_LIMIT,
+                trialEnd: null,
+                stripeCustomerId: 'cus_new_test',
+            }),
+        ]);
+    });
+
+    it('uses the invite storageLimit override when present', async () => {
+        const invite = createInviteFixture({ storageLimit: 20 * 1024 ** 4 });
+        mocks.invites.findFirst.mockResolvedValue(invite);
+        mocks.returning.mockResolvedValueOnce([invite]);
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            invite.token
+        );
+
+        expect(mocks.values).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: 'sponsored',
+                storageLimit: 20 * 1024 ** 4,
+            })
+        );
+    });
+
+    it('falls back to trial when the token matches no invite', async () => {
+        mocks.invites.findFirst.mockResolvedValue(undefined);
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            'unknown-token'
+        );
+
+        expect(mocks.update).not.toHaveBeenCalled();
+        expect(insertedRows()).toEqual([
+            expect.objectContaining({ status: 'trialing' }),
+        ]);
+        expect(hoisted.logger.warn).toHaveBeenCalled();
+    });
+
+    it('falls back to trial and logs loudly on an email-binding mismatch', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ email: 'invited@example.com' })
+        );
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            'token'
+        );
+
+        // No claim attempt, no Stripe customer burned on the sponsored path
+        expect(mocks.update).not.toHaveBeenCalled();
+        expect(hoisted.stripeClient.customers.create).toHaveBeenCalledTimes(1);
+        expect(insertedRows()).toEqual([
+            expect.objectContaining({ status: 'trialing' }),
+        ]);
+        // The mismatch is surfaced to monitoring with both addresses
+        expect(hoisted.logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({
+                inviteEmail: 'invited@example.com',
+                signupEmail: user.email,
+            }),
+            expect.stringContaining('email mismatch')
+        );
+    });
+
+    it('matches email binding case-insensitively', async () => {
+        const invite = createInviteFixture({ email: 'Tester@Example.COM' });
+        mocks.invites.findFirst.mockResolvedValue(invite);
+        mocks.returning.mockResolvedValueOnce([invite]);
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            invite.token
+        );
+
+        expect(mocks.values).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'sponsored' })
+        );
+    });
+
+    it('does not raise the email-mismatch alert for an already-redeemed invite', async () => {
+        // A re-click of a consumed email-bound link by a different email is
+        // benign ("already redeemed"), not a wrong-email signup — it must take
+        // the quiet warn path, or monitoring drowns in false positives.
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({
+                status: 'redeemed',
+                email: 'invited@example.com',
+            })
+        );
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            'token'
+        );
+
+        expect(insertedRows()).toEqual([
+            expect.objectContaining({ status: 'trialing' }),
+        ]);
+        expect(hoisted.logger.warn).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'redeemed' }),
+            expect.stringContaining('no longer pending')
+        );
+        expect(hoisted.logger.error).not.toHaveBeenCalled();
+    });
+
+    it('falls back to trial when the subscription insert fails after the claim', async () => {
+        // The claim and insert share a transaction — a failed insert rolls
+        // the claim back in real Postgres (not observable through this mock,
+        // which has no rollback semantics). This pins the error path: the
+        // failure escapes the transaction and still lands on a trial.
+        const invite = createInviteFixture();
+        mocks.invites.findFirst.mockResolvedValue(invite);
+        mocks.returning.mockResolvedValueOnce([invite]);
+        mocks.values.mockImplementationOnce(() => {
+            throw new Error('insert failed');
+        });
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            invite.token
+        );
+
+        // The claim ran before the insert blew up...
+        expect(mocks.set).toHaveBeenCalledWith(
+            expect.objectContaining({ status: 'redeemed' })
+        );
+        // ...and the user still ends up on a trial, signup unblocked
+        // (the first .values() call is the sponsored insert that threw)
+        expect(mocks.values).toHaveBeenLastCalledWith(
+            expect.objectContaining({ status: 'trialing' })
+        );
+        expect(hoisted.logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: user.id }),
+            'Sponsored provisioning failed; provisioning trial instead'
+        );
+    });
+
+    it('falls back to trial on a repeat redemption (invite already redeemed)', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ status: 'redeemed' })
+        );
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            'token'
+        );
+
+        expect(mocks.update).not.toHaveBeenCalled();
+        expect(insertedRows()).toEqual([
+            expect.objectContaining({ status: 'trialing' }),
+        ]);
+    });
+
+    it('falls back to trial when the invite is expired', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ expiresAt: new Date(Date.now() - 1000) })
+        );
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            'token'
+        );
+
+        expect(mocks.update).not.toHaveBeenCalled();
+        expect(insertedRows()).toEqual([
+            expect.objectContaining({ status: 'trialing' }),
+        ]);
+    });
+
+    it('falls back to trial when the atomic claim loses a concurrent race', async () => {
+        // Pre-check sees a pending invite, but the conditional UPDATE matches
+        // nothing — a concurrent signup claimed it in between.
+        mocks.invites.findFirst.mockResolvedValue(createInviteFixture());
+        // default mocks.returning resolves [] → claim comes back empty
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            'token'
+        );
+
+        expect(insertedRows()).toEqual([
+            expect.objectContaining({ status: 'trialing' }),
+        ]);
+        expect(hoisted.logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: user.id }),
+            expect.stringContaining('lost a concurrent race')
+        );
+    });
+
+    it('falls back to trial when the sponsored path fails on infrastructure', async () => {
+        mocks.invites.findFirst.mockResolvedValue(createInviteFixture());
+        hoisted.stripeClient.customers.create
+            .mockRejectedValueOnce(new Error('stripe down'))
+            .mockResolvedValueOnce({ id: 'cus_retry_test' });
+
+        await subscriptionService.provisionSignupSubscription(
+            db,
+            user,
+            'token'
+        );
+
+        expect(insertedRows()).toEqual([
+            expect.objectContaining({
+                status: 'trialing',
+                stripeCustomerId: 'cus_retry_test',
+            }),
+        ]);
+        expect(hoisted.logger.error).toHaveBeenCalledWith(
+            expect.objectContaining({ userId: user.id }),
+            'Sponsored provisioning failed; provisioning trial instead'
+        );
+    });
+
+    it('rethrows when trial provisioning itself fails (loud signup failure)', async () => {
+        hoisted.stripeClient.customers.create.mockRejectedValue(
+            new Error('stripe down')
+        );
+
+        await expect(
+            subscriptionService.provisionSignupSubscription(db, user, null)
+        ).rejects.toThrow('stripe down');
+
+        expect(mocks.values).not.toHaveBeenCalled();
     });
 });
 

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -1,6 +1,7 @@
 import type Stripe from 'stripe';
 import { addDays } from 'date-fns';
 import type { DB } from '@nexus/db';
+import { createInviteRepo } from '@nexus/db/repo/invites';
 import {
     createSubscriptionRepo,
     type Subscription,
@@ -12,6 +13,7 @@ import { NotFoundError, InvalidStateError } from '@/server/errors';
 import { logger } from '@/server/lib/logger';
 import {
     PLAN_LIMITS,
+    SPONSORED_DEFAULT_STORAGE_LIMIT,
     TRIAL_DURATION_DAYS,
     type PlanTier,
     type CheckoutTier,
@@ -190,21 +192,17 @@ async function createPortalSession(
 }
 
 /**
- * Provisions a local-only trial: creates a Stripe Customer but no Stripe
- * Subscription. Expiry is enforced soft by `quotaService.checkQuota` —
- * the row stays `status: 'trialing'` until a real subscription replaces it.
+ * Create the Stripe customer backing a new user's subscription row (trial or
+ * sponsored) — or, under the e2e flag, a synthetic stand-in. The e2e suite
+ * runs against a live server (E2E=1) that signs up with a fresh email every
+ * run, so a real call here would leak a test-mode customer with no cleanup
+ * and make the smoke tier depend on Stripe's API being reachable. A synthetic
+ * id keeps signup a pure local flow; the subscription row and settings UI
+ * never need a real customer, and real creation stays covered by unit tests.
+ * Mirrors the E2E rate-limit gate in `lib/auth/server.ts` and the `cus_test_`
+ * fixtures in `@nexus/db/test-db`.
  */
-/**
- * Create the Stripe customer backing a new user's trial — or, under the e2e
- * flag, a synthetic stand-in. The e2e suite runs against a live server
- * (E2E=1) that signs up with a fresh email every run, so a real call here
- * would leak a test-mode customer with no cleanup and make the smoke tier
- * depend on Stripe's API being reachable. A synthetic id keeps signup a pure
- * local flow; the trial row and settings UI never need a real customer, and
- * real creation stays covered by unit tests. Mirrors the E2E rate-limit gate
- * in `lib/auth/server.ts` and the `cus_test_` fixtures in `@nexus/db/test-db`.
- */
-async function createTrialCustomer(
+async function createSignupCustomer(
     userId: string,
     email: string,
     name?: string
@@ -217,13 +215,18 @@ async function createTrialCustomer(
     });
 }
 
+/**
+ * Provisions a local-only trial: creates a Stripe Customer but no Stripe
+ * Subscription. Expiry is enforced soft by `quotaService.checkQuota` —
+ * the row stays `status: 'trialing'` until a real subscription replaces it.
+ */
 async function provisionTrialSubscription(
     db: DB,
     userId: string,
     email: string,
     name?: string
 ): Promise<void> {
-    const customer = await createTrialCustomer(userId, email, name);
+    const customer = await createSignupCustomer(userId, email, name);
 
     const trialEnd = addDays(new Date(), TRIAL_DURATION_DAYS);
 
@@ -242,6 +245,157 @@ async function provisionTrialSubscription(
         { userId, stripeCustomerId: customer.id },
         'Trial subscription provisioned'
     );
+}
+
+interface SignupUser {
+    id: string;
+    email: string;
+    name?: string;
+}
+
+/**
+ * Attempt sponsored provisioning from an invite token. Returns true when the
+ * invite was claimed and the sponsored row inserted; false when the invite is
+ * unusable (unknown, non-pending, expired, email-bound mismatch, or lost the
+ * claim race) so the caller falls back to a normal trial. Throws only on
+ * infrastructure failure (Stripe/DB), which the caller also treats as
+ * fall-back-to-trial.
+ */
+async function tryProvisionSponsoredSubscription(
+    db: DB,
+    user: SignupUser,
+    inviteToken: string
+): Promise<boolean> {
+    const invite = await createInviteRepo(db).findByToken(inviteToken);
+
+    if (!invite) {
+        log.warn(
+            // The token is a credential; log a prefix, enough to correlate.
+            { userId: user.id, tokenPrefix: inviteToken.slice(0, 8) },
+            'Invite token not found; provisioning trial instead'
+        );
+        return false;
+    }
+
+    // Pre-checks only shape logging (and avoid a pointless Stripe call); the
+    // conditional UPDATE in `claim` below is the authoritative single-use gate.
+    if (invite.status !== 'pending') {
+        log.warn(
+            { userId: user.id, inviteId: invite.id, status: invite.status },
+            'Invite no longer pending; provisioning trial instead'
+        );
+        return false;
+    }
+    if (invite.expiresAt && invite.expiresAt <= new Date()) {
+        log.warn(
+            {
+                userId: user.id,
+                inviteId: invite.id,
+                expiresAt: invite.expiresAt,
+            },
+            'Invite expired; provisioning trial instead'
+        );
+        return false;
+    }
+
+    // Email-bound defense in depth: #246's redemption UI locks the signup
+    // email, so a mismatch here means the tester signed up outside the invite
+    // flow and lands on a trial with no way to attach the invite — loud by
+    // design so an admin can intervene. Checked only for still-usable invites
+    // (after the status/expiry guards) so a re-click of an already-redeemed
+    // link doesn't false-alarm monitoring.
+    if (
+        invite.email &&
+        invite.email.toLowerCase() !== user.email.toLowerCase()
+    ) {
+        log.error(
+            {
+                userId: user.id,
+                inviteId: invite.id,
+                inviteEmail: invite.email,
+                signupEmail: user.email,
+            },
+            'Invite email mismatch on signup; provisioning trial instead'
+        );
+        return false;
+    }
+
+    // Stripe first, so a Stripe failure leaves the invite claimable; the
+    // claim and insert share a transaction, so a failed insert releases the
+    // claim instead of burning the invite.
+    const customer = await createSignupCustomer(user.id, user.email, user.name);
+    const storageLimit = invite.storageLimit ?? SPONSORED_DEFAULT_STORAGE_LIMIT;
+
+    const claimed = await db.transaction(async (tx) => {
+        const claimedInvite = await createInviteRepo(tx).claim(
+            invite.token,
+            user.id
+        );
+        if (!claimedInvite) return null;
+
+        await createSubscriptionRepo(tx).insert({
+            id: crypto.randomUUID(),
+            userId: user.id,
+            stripeCustomerId: customer.id,
+            planTier: 'max',
+            status: 'sponsored',
+            storageLimit,
+            trialEnd: null,
+        });
+        return claimedInvite;
+    });
+
+    if (!claimed) {
+        log.error(
+            {
+                userId: user.id,
+                inviteId: invite.id,
+                stripeCustomerId: customer.id,
+            },
+            'Invite claim lost a concurrent race; provisioning trial instead (Stripe customer orphaned)'
+        );
+        return false;
+    }
+
+    log.info(
+        {
+            userId: user.id,
+            inviteId: invite.id,
+            stripeCustomerId: customer.id,
+            storageLimit,
+        },
+        'Sponsored subscription provisioned'
+    );
+    return true;
+}
+
+/**
+ * Signup entry point: sponsored when a valid invite token accompanies the
+ * signup, otherwise a trial. Sponsored failure never blocks signup (#239) —
+ * any error falls back to the trial path; trial failures keep the loud
+ * rethrow posture of the auth hook.
+ */
+async function provisionSignupSubscription(
+    db: DB,
+    user: SignupUser,
+    inviteToken: string | null
+): Promise<void> {
+    if (inviteToken) {
+        try {
+            const isSponsored = await tryProvisionSponsoredSubscription(
+                db,
+                user,
+                inviteToken
+            );
+            if (isSponsored) return;
+        } catch (err) {
+            log.error(
+                { err, userId: user.id },
+                'Sponsored provisioning failed; provisioning trial instead'
+            );
+        }
+    }
+    await provisionTrialSubscription(db, user.id, user.email, user.name);
 }
 
 // ─── Webhook event handlers ─────────────────────────────────────────────
@@ -433,5 +587,6 @@ export const subscriptionService = {
     createCheckoutSession,
     createPortalSession,
     provisionTrialSubscription,
+    provisionSignupSubscription,
     dispatchWebhookEvent,
 } as const;

--- a/apps/web/server/trpc/routers/admin.ts
+++ b/apps/web/server/trpc/routers/admin.ts
@@ -6,6 +6,7 @@ import {
     type SqsMessageBody,
 } from '@nexus/db/repo/jobs';
 import { sendToQueue } from '@/lib/jobs/publish';
+import { inviteService } from '@/server/services/invites';
 import { adminProcedure, router } from '../init';
 import { devToolsRouter } from './adminDevTools';
 
@@ -18,6 +19,32 @@ const jobStatusSchema = z.enum([
 
 export const adminRouter = router({
     devTools: devToolsRouter,
+    invites: router({
+        create: adminProcedure
+            .input(
+                z
+                    .object({
+                        email: z.email().optional(),
+                        storageLimit: z.number().int().positive().optional(),
+                        expiresAt: z.date().optional(),
+                    })
+                    .optional()
+            )
+            .mutation(({ ctx, input }) =>
+                inviteService.createInvite(ctx.db, {
+                    createdBy: ctx.session.user.id,
+                    email: input?.email,
+                    storageLimit: input?.storageLimit,
+                    expiresAt: input?.expiresAt,
+                })
+            ),
+
+        revoke: adminProcedure
+            .input(z.object({ id: z.string() }))
+            .mutation(({ ctx, input }) =>
+                inviteService.revokeInvite(ctx.db, input.id)
+            ),
+    }),
     jobs: router({
         list: adminProcedure
             .input(

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,11 @@
             "import": "./src/schema/index.ts",
             "default": "./src/schema/index.ts"
         },
+        "./repo/invites": {
+            "types": "./src/repositories/invites.ts",
+            "import": "./src/repositories/invites.ts",
+            "default": "./src/repositories/invites.ts"
+        },
         "./repo/files": {
             "types": "./src/repositories/files.ts",
             "import": "./src/repositories/files.ts",

--- a/packages/db/src/migrations/0012_overjoyed_union_jack.sql
+++ b/packages/db/src/migrations/0012_overjoyed_union_jack.sql
@@ -1,0 +1,20 @@
+CREATE TYPE "public"."invite_status" AS ENUM('pending', 'redeemed', 'revoked');--> statement-breakpoint
+ALTER TYPE "public"."subscription_status" ADD VALUE 'sponsored';--> statement-breakpoint
+CREATE TABLE "invites" (
+	"id" text PRIMARY KEY NOT NULL,
+	"token" text NOT NULL,
+	"email" text,
+	"storage_limit" bigint,
+	"status" "invite_status" DEFAULT 'pending' NOT NULL,
+	"expires_at" timestamp,
+	"created_by" text NOT NULL,
+	"redeemed_by_user_id" text,
+	"redeemed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "invites" ADD CONSTRAINT "invites_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invites" ADD CONSTRAINT "invites_redeemed_by_user_id_user_id_fk" FOREIGN KEY ("redeemed_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "invites_token_idx" ON "invites" USING btree ("token");--> statement-breakpoint
+CREATE INDEX "invites_status_idx" ON "invites" USING btree ("status");

--- a/packages/db/src/migrations/meta/0012_snapshot.json
+++ b/packages/db/src/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1543 @@
+{
+  "id": "bb463d0a-8b8a-433e-a751-233722967db8",
+  "prevId": "c881b8d2-00b7-40ab-9f7a-4115885a66f0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by_user_id": {
+          "name": "redeemed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_token_idx": {
+          "name": "invites_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_status_idx": {
+          "name": "invites_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_user_id_user_id_fk": {
+          "name": "invites_redeemed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "redeemed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.background_jobs": {
+      "name": "background_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "background_jobs_status_created_at_idx": {
+          "name": "background_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "storage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'glacier'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_user_id_idx": {
+          "name": "files_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_status_idx": {
+          "name": "files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_storage_tier_idx": {
+          "name": "files_storage_tier_idx",
+          "columns": [
+            {
+              "expression": "storage_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_batch_id_idx": {
+          "name": "files_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_user_id_created_at_idx": {
+          "name": "files_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_user_id_fk": {
+          "name": "files_user_id_user_id_fk",
+          "tableFrom": "files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_batch_id_upload_batches_id_fk": {
+          "name": "files_batch_id_upload_batches_id_fk",
+          "tableFrom": "files",
+          "tableTo": "upload_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_s3_key_unique": {
+          "name": "files_s3_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "s3_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrievals": {
+      "name": "retrievals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "retrieval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "retrieval_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retrievals_file_id_idx": {
+          "name": "retrievals_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_user_id_idx": {
+          "name": "retrievals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_status_idx": {
+          "name": "retrievals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_batch_id_idx": {
+          "name": "retrievals_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_expires_at_idx": {
+          "name": "retrievals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retrievals_file_id_files_id_fk": {
+          "name": "retrievals_file_id_files_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_user_id_user_id_fk": {
+          "name": "retrievals_user_id_user_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_batch_id_upload_batches_id_fk": {
+          "name": "retrievals_batch_id_upload_batches_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "upload_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_usage": {
+      "name": "storage_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_bytes": {
+          "name": "used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_usage_user_id_idx": {
+          "name": "storage_usage_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_usage_user_id_user_id_fk": {
+          "name": "storage_usage_user_id_user_id_fk",
+          "tableFrom": "storage_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_usage_user_id_unique": {
+          "name": "storage_usage_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_batches": {
+      "name": "upload_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upload_batches_user_id_idx": {
+          "name": "upload_batches_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_batches_user_id_user_id_fk": {
+          "name": "upload_batches_user_id_user_id_fk",
+          "tableFrom": "upload_batches",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "plan_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starter'"
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trialing'"
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_user_id_unique": {
+          "name": "subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "webhook_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_source_external_id_idx": {
+          "name": "webhook_events_source_external_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_status_created_at_idx": {
+          "name": "webhook_events_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "redeemed",
+        "revoked"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "available",
+        "restoring",
+        "deleted"
+      ]
+    },
+    "public.retrieval_status": {
+      "name": "retrieval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "ready",
+        "expired",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.retrieval_tier": {
+      "name": "retrieval_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "bulk",
+        "expedited"
+      ]
+    },
+    "public.storage_tier": {
+      "name": "storage_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "glacier",
+        "deep_archive"
+      ]
+    },
+    "public.plan_tier": {
+      "name": "plan_tier",
+      "schema": "public",
+      "values": [
+        "starter",
+        "pro",
+        "max",
+        "enterprise"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "incomplete",
+        "sponsored"
+      ]
+    },
+    "public.webhook_source": {
+      "name": "webhook_source",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "sns"
+      ]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778263641058,
       "tag": "0011_skinny_devos",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1783010307674,
+      "tag": "0012_overjoyed_union_jack",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repositories/fixtures.ts
+++ b/packages/db/src/repositories/fixtures.ts
@@ -1,6 +1,7 @@
 import * as schema from '../schema';
 import { PLAN_LIMITS } from '../plans';
 import type { File, NewFile } from './files';
+import type { Invite } from './invites';
 import type { Job, NewJob } from './jobs';
 import type { Retrieval } from './retrievals';
 import type { Subscription } from './subscriptions';
@@ -17,6 +18,9 @@ export const TEST_SUBSCRIPTION_ID = 'sub_test303';
 export const TEST_STRIPE_CUSTOMER_ID = 'cus_test303';
 export const TEST_WEBHOOK_EVENT_ID = 'wh_test404';
 export const TEST_BATCH_ID = 'batch_test505';
+export const TEST_INVITE_ID = 'invite_test606';
+export const TEST_INVITE_TOKEN = 'test-invite-token-abcdefghijklmnopqrstuvwxyz';
+export const TEST_ADMIN_USER_ID = 'admin_test707';
 
 export type { User } from './users';
 export type StorageUsage = typeof schema.storageUsage.$inferSelect;
@@ -141,6 +145,24 @@ export function createSubscriptionFixture(
         currentPeriodEnd: null,
         cancelAtPeriodEnd: false,
         trialEnd: null,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+    };
+}
+
+export function createInviteFixture(overrides: Partial<Invite> = {}): Invite {
+    const now = new Date();
+    return {
+        id: TEST_INVITE_ID,
+        token: TEST_INVITE_TOKEN,
+        email: null,
+        storageLimit: null,
+        status: 'pending',
+        expiresAt: null,
+        createdBy: TEST_ADMIN_USER_ID,
+        redeemedByUserId: null,
+        redeemedAt: null,
         createdAt: now,
         updatedAt: now,
         ...overrides,

--- a/packages/db/src/repositories/invites.ts
+++ b/packages/db/src/repositories/invites.ts
@@ -1,0 +1,75 @@
+import { and, eq, gt, isNull, or } from 'drizzle-orm';
+import type { DB } from '../connection';
+import * as schema from '../schema';
+import { createRepository } from './create';
+
+export type Invite = typeof schema.invites.$inferSelect;
+export type NewInvite = typeof schema.invites.$inferInsert;
+
+function findById(db: DB, id: string): Promise<Invite | undefined> {
+    return db.query.invites.findFirst({
+        where: eq(schema.invites.id, id),
+    });
+}
+
+function findByToken(db: DB, token: string): Promise<Invite | undefined> {
+    return db.query.invites.findFirst({
+        where: eq(schema.invites.token, token),
+    });
+}
+
+async function insert(db: DB, data: NewInvite): Promise<Invite> {
+    const [invite] = await db.insert(schema.invites).values(data).returning();
+    return invite;
+}
+
+/**
+ * Atomically claim a pending, unexpired invite for `userId`. The conditional
+ * UPDATE is the single-use gate: a concurrent or repeat redemption finds no
+ * matching row and gets `undefined` back — losers must fall back to trial
+ * provisioning, never throw.
+ */
+async function claim(
+    db: DB,
+    token: string,
+    userId: string,
+    now: Date = new Date()
+): Promise<Invite | undefined> {
+    const [invite] = await db
+        .update(schema.invites)
+        .set({ status: 'redeemed', redeemedByUserId: userId, redeemedAt: now })
+        .where(
+            and(
+                eq(schema.invites.token, token),
+                eq(schema.invites.status, 'pending'),
+                or(
+                    isNull(schema.invites.expiresAt),
+                    gt(schema.invites.expiresAt, now)
+                )
+            )
+        )
+        .returning();
+    return invite;
+}
+
+/** Revoke a pending invite; returns `undefined` when it isn't pending (or doesn't exist). */
+async function revoke(db: DB, id: string): Promise<Invite | undefined> {
+    const [invite] = await db
+        .update(schema.invites)
+        .set({ status: 'revoked' })
+        .where(
+            and(eq(schema.invites.id, id), eq(schema.invites.status, 'pending'))
+        )
+        .returning();
+    return invite;
+}
+
+export const createInviteRepo = createRepository({
+    findById,
+    findByToken,
+    insert,
+    claim,
+    revoke,
+});
+
+export type InviteRepo = ReturnType<typeof createInviteRepo>;

--- a/packages/db/src/repositories/mocks.ts
+++ b/packages/db/src/repositories/mocks.ts
@@ -38,6 +38,7 @@ export function createMockDb() {
     const deleteFn: AnyMock = vi.fn(() => ({ where }));
 
     const files = createQueryMock();
+    const invites = createQueryMock();
     const backgroundJobs = createQueryMock();
     const retrievals = createQueryMock();
     const storageUsage = createQueryMock();
@@ -49,6 +50,7 @@ export function createMockDb() {
     const db = {
         query: {
             files,
+            invites,
             backgroundJobs,
             retrievals,
             storageUsage,
@@ -85,6 +87,7 @@ export function createMockDb() {
             orderBy,
             // Per-table query mocks (db.query.<table>.findFirst/findMany)
             files,
+            invites,
             backgroundJobs,
             retrievals,
             storageUsage,

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
+export * from './invites';
 export * from './jobs';
 export * from './storage';
 export * from './subscriptions';

--- a/packages/db/src/schema/invites.ts
+++ b/packages/db/src/schema/invites.ts
@@ -1,0 +1,51 @@
+import {
+    pgTable,
+    pgEnum,
+    text,
+    timestamp,
+    bigint,
+    uniqueIndex,
+    index,
+} from 'drizzle-orm/pg-core';
+import { user } from './auth';
+import { timestamps } from './helpers';
+
+export const inviteStatusEnum = pgEnum('invite_status', [
+    'pending', // Issued, not yet used
+    'redeemed', // Consumed by a signup (single-use)
+    'revoked', // Withdrawn by an admin before redemption
+]);
+
+/**
+ * Admin-issued invite links granting sponsored (comped) access. Redeeming one
+ * at signup provisions a `sponsored` subscription instead of a trial.
+ */
+export const invites = pgTable(
+    'invites',
+    {
+        id: text('id').primaryKey(),
+        // Crypto-random, ≥128 bits of entropy — the token IS the credential
+        token: text('token').notNull(),
+        // Optional binding: when set, signup under a different email falls
+        // back to a trial (server-side backstop; the UI lock lives in #246)
+        email: text('email'),
+        // Per-tester override; null → SPONSORED_DEFAULT_STORAGE_LIMIT
+        storageLimit: bigint('storage_limit', { mode: 'number' }),
+        status: inviteStatusEnum('status').notNull().default('pending'),
+        expiresAt: timestamp('expires_at'),
+        createdBy: text('created_by')
+            .notNull()
+            .references(() => user.id),
+        redeemedByUserId: text('redeemed_by_user_id').references(
+            () => user.id,
+            // Keep the invite as a historical record if the account is deleted
+            { onDelete: 'set null' }
+        ),
+        redeemedAt: timestamp('redeemed_at'),
+        ...timestamps(),
+    },
+    (table) => [
+        uniqueIndex('invites_token_idx').on(table.token),
+        index('invites_status_idx').on(table.status),
+    ]
+);

--- a/packages/db/src/schema/subscriptions.ts
+++ b/packages/db/src/schema/subscriptions.ts
@@ -24,6 +24,7 @@ export const subscriptionStatusEnum = pgEnum('subscription_status', [
     'canceled', // Subscription ended
     'unpaid', // Payment failed, access restricted
     'incomplete', // Initial payment pending
+    'sponsored', // Comped access (alpha testers via invite) — good standing, no Stripe subscription, no trial expiry
 ]);
 
 export const subscriptions = pgTable(


### PR DESCRIPTION
## Summary

Backend foundation for onboarding alpha photographers with free, full access: a new `sponsored` subscription status, an `invites` table with admin create/revoke mutations, and a sponsored-provisioning branch in the signup create-hook. The redemption UX (`/invite/[token]` page, token threading, sponsored UI) is #246, which this unblocks.

Closes #239

## Changes

- **Schema:** `sponsored` added to `subscription_status`; new `invites` table (unique crypto-random token, optional email binding, optional per-tester `storageLimit` override, `pending`/`redeemed`/`revoked`, optional expiry) with repo, fixtures, and mocks in `@nexus/db`. Migration `0012` (additive only) generated and applied to dev.
- **Quota:** `sponsored` is good-standing by construction — only `trialing` rows hit the expiry check; `storageLimit` alone is enforced. Comment flags that #199's future allowlist must include `sponsored`.
- **Constants:** `SPONSORED_DEFAULT_STORAGE_LIMIT = PLAN_LIMITS.max` (10 TB).
- **Invite service + admin mutations:** `admin.invites.create` (returns invite + redemption URL; accepts optional email/storageLimit/expiresAt; 32-byte base64url token) and `admin.invites.revoke`, both behind `adminProcedure`.
- **Provisioning:** `provisionSignupSubscription` orchestrates the signup hook. With a valid pending invite (read from the `nexus_invite_token` httpOnly cookie #246 will set): Stripe customer first, then an atomic conditional-UPDATE claim + sponsored insert in one transaction — a lost race, mismatched email binding, expired/consumed invite, or any infrastructure failure falls back to trial provisioning and logs to monitoring; trial failures keep the existing loud-rethrow posture. Email-mismatch alerts only fire for still-usable invites so re-clicks of consumed links don't false-alarm.

## Notes for review

- Sponsored rows get `planTier: 'max'` to match the 10 TB default; the row's `storageLimit` stays authoritative everywhere (`resolvePlan`), so a custom override doesn't need a matching tier.
- A lost claim race orphans the just-created Stripe customer (logged with its id, no cleanup path). Deliberate tradeoff; follow-up issue for a reconciliation script to be filed.
- Transaction rollback (failed insert releases the claim) is Postgres's guarantee; unit tests pin the error path but can't observe rollback through the mock DB.
- #199 interplay: when the expired-trial lifecycle lands, `sponsored` belongs in its good-standing allowlist (noted in `quota.ts`).

## Test Plan

- [x] `pnpm check` green (lint + build + unit tests, 375 web tests)
- [x] `pnpm -F web test:e2e:smoke` green (33/33 — exercises the real signup → trial path against a production build)
- [x] Unit coverage: sponsored quota (never `TRIAL_EXPIRED`, limit enforced), invite create/revoke (token entropy, domain errors), provisioning branches (valid invite → sponsored w/ default + override limits, unknown/redeemed/expired token → trial, email mismatch → trial + loud log, case-insensitive email match, claim race lost → trial, Stripe failure → trial, insert-after-claim failure → trial, trial failure → rethrow)
- [ ] Manual: create an invite via `admin.invites.create`, sign up with the `nexus_invite_token` cookie set, confirm a `sponsored` row with no `trialEnd` and 10 TB limit