### PR TITLE
feat: send sponsored-access invite by email (#247)

### DIFF
--- a/apps/web/lib/email/index.ts
+++ b/apps/web/lib/email/index.ts
@@ -26,4 +26,4 @@ export const email = {
     templates,
 } as const;
 
-export type { RetrievalReadyEmailProps } from './templates';
+export type { InviteEmailProps, RetrievalReadyEmailProps } from './templates';

--- a/apps/web/lib/email/templates/components/callout.tsx
+++ b/apps/web/lib/email/templates/components/callout.tsx
@@ -1,0 +1,56 @@
+/**
+ * Icon + message callout for notes that deserve their own weight (expiries,
+ * time-boxed links). The message is children so copy stays per-template; wrap
+ * emphasized runs in <CalloutStrong>.
+ */
+import type { CSSProperties, ReactNode } from 'react';
+import { Column, Row, Section, Text } from '@react-email/components';
+import { colors, radii } from '../theme';
+
+interface CalloutProps {
+    /** Rendered in the leading cell — typically a 16px primary-colored icon. */
+    icon: ReactNode;
+    children: ReactNode;
+}
+
+export function Callout({ icon, children }: CalloutProps) {
+    return (
+        <Section style={callout}>
+            <Row>
+                <Column style={calloutIconCell}>{icon}</Column>
+                <Column>
+                    <Text style={calloutText}>{children}</Text>
+                </Column>
+            </Row>
+        </Section>
+    );
+}
+
+export function CalloutStrong({ children }: { children: ReactNode }) {
+    return <strong style={calloutStrong}>{children}</strong>;
+}
+
+const callout: CSSProperties = {
+    backgroundColor: colors.accentSurfaceSoft,
+    border: `1px solid ${colors.accentSurface}`,
+    borderRadius: radii.md,
+    padding: '12px 16px',
+};
+
+const calloutIconCell: CSSProperties = {
+    width: '26px',
+    verticalAlign: 'top',
+    paddingTop: '2px',
+};
+
+const calloutText: CSSProperties = {
+    margin: 0,
+    fontSize: '13px',
+    lineHeight: '20px',
+    color: colors.primaryText,
+};
+
+const calloutStrong: CSSProperties = {
+    fontWeight: 600,
+    color: colors.primaryTextStrong,
+};

--- a/apps/web/lib/email/templates/components/link-fallback.tsx
+++ b/apps/web/lib/email/templates/components/link-fallback.tsx
@@ -1,0 +1,38 @@
+/**
+ * "Button not working?" plain-text link fallback. Templates with a primary
+ * action pass this through EmailLayout's `footer` slot so the fallback copy
+ * stays identical across the email library.
+ */
+import type { CSSProperties } from 'react';
+import { Text } from '@react-email/components';
+import { colors } from '../theme';
+
+interface LinkFallbackProps {
+    url: string;
+}
+
+export function LinkFallback({ url }: LinkFallbackProps) {
+    return (
+        <>
+            <Text style={footerLabel}>
+                Button not working? Paste this link into your browser:
+            </Text>
+            <Text style={footerLink}>{url}</Text>
+        </>
+    );
+}
+
+const footerLabel: CSSProperties = {
+    fontSize: '12px',
+    lineHeight: '18px',
+    color: colors.muted,
+    margin: '0 0 4px',
+};
+
+const footerLink: CSSProperties = {
+    fontSize: '12px',
+    lineHeight: '18px',
+    color: colors.faint,
+    margin: '0 0 20px',
+    wordBreak: 'break-all',
+};

--- a/apps/web/lib/email/templates/index.ts
+++ b/apps/web/lib/email/templates/index.ts
@@ -1,3 +1,4 @@
+export { InviteEmail, inviteSubject, type InviteEmailProps } from './invite';
 export {
     RetrievalReadyEmail,
     retrievalReadySubject,

--- a/apps/web/lib/email/templates/invite.test.tsx
+++ b/apps/web/lib/email/templates/invite.test.tsx
@@ -1,0 +1,46 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { render } from '@react-email/components';
+import { InviteEmail, inviteSubject } from './invite';
+
+describe('InviteEmail', () => {
+    const inviteUrl = 'https://test.example/invite/abc123token';
+
+    let html: string;
+    beforeAll(async () => {
+        html = await render(
+            <InviteEmail inviteUrl={inviteUrl} expiresAt={null} />
+        );
+    });
+
+    it('renders the invite link on the button and as fallback text', () => {
+        // Button href + plain-text fallback both carry the URL
+        expect(html).toContain(inviteUrl);
+    });
+
+    it('frames the invite as free access to Nexus', () => {
+        expect(html).toContain('free access to');
+    });
+
+    it('omits the expiry callout when the invite has no expiry', () => {
+        expect(html).not.toContain('This invite expires on');
+    });
+
+    it('renders the expiry in UTC when the invite is time-boxed', async () => {
+        const withExpiry = await render(
+            <InviteEmail
+                inviteUrl={inviteUrl}
+                expiresAt={new Date('2026-08-01T12:00:00Z')}
+            />
+        );
+        expect(withExpiry).toContain('This invite expires on');
+        expect(withExpiry).toContain('August 1, 2026 at 12:00 PM UTC');
+    });
+
+    it('renders to a full HTML document', () => {
+        expect(html).toContain('<!DOCTYPE html');
+    });
+
+    it('builds a subject line naming the free access', () => {
+        expect(inviteSubject()).toBe("You've been given free access to Nexus");
+    });
+});

--- a/apps/web/lib/email/templates/invite.tsx
+++ b/apps/web/lib/email/templates/invite.tsx
@@ -1,0 +1,56 @@
+import { Button, Heading, Section, Text } from '@react-email/components';
+import { EmailLayout } from './_layout';
+import { Callout, CalloutStrong } from './components/callout';
+import { ClockIcon } from './components/icons';
+import { LinkFallback } from './components/link-fallback';
+import { formatEmailDateTime } from './format';
+import { button, buttonSection, heading, intro, introStrong } from './styles';
+import { colors } from './theme';
+
+export interface InviteEmailProps {
+    inviteUrl: string;
+    /** Invites may be open-ended; the expiry callout renders only when set. */
+    expiresAt: Date | null;
+}
+
+/**
+ * Subject line for this email. Co-located with the component so the whole
+ * message — subject, preview, body — reads and tests as one unit, and a copy
+ * change can't drift between the inbox line and the body.
+ */
+export function inviteSubject(): string {
+    return "You've been given free access to Nexus";
+}
+
+export function InviteEmail({ inviteUrl, expiresAt }: InviteEmailProps) {
+    return (
+        <EmailLayout
+            preview="Accept your invite to start archiving your files"
+            footer={<LinkFallback url={inviteUrl} />}
+        >
+            <Heading style={heading}>You&apos;ve been invited</Heading>
+            <Text style={intro}>
+                You&apos;ve been given free access to{' '}
+                <strong style={introStrong}>Nexus</strong> — deep storage for
+                the files you can&apos;t afford to lose. Accept your invite to
+                create an account and start archiving.
+            </Text>
+
+            <Section style={buttonSection}>
+                <Button style={button} href={inviteUrl}>
+                    Accept invite
+                </Button>
+            </Section>
+
+            {expiresAt && (
+                <Callout icon={<ClockIcon size={16} color={colors.primary} />}>
+                    This invite expires on{' '}
+                    <CalloutStrong>
+                        {formatEmailDateTime(expiresAt)}
+                    </CalloutStrong>
+                    . Accept it before then to claim your access.
+                </Callout>
+            )}
+        </EmailLayout>
+    );
+}

--- a/apps/web/lib/email/templates/retrieval-ready.tsx
+++ b/apps/web/lib/email/templates/retrieval-ready.tsx
@@ -8,8 +8,11 @@ import {
     Text,
 } from '@react-email/components';
 import { EmailLayout } from './_layout';
+import { Callout, CalloutStrong } from './components/callout';
 import { ArchiveIcon, ClockIcon } from './components/icons';
+import { LinkFallback } from './components/link-fallback';
 import { formatEmailDateTime } from './format';
+import { button, buttonSection, heading, intro, introStrong } from './styles';
 import { colors, radii, spacing } from './theme';
 
 export interface RetrievalReadyEmailProps {
@@ -40,14 +43,7 @@ export function RetrievalReadyEmail({
     return (
         <EmailLayout
             preview={`${fileName} is ready to download`}
-            footer={
-                <>
-                    <Text style={footerLabel}>
-                        Button not working? Paste this link into your browser:
-                    </Text>
-                    <Text style={footerLink}>{downloadUrl}</Text>
-                </>
-            }
+            footer={<LinkFallback url={downloadUrl} />}
         >
             <Heading style={heading}>Your file is ready</Heading>
             <Text style={intro}>
@@ -76,50 +72,18 @@ export function RetrievalReadyEmail({
                 </Button>
             </Section>
 
-            {/* Expiry callout — this link is time-boxed, so give it its own
-                weight rather than burying it in prose. */}
-            <Section style={callout}>
-                <Row>
-                    <Column style={calloutIconCell}>
-                        <ClockIcon size={16} color={colors.primary} />
-                    </Column>
-                    <Column>
-                        <Text style={calloutText}>
-                            This link expires on{' '}
-                            <strong style={calloutStrong}>
-                                {formattedExpiry}
-                            </strong>
-                            . After that, request the file again from your
-                            library.
-                        </Text>
-                    </Column>
-                </Row>
-            </Section>
+            {/* This link is time-boxed, so the expiry gets its own weight
+                rather than being buried in prose. */}
+            <Callout icon={<ClockIcon size={16} color={colors.primary} />}>
+                This link expires on{' '}
+                <CalloutStrong>{formattedExpiry}</CalloutStrong>. After that,
+                request the file again from your library.
+            </Callout>
         </EmailLayout>
     );
 }
 
 // --- Styles -----------------------------------------------------------------
-
-const heading: CSSProperties = {
-    fontSize: '22px',
-    fontWeight: 600,
-    letterSpacing: '-0.02em',
-    color: colors.ink,
-    margin: '0 0 12px',
-};
-
-const intro: CSSProperties = {
-    fontSize: '15px',
-    lineHeight: '24px',
-    color: colors.body,
-    margin: `0 0 ${spacing.block}`,
-};
-
-const introStrong: CSSProperties = {
-    color: colors.ink,
-    fontWeight: 600,
-};
 
 const fileCard: CSSProperties = {
     backgroundColor: colors.cardSurface,
@@ -162,60 +126,4 @@ const fileSub: CSSProperties = {
     lineHeight: '18px',
     color: colors.success,
     fontWeight: 500,
-};
-
-const buttonSection: CSSProperties = {
-    margin: `0 0 ${spacing.block}`,
-};
-
-const button: CSSProperties = {
-    display: 'block',
-    backgroundColor: colors.primary,
-    color: colors.onPrimary,
-    fontSize: '15px',
-    fontWeight: 600,
-    textDecoration: 'none',
-    textAlign: 'center',
-    padding: '13px 20px',
-    borderRadius: radii.sm,
-};
-
-const callout: CSSProperties = {
-    backgroundColor: colors.accentSurfaceSoft,
-    border: `1px solid ${colors.accentSurface}`,
-    borderRadius: radii.md,
-    padding: '12px 16px',
-};
-
-const calloutIconCell: CSSProperties = {
-    width: '26px',
-    verticalAlign: 'top',
-    paddingTop: '2px',
-};
-
-const calloutText: CSSProperties = {
-    margin: 0,
-    fontSize: '13px',
-    lineHeight: '20px',
-    color: colors.primaryText,
-};
-
-const calloutStrong: CSSProperties = {
-    fontWeight: 600,
-    color: colors.primaryTextStrong,
-};
-
-const footerLabel: CSSProperties = {
-    fontSize: '12px',
-    lineHeight: '18px',
-    color: colors.muted,
-    margin: '0 0 4px',
-};
-
-const footerLink: CSSProperties = {
-    fontSize: '12px',
-    lineHeight: '18px',
-    color: colors.faint,
-    margin: '0 0 20px',
-    wordBreak: 'break-all',
 };

--- a/apps/web/lib/email/templates/styles.ts
+++ b/apps/web/lib/email/templates/styles.ts
@@ -1,0 +1,44 @@
+/**
+ * Composed style constants shared across email templates — one level above
+ * theme.ts's raw tokens. Every template's heading/intro/primary-button should
+ * look identical; a template needing a one-off variation defines its own
+ * constant locally rather than forking these.
+ */
+import type { CSSProperties } from 'react';
+import { colors, radii, spacing } from './theme';
+
+export const heading: CSSProperties = {
+    fontSize: '22px',
+    fontWeight: 600,
+    letterSpacing: '-0.02em',
+    color: colors.ink,
+    margin: '0 0 12px',
+};
+
+export const intro: CSSProperties = {
+    fontSize: '15px',
+    lineHeight: '24px',
+    color: colors.body,
+    margin: `0 0 ${spacing.block}`,
+};
+
+export const introStrong: CSSProperties = {
+    color: colors.ink,
+    fontWeight: 600,
+};
+
+export const buttonSection: CSSProperties = {
+    margin: `0 0 ${spacing.block}`,
+};
+
+export const button: CSSProperties = {
+    display: 'block',
+    backgroundColor: colors.primary,
+    color: colors.onPrimary,
+    fontSize: '15px',
+    fontWeight: 600,
+    textDecoration: 'none',
+    textAlign: 'center',
+    padding: '13px 20px',
+    borderRadius: radii.sm,
+};

--- a/apps/web/server/services/email.test.ts
+++ b/apps/web/server/services/email.test.ts
@@ -86,4 +86,34 @@ describe('email service', () => {
             );
         });
     });
+
+    describe('sendInviteEmail', () => {
+        const inviteOpts = {
+            to: 'tester@example.com',
+            inviteUrl: 'https://test.example/invite/abc123token',
+            expiresAt: null,
+        };
+
+        it('sends to the bound email with the free-access subject', async () => {
+            await emailService.sendInviteEmail(inviteOpts);
+
+            expect(mockEmail.send).toHaveBeenCalledOnce();
+            const sent = mockEmail.send.mock.calls[0][0];
+            expect(sent.to).toBe('tester@example.com');
+            expect(sent.subject).toContain('free access to Nexus');
+            expect(sent.react).toBeDefined();
+        });
+
+        it('logs and swallows when the send fails', async () => {
+            mockEmail.send.mockRejectedValueOnce(new Error('Resend outage'));
+
+            await expect(
+                emailService.sendInviteEmail(inviteOpts)
+            ).resolves.toBeUndefined();
+            expect(hoisted.logger.warn).toHaveBeenCalledWith(
+                { to: 'tester@example.com', err: expect.any(Error) },
+                'Failed to send invite email'
+            );
+        });
+    });
 });

--- a/apps/web/server/services/email.ts
+++ b/apps/web/server/services/email.ts
@@ -1,7 +1,11 @@
 import { createElement } from 'react';
 import type { DB } from '@nexus/db';
 import { createUserRepo } from '@nexus/db/repo/users';
-import { email, type RetrievalReadyEmailProps } from '@/lib/email';
+import {
+    email,
+    type InviteEmailProps,
+    type RetrievalReadyEmailProps,
+} from '@/lib/email';
 import { logger } from '@/server/lib/logger';
 
 const log = logger.child({ service: 'email' });
@@ -42,6 +46,28 @@ async function sendRetrievalReadyEmail(
     }
 }
 
+export interface SendInviteEmailOptions extends InviteEmailProps {
+    /** Recipient — the invite's bound email; unbound invites are never sent. */
+    to: string;
+}
+
+// No db lookup here: the recipient comes straight off the invite row. Same
+// warn-and-swallow contract as above — delivery must not fail invite creation.
+async function sendInviteEmail(opts: SendInviteEmailOptions): Promise<void> {
+    const { to, ...props } = opts;
+
+    try {
+        await email.send({
+            to,
+            subject: email.templates.inviteSubject(),
+            react: createElement(email.templates.InviteEmail, props),
+        });
+    } catch (err) {
+        log.warn({ to, err }, 'Failed to send invite email');
+    }
+}
+
 export const emailService = {
+    sendInviteEmail,
     sendRetrievalReadyEmail,
 } as const;

--- a/apps/web/server/services/invites.test.ts
+++ b/apps/web/server/services/invites.test.ts
@@ -11,7 +11,10 @@ import {
 
 const hoisted = await vi.hoisted(async () => {
     const { createMockLogger } = await import('@/server/lib/logger/testing');
-    return { logger: createMockLogger() };
+    return {
+        logger: createMockLogger(),
+        sendInviteEmail: vi.fn(async (): Promise<void> => {}),
+    };
 });
 
 vi.mock('@/lib/env', () => ({
@@ -19,6 +22,10 @@ vi.mock('@/lib/env', () => ({
 }));
 
 vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
+
+vi.mock('@/server/services/email', () => ({
+    emailService: { sendInviteEmail: hoisted.sendInviteEmail },
+}));
 
 import { NotFoundError, InvalidStateError } from '@/server/errors';
 import { inviteService } from './invites';
@@ -99,6 +106,55 @@ describe('inviteService.createInvite', () => {
         });
 
         expect(url).toBe(`https://test.example/invite/${TEST_INVITE_TOKEN}`);
+    });
+
+    it('emails the invite link to an email-bound invite', async () => {
+        const expiresAt = new Date('2026-08-01T00:00:00Z');
+        mocks.returning.mockResolvedValue([
+            createInviteFixture({ email: 'tester@example.com', expiresAt }),
+        ]);
+
+        await inviteService.createInvite(db, {
+            createdBy: TEST_ADMIN_USER_ID,
+            email: 'tester@example.com',
+            expiresAt,
+        });
+
+        expect(hoisted.sendInviteEmail).toHaveBeenCalledOnce();
+        expect(hoisted.sendInviteEmail).toHaveBeenCalledWith({
+            to: 'tester@example.com',
+            inviteUrl: `https://test.example/invite/${TEST_INVITE_TOKEN}`,
+            expiresAt,
+        });
+    });
+
+    it('does not send an email for an unbound invite', async () => {
+        await inviteService.createInvite(db, {
+            createdBy: TEST_ADMIN_USER_ID,
+        });
+
+        expect(hoisted.sendInviteEmail).not.toHaveBeenCalled();
+    });
+
+    it('still creates the invite and returns the link when the email fails', async () => {
+        mocks.returning.mockResolvedValue([
+            createInviteFixture({ email: 'tester@example.com' }),
+        ]);
+        hoisted.sendInviteEmail.mockRejectedValueOnce(
+            new Error('Resend outage')
+        );
+
+        const { invite, url } = await inviteService.createInvite(db, {
+            createdBy: TEST_ADMIN_USER_ID,
+            email: 'tester@example.com',
+        });
+
+        expect(invite.id).toBe(TEST_INVITE_ID);
+        expect(url).toBe(`https://test.example/invite/${TEST_INVITE_TOKEN}`);
+        expect(hoisted.logger.error).toHaveBeenCalledWith(
+            { err: expect.any(Error), inviteId: TEST_INVITE_ID },
+            'Invite email failed after invite creation'
+        );
     });
 });
 

--- a/apps/web/server/services/invites.ts
+++ b/apps/web/server/services/invites.ts
@@ -4,6 +4,7 @@ import { createInviteRepo, type Invite } from '@nexus/db/repo/invites';
 import { env } from '@/lib/env';
 import { InvalidStateError, NotFoundError } from '@/server/errors';
 import { logger } from '@/server/lib/logger';
+import { emailService } from '@/server/services/email';
 
 const log = logger.child({ service: 'invites' });
 
@@ -44,7 +45,29 @@ async function createInvite(
         'Invite created'
     );
 
-    return { invite, url: `${env.NEXT_PUBLIC_APP_URL}/invite/${invite.token}` };
+    const url = `${env.NEXT_PUBLIC_APP_URL}/invite/${invite.token}`;
+
+    // Email-bound invites are delivered directly; unbound ones have no
+    // recipient and stay manual. Delivery failure must never block creation —
+    // the row is persisted and the link is still returned. (The email service
+    // swallows send errors itself; this catch is a backstop so createInvite
+    // holds that guarantee locally.)
+    if (invite.email) {
+        try {
+            await emailService.sendInviteEmail({
+                to: invite.email,
+                inviteUrl: url,
+                expiresAt: invite.expiresAt,
+            });
+        } catch (err) {
+            log.error(
+                { err, inviteId: invite.id },
+                'Invite email failed after invite creation'
+            );
+        }
+    }
+
+    return { invite, url };
 }
 
 async function revokeInvite(db: DB, id: string): Promise<Invite> {


### PR DESCRIPTION
## Summary
Delivers sponsored-access invites (#239) by email instead of hand-delivery. Creating an email-bound invite now sends the tester a \"you've been given free access to Nexus\" email with the `/invite/<token>` link, reusing the transactional-email infrastructure from #26 (Resend + React Email). Send-on-create was chosen per the issue's default (no resend action needed for alpha), and `email` stays optional: unbound invites keep returning just the link.

Closes #247

## Changes
- New `InviteEmail` template + co-located `inviteSubject`, following the retrieval-ready pattern; expiry callout renders only for time-boxed invites
- `emailService.sendInviteEmail` — sends to the invite's bound email, warn-and-swallows send failures (no user lookup needed)
- `inviteService.createInvite` sends on create when `invite.email` is set, with a backstop catch so delivery can never block creation (row persisted, link still returned; failures logged for monitoring)
- Extracted exact duplication between the two templates (self-review finding): shared `styles.ts` (heading/intro/button), `Callout`/`CalloutStrong`, and `LinkFallback` components; `retrieval-ready.tsx` now consumes them
- Tests: template render (link, framing, expiry variants), send orchestration (happy path, failure swallow), invite service (bound sends / unbound doesn't / failure doesn't block)

## Test Plan
- [x] `pnpm check` (passes: 10/10)
- [x] `pnpm -F web test:e2e:smoke` (passes: 33/33)
- [x] Manual: create an invite with an email via `adminRouter.invites.create` against a real `RESEND_API_KEY`; confirm the email arrives, the button links to `/invite/<token>`, and an invite without email sends nothing