### PR TITLE
feat: sponsored invite redemption UX — /invite page + signup token threading (#246)

### DIFF
--- a/apps/web/app/(auth)/invite/[token]/page.tsx
+++ b/apps/web/app/(auth)/invite/[token]/page.tsx
@@ -1,0 +1,82 @@
+import Link from 'next/link';
+import { Shield, DollarSign, Archive } from 'lucide-react';
+import { InviteSignUpForm } from '@/components/auth/invite-sign-up-form';
+import { db } from '@/server/db';
+import {
+    inviteService,
+    type InviteInvalidReason,
+} from '@/server/services/invites';
+
+interface InvitePageProps {
+    params: Promise<{ token: string }>;
+}
+
+export default async function InvitePage({ params }: InvitePageProps) {
+    const { token } = await params;
+    const invite = await inviteService.getRedeemableInvite(db, token);
+
+    if (!invite.valid) {
+        return <InviteUnavailable reason={invite.reason} />;
+    }
+
+    return (
+        <div className="mx-auto w-full max-w-md">
+            <div className="mb-8 text-center">
+                <h1 className="mb-2 text-2xl font-bold">Accept your invite</h1>
+                <p className="text-muted-foreground">
+                    Create your account and start archiving
+                </p>
+            </div>
+            <InviteSignUpForm token={token} boundEmail={invite.email} />
+            <p className="mt-6 text-center text-sm text-muted-foreground">
+                Already have an account?{' '}
+                <Link
+                    href="/sign-in"
+                    className="font-medium text-primary hover:underline"
+                >
+                    Sign in
+                </Link>
+            </p>
+            <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-xs text-muted-foreground">
+                <div className="flex items-center gap-1.5">
+                    <DollarSign className="size-3.5 text-primary" />
+                    <span>Sponsored access</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                    <Shield className="size-3.5 text-primary" />
+                    <span>Encrypted</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                    <Archive className="size-3.5 text-primary" />
+                    <span>No credit card</span>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+const INVALID_MESSAGES: Record<InviteInvalidReason, string> = {
+    not_found:
+        "This invite link isn't valid. Check that you copied the whole link.",
+    redeemed: 'This invite has already been used to create an account.',
+    revoked: 'This invite is no longer active. Ask your contact for a new one.',
+    expired: 'This invite has expired. Ask your contact for a new one.',
+};
+
+function InviteUnavailable({ reason }: { reason: InviteInvalidReason }) {
+    return (
+        <div className="mx-auto w-full max-w-md text-center">
+            <h1 className="mb-2 text-2xl font-bold">Invite unavailable</h1>
+            <p className="text-muted-foreground">{INVALID_MESSAGES[reason]}</p>
+            <p className="mt-6 text-sm text-muted-foreground">
+                Already have an account?{' '}
+                <Link
+                    href="/sign-in"
+                    className="font-medium text-primary hover:underline"
+                >
+                    Sign in
+                </Link>
+            </p>
+        </div>
+    );
+}

--- a/apps/web/components/auth/invite-sign-up-form.tsx
+++ b/apps/web/components/auth/invite-sign-up-form.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import Link from 'next/link';
+
+import type React from 'react';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { signUp } from '@/lib/auth/client';
+import { INVITE_TOKEN_COOKIE } from '@/lib/auth/inviteCookie';
+import { DEFAULT_REDIRECT } from '@/lib/auth/sanitizeRedirect';
+
+interface InviteSignUpFormProps {
+    /** The redemption token; carried to the create-hook via a short-lived cookie. */
+    token: string;
+    /**
+     * When the invite is email-bound, the address it was issued to. The field is
+     * locked to it so the signup email can't drift from the invite — the server
+     * treats a mismatch as an error (`subscriptions.ts`), so the UI makes one
+     * unreachable rather than relying on that backstop.
+     */
+    boundEmail: string | null;
+}
+
+export function InviteSignUpForm({ token, boundEmail }: InviteSignUpFormProps) {
+    const router = useRouter();
+    const [isLoading, setIsLoading] = useState(false);
+    const [name, setName] = useState('');
+    const [email, setEmail] = useState(boundEmail ?? '');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState<string | null>(null);
+
+    async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        setError(null);
+        setIsLoading(true);
+
+        // The create-hook reads the token from this cookie (lib/auth/server.ts).
+        // Set it just before signup and clear it in `finally` so it can never
+        // ride along on a later, unrelated signup from the same browser — even
+        // if the request throws. Short max-age is a backstop; SameSite=Lax
+        // keeps it same-origin.
+        setInviteCookie(token);
+        try {
+            const result = await signUp.email({ name, email, password });
+            if (result.error) {
+                setError(result.error.message ?? 'Failed to create account');
+                return;
+            }
+            router.push(DEFAULT_REDIRECT);
+        } catch {
+            setError('Failed to create account');
+        } finally {
+            clearInviteCookie();
+            setIsLoading(false);
+        }
+    }
+
+    return (
+        <form onSubmit={onSubmit} className="space-y-4">
+            {error && (
+                <div
+                    role="alert"
+                    className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+                >
+                    {error}
+                </div>
+            )}
+            <div className="space-y-2">
+                <Label htmlFor="name">Name</Label>
+                <Input
+                    id="name"
+                    type="text"
+                    placeholder="Your name"
+                    required
+                    disabled={isLoading}
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                />
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                    id="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    required
+                    disabled={isLoading}
+                    // Email-bound invites lock the field to the invited
+                    // address. `readOnly` covers the keyboard; ignoring
+                    // onChange while bound pins the value against autofill or
+                    // devtools tampering too, so the submitted email can't drift
+                    // from the invite and silently downgrade to a trial.
+                    readOnly={boundEmail !== null}
+                    aria-readonly={boundEmail !== null}
+                    value={email}
+                    onChange={(e) => {
+                        if (boundEmail === null) setEmail(e.target.value);
+                    }}
+                />
+                {boundEmail !== null && (
+                    <p className="text-xs text-muted-foreground">
+                        This invite is for {boundEmail}.
+                    </p>
+                )}
+            </div>
+            <div className="space-y-2">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                    id="password"
+                    type="password"
+                    placeholder="Create a password"
+                    required
+                    disabled={isLoading}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+            </div>
+            <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Create account
+            </Button>
+            <p className="text-center text-xs text-muted-foreground">
+                By signing up, you agree to our{' '}
+                <Link
+                    href="#"
+                    className="underline underline-offset-4 hover:text-primary"
+                >
+                    Terms of Service
+                </Link>{' '}
+                and{' '}
+                <Link
+                    href="#"
+                    className="underline underline-offset-4 hover:text-primary"
+                >
+                    Privacy Policy
+                </Link>
+                .
+            </p>
+        </form>
+    );
+}
+
+function setInviteCookie(token: string): void {
+    document.cookie = `${INVITE_TOKEN_COOKIE}=${encodeURIComponent(token)}; path=/; max-age=600; samesite=lax`;
+}
+
+function clearInviteCookie(): void {
+    document.cookie = `${INVITE_TOKEN_COOKIE}=; path=/; max-age=0; samesite=lax`;
+}

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -61,6 +61,7 @@ export const PAGES: PageEntry[] = [
     { route: '/', title: 'Landing', auth: 'public' },
     { route: '/sign-in', title: 'Sign in', auth: 'public' },
     { route: '/sign-up', title: 'Sign up', auth: 'public' },
+    { route: '/invite/[token]', title: 'Invite redemption', auth: 'public' },
     { route: '/dashboard', title: 'Dashboard overview', auth: 'user' },
     { route: '/dashboard/files', title: 'Files', auth: 'user' },
     { route: '/dashboard/upload', title: 'Upload', auth: 'user' },
@@ -92,6 +93,18 @@ export const USE_CASES: UseCaseEntry[] = [
         title: 'Trial subscription is provisioned at signup',
         area: 'auth',
         routes: ['/sign-up', '/dashboard/settings'],
+    },
+    {
+        id: 'invite-redemption',
+        title: 'Redeeming an invite validates the token and renders the signup form (friendly message when unusable)',
+        area: 'auth',
+        routes: ['/invite/[token]'],
+    },
+    {
+        id: 'sponsored-on-signup',
+        title: 'Redeeming a valid invite provisions sponsored access with no trial UI',
+        area: 'auth',
+        routes: ['/invite/[token]', '/dashboard/settings'],
     },
     {
         id: 'sign-in-email',

--- a/apps/web/e2e/smoke/auth-flows.spec.ts
+++ b/apps/web/e2e/smoke/auth-flows.spec.ts
@@ -5,20 +5,58 @@
  */
 import { test, expect } from '@playwright/test';
 import { REGULAR_USER } from '../helpers/auth';
-import { deleteUserByEmail } from '@nexus/db/test-db';
+import {
+    deleteInvite,
+    deleteUserByEmail,
+    findUserByEmail,
+    insertInvite,
+} from '@nexus/db/test-db';
 import { createTestDb } from '../helpers/connection';
 
 // Unique per run so a crashed previous run can't collide; cleaned in afterAll.
 const SIGNUP_EMAIL = `signup-e2e-${Date.now()}@test.local`;
 const SIGNUP_PASSWORD = 'signup-e2e-password-123';
 
+// Sponsored-invite redemption seeds a pending invite before the run and drops
+// it after. The token/email are unique per run. The invite's createdBy points
+// at the already-seeded REGULAR_USER (created durably by the setup project)
+// rather than a throwaway user — one insert against a committed FK target, so
+// the invite's foreign key can't lose a race on the transaction-mode pooler.
+const INVITE_SIGNUP_EMAIL = `invite-e2e-${Date.now()}@test.local`;
+const INVITE_TOKEN = `invite-e2e-token-${Date.now()}`;
+let inviteId: string;
+
 test.describe('auth flows', () => {
+    test.beforeAll(async () => {
+        const db = createTestDb();
+        try {
+            const creator = await findUserByEmail(db, REGULAR_USER.email);
+            if (!creator) {
+                throw new Error(
+                    'REGULAR_USER must be seeded by the setup project before this spec'
+                );
+            }
+            const invite = await insertInvite(db, {
+                token: INVITE_TOKEN,
+                createdBy: creator.id,
+            });
+            inviteId = invite.id;
+        } finally {
+            await db.$client.end({ timeout: 5 });
+        }
+    });
+
     test.afterAll(async () => {
         // These tests run unauthenticated (outside the fixture chain), so use a
         // direct connection rather than the worker `db` fixture.
         const db = createTestDb();
         try {
             await deleteUserByEmail(db, SIGNUP_EMAIL);
+            // Drop the redeemer first (nulls redeemedByUserId via ON DELETE SET
+            // NULL), then the invite. The creator is the shared REGULAR_USER —
+            // never delete it.
+            await deleteUserByEmail(db, INVITE_SIGNUP_EMAIL);
+            await deleteInvite(db, inviteId);
         } finally {
             await db.$client.end({ timeout: 5 });
         }
@@ -47,6 +85,38 @@ test.describe('auth flows', () => {
                 .getByRole('heading', { name: 'Starter', exact: true })
                 .locator('..');
             await expect(starterCard.getByText('Current')).toBeVisible();
+        }
+    );
+
+    test(
+        'redeeming an invite provisions sponsored access and hides trial UI',
+        {
+            tag: [
+                '@page:/invite/[token]',
+                '@uc:invite-redemption',
+                '@uc:sponsored-on-signup',
+            ],
+        },
+        async ({ page }) => {
+            await page.goto(`/invite/${INVITE_TOKEN}`);
+
+            await page.getByLabel('Name').fill('Invite E2E');
+            await page.getByLabel('Email').fill(INVITE_SIGNUP_EMAIL);
+            await page.getByLabel('Password').fill(SIGNUP_PASSWORD);
+            await page.getByRole('button', { name: 'Create account' }).click();
+
+            await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
+
+            // Settings shows the Sponsored badge and never any trial UI —
+            // sponsored rows are 'sponsored'/trialEnd null, so the trial
+            // countdown and TRIAL_EXPIRED banner can't render for them.
+            await page.goto('/dashboard/settings');
+            await expect(
+                page.getByText('Sponsored', { exact: true })
+            ).toBeVisible({ timeout: 15_000 });
+            await expect(page.getByText('Trial', { exact: true })).toHaveCount(
+                0
+            );
         }
     );
 

--- a/apps/web/e2e/smoke/auth.spec.ts
+++ b/apps/web/e2e/smoke/auth.spec.ts
@@ -45,4 +45,24 @@ test.describe('Auth Pages', () => {
             expect(errors).toEqual([]);
         }
     );
+
+    test(
+        'invite page shows a friendly message for an invalid token',
+        { tag: ['@page:/invite/[token]'] },
+        async ({ page }) => {
+            const errors = setupConsoleErrorTracking(page);
+
+            await page.goto('/invite/definitely-not-a-real-token');
+
+            await expect(
+                page.getByRole('heading', { name: /invite unavailable/i })
+            ).toBeVisible();
+            // Never render the signup form for an unusable invite.
+            await expect(
+                page.getByRole('button', { name: /create account/i })
+            ).toHaveCount(0);
+
+            expect(errors).toEqual([]);
+        }
+    );
 });

--- a/apps/web/server/services/invites.test.ts
+++ b/apps/web/server/services/invites.test.ts
@@ -158,6 +158,106 @@ describe('inviteService.createInvite', () => {
     });
 });
 
+describe('inviteService.getRedeemableInvite', () => {
+    let db: MockDb;
+    let mocks: MockDbMocks;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+    });
+
+    it('returns valid with the bound email for a pending invite', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ email: 'tester@example.com' })
+        );
+
+        const result = await inviteService.getRedeemableInvite(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({ valid: true, email: 'tester@example.com' });
+    });
+
+    it('returns valid with a null email for an unbound invite', async () => {
+        mocks.invites.findFirst.mockResolvedValue(createInviteFixture());
+
+        const result = await inviteService.getRedeemableInvite(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({ valid: true, email: null });
+    });
+
+    it('returns not_found when no invite matches the token', async () => {
+        mocks.invites.findFirst.mockResolvedValue(undefined);
+
+        const result = await inviteService.getRedeemableInvite(db, 'missing');
+
+        expect(result).toEqual({ valid: false, reason: 'not_found' });
+    });
+
+    it('reports a redeemed invite by its status', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ status: 'redeemed' })
+        );
+
+        const result = await inviteService.getRedeemableInvite(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({ valid: false, reason: 'redeemed' });
+    });
+
+    it('reports a revoked invite by its status', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ status: 'revoked' })
+        );
+
+        const result = await inviteService.getRedeemableInvite(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({ valid: false, reason: 'revoked' });
+    });
+
+    it('reports an expired invite whose expiry has passed', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({
+                expiresAt: new Date('2020-01-01T00:00:00Z'),
+            })
+        );
+
+        const result = await inviteService.getRedeemableInvite(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({ valid: false, reason: 'expired' });
+    });
+
+    it('treats a future expiry as still valid', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({
+                expiresAt: new Date('2999-01-01T00:00:00Z'),
+            })
+        );
+
+        const result = await inviteService.getRedeemableInvite(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({ valid: true, email: null });
+    });
+});
+
 describe('inviteService.revokeInvite', () => {
     let db: MockDb;
     let mocks: MockDbMocks;

--- a/apps/web/server/services/invites.ts
+++ b/apps/web/server/services/invites.ts
@@ -15,6 +15,17 @@ export interface CreateInviteInput {
     expiresAt?: Date;
 }
 
+/** Why an invite can't be redeemed — drives the message on the redemption page. */
+export type InviteInvalidReason =
+    | 'not_found'
+    | 'redeemed'
+    | 'revoked'
+    | 'expired';
+
+export type RedeemableInvite =
+    | { valid: true; email: string | null }
+    | { valid: false; reason: InviteInvalidReason };
+
 /** 32 bytes → 43-char base64url; ≥128 bits of entropy per the token decision in #239. */
 function generateInviteToken(): string {
     return randomBytes(32).toString('base64url');
@@ -70,6 +81,32 @@ async function createInvite(
     return { invite, url };
 }
 
+/**
+ * Client-safe validation for the `/invite/[token]` redemption page. Mirrors the
+ * pre-checks in `subscriptionService.tryProvisionSponsoredSubscription` (status
+ * `pending`, not expired) but returns only what the page needs to render — a
+ * valid/invalid verdict plus the bound email to pre-fill and lock. It never
+ * exposes the full row (storageLimit, createdBy, etc.). Not authoritative: the
+ * conditional-UPDATE `claim` at redemption is the real single-use gate, so a
+ * `valid` result here can still lose a concurrent race and fall back to a trial.
+ */
+async function getRedeemableInvite(
+    db: DB,
+    token: string
+): Promise<RedeemableInvite> {
+    const invite = await createInviteRepo(db).findByToken(token);
+
+    if (!invite) return { valid: false, reason: 'not_found' };
+    if (invite.status !== 'pending') {
+        return { valid: false, reason: invite.status };
+    }
+    if (invite.expiresAt && invite.expiresAt <= new Date()) {
+        return { valid: false, reason: 'expired' };
+    }
+
+    return { valid: true, email: invite.email };
+}
+
 async function revokeInvite(db: DB, id: string): Promise<Invite> {
     const repo = createInviteRepo(db);
     const revoked = await repo.revoke(id);
@@ -89,5 +126,6 @@ async function revokeInvite(db: DB, id: string): Promise<Invite> {
 
 export const inviteService = {
     createInvite,
+    getRedeemableInvite,
     revokeInvite,
 } as const;

--- a/packages/db/src/test-db/inserts.ts
+++ b/packages/db/src/test-db/inserts.ts
@@ -25,6 +25,7 @@ import {
     createSubscriptionFixture,
     createStorageUsageFixture,
     createJobFixture,
+    createInviteFixture,
     type User,
     type StorageUsage,
 } from '../repositories/fixtures';
@@ -33,6 +34,7 @@ import type { UploadBatch } from '../repositories/uploadBatches';
 import type { Retrieval } from '../repositories/retrievals';
 import type { Subscription } from '../repositories/subscriptions';
 import type { Job } from '../repositories/jobs';
+import type { Invite } from '../repositories/invites';
 
 /**
  * Writes ONLY the `user` row — no BetterAuth `account`/password. A user that
@@ -133,6 +135,19 @@ export async function insertStorageUsage(
         })
         .returning();
     return usage!;
+}
+
+export async function insertInvite(
+    db: DB,
+    overrides: Partial<Invite> = {}
+): Promise<Invite> {
+    const row = createInviteFixture(overrides);
+    if (overrides.id === undefined) row.id = crypto.randomUUID();
+    // token is UNIQUE-indexed; derive a collision-free default from the (now
+    // unique) id so back-to-back seeds don't clash on the factory's fixed token.
+    if (overrides.token === undefined) row.token = `invite-token-${row.id}`;
+    const [invite] = await db.insert(schema.invites).values(row).returning();
+    return invite!;
 }
 
 export async function insertJob(

--- a/packages/db/src/test-db/queries.ts
+++ b/packages/db/src/test-db/queries.ts
@@ -80,6 +80,10 @@ export async function deleteJob(db: DB, id: string): Promise<void> {
         .where(eq(schema.backgroundJobs.id, id));
 }
 
+export async function deleteInvite(db: DB, id: string): Promise<void> {
+    await db.delete(schema.invites).where(eq(schema.invites.id, id));
+}
+
 /**
  * Upserts the user's subscription to a fresh trial. Used by global setup (the
  * shared e2e users are reused across runs and may pre-date the signup trial


### PR DESCRIPTION
## Summary

Ships the redemption UX for sponsored-access invites — the last gap in the emailed invite flow (#247). A tester who clicks an `/invite/<token>` link now lands on a real page that validates the token, presents a signup form, and provisions sponsored access on submit.

The backend provisioning branch (#239) reads the invite token from a `nexus_invite_token` cookie in the create-hook. That's the channel that actually shipped, so this PR delivers the token by setting that cookie client-side at submit (the issue's preferred body-threading would have meant re-plumbing merged #239 code for no gain). Sponsored UI was verify-only per the issue: the existing minimal `Sponsored` badge already keeps trial UI away structurally (`sponsored` rows are never `trialing` and have `trialEnd: null`), so this adds an e2e assertion rather than new UI.

Closes #246

## Changes

- **Redemption page** `app/(auth)/invite/[token]/page.tsx` (RSC): validates the token server-side via a new `inviteService.getRedeemableInvite` and renders either the signup form or a friendly "Invite unavailable" message (not_found / redeemed / revoked / expired) — never crashes signup.
- **Invite signup form** `components/auth/invite-sign-up-form.tsx`: sets the invite cookie just before `signUp.email` and clears it in `finally` (no leak/hang if the request throws); locks the email field to the bound address when the invite is email-bound (readOnly + pinned state, so autofill/devtools can't drift it into a silent trial downgrade).
- **Service** `getRedeemableInvite`: client-safe discriminated verdict, mirroring the pre-checks in `subscriptions.ts` (non-authoritative — the real single-use gate is the `claim` at redemption). Unit-tested across all branches.
- **Test-db helpers**: `insertInvite` / `deleteInvite`, following the existing per-table pattern.
- **E2E**: an invalid-token render smoke test, and a behavioral test that redeems a seeded invite and asserts the settings page shows `Sponsored` and no `Trial` UI. Registered the page + use-cases in the coverage manifest.

## Test Plan

- [ ] `pnpm check` (lint + build + unit) passes
- [ ] `pnpm -F web test:e2e:smoke` passes (35/35), including the redemption flow
- [ ] Visit `/invite/<valid-token>` → signup form; submit → land on dashboard with sponsored access; `/dashboard/settings` shows the `Sponsored` badge and no trial countdown
- [ ] Visit `/invite/<bad-token>` → friendly "Invite unavailable" message, no signup form
- [ ] Email-bound invite: email field is pre-filled and read-only