### PR TITLE
feat: sponsored invite redemption UX (/invite page + signup threading) (#246)

### DIFF
--- a/apps/web/app/(auth)/invite/[token]/page.tsx
+++ b/apps/web/app/(auth)/invite/[token]/page.tsx
@@ -1,0 +1,107 @@
+import Link from 'next/link';
+import { Sparkles, MailQuestion } from 'lucide-react';
+import { cn } from '@/lib/cn';
+import { SignUpForm } from '@/components/auth/sign-up-form';
+import { db } from '@/server/db';
+import {
+    inviteService,
+    type InviteRedemption,
+} from '@/server/services/invites';
+
+// Invite state must be fresh on every request — a redeemed, revoked, or
+// expired link has to stop working immediately, so opt out of route caching.
+export const dynamic = 'force-dynamic';
+
+interface InvitePageProps {
+    params: Promise<{ token: string }>;
+}
+
+export default async function InvitePage({ params }: InvitePageProps) {
+    const { token } = await params;
+    const redemption = await inviteService.getInviteRedemption(db, token);
+
+    if (redemption.status !== 'valid') {
+        return <InviteUnavailable status={redemption.status} />;
+    }
+
+    return (
+        <div className="mx-auto w-full max-w-md">
+            <div className="mb-8 text-center">
+                <span className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium tracking-wide text-primary uppercase">
+                    <Sparkles className="size-3.5" />
+                    Sponsored access
+                </span>
+                <h1 className="mb-2 text-2xl font-bold">
+                    You&apos;re invited to Nexus
+                </h1>
+                <p className="text-muted-foreground">
+                    Create your account and start archiving — storage is on us.
+                </p>
+            </div>
+            <SignUpForm
+                inviteToken={token}
+                lockedEmail={redemption.email ?? undefined}
+            />
+            <SignInPrompt className="mt-6" />
+        </div>
+    );
+}
+
+const UNAVAILABLE_COPY: Record<
+    Exclude<InviteRedemption['status'], 'valid'>,
+    { title: string; body: string }
+> = {
+    invalid: {
+        title: 'This invite link isn’t valid',
+        body: 'Check that the link matches the one you were sent — it may have been truncated. If it still doesn’t work, ask the person who invited you for a fresh link.',
+    },
+    expired: {
+        title: 'This invite has expired',
+        body: 'Invite links are only valid for a limited time. Ask the person who invited you to send a new one.',
+    },
+    redeemed: {
+        title: 'This invite has already been used',
+        body: 'Each invite works exactly once. If you redeemed it yourself, just sign in to your account.',
+    },
+    revoked: {
+        title: 'This invite is no longer active',
+        body: 'The invite was withdrawn. If you think that’s a mistake, reach out to the person who invited you.',
+    },
+};
+
+function InviteUnavailable({
+    status,
+}: {
+    status: Exclude<InviteRedemption['status'], 'valid'>;
+}) {
+    const copy = UNAVAILABLE_COPY[status];
+    return (
+        <div className="mx-auto w-full max-w-md text-center">
+            <div className="mb-6 inline-flex size-12 items-center justify-center rounded-full bg-muted">
+                <MailQuestion className="size-6 text-muted-foreground" />
+            </div>
+            <h1 className="mb-2 text-2xl font-bold">{copy.title}</h1>
+            <p className="mb-8 text-muted-foreground">{copy.body}</p>
+            <SignInPrompt />
+        </div>
+    );
+}
+
+function SignInPrompt({ className }: { className?: string }) {
+    return (
+        <p
+            className={cn(
+                'text-center text-sm text-muted-foreground',
+                className
+            )}
+        >
+            Already have an account?{' '}
+            <Link
+                href="/sign-in"
+                className="font-medium text-primary hover:underline"
+            >
+                Sign in
+            </Link>
+        </p>
+    );
+}

--- a/apps/web/components/auth/sign-up-form.tsx
+++ b/apps/web/components/auth/sign-up-form.tsx
@@ -18,16 +18,31 @@ import { DEFAULT_REDIRECT } from '@/lib/auth/sanitizeRedirect';
 interface SignUpFormProps {
     /** Sanitized path to land on after a successful sign-up. */
     redirectTo?: string;
+    /**
+     * Sponsored invite token (#246). Rides the signup request body so the
+     * user create-hook can provision sponsored access in the same request.
+     */
+    inviteToken?: string;
+    /**
+     * Email an invite is bound to. Locks the field so redemption can't be
+     * silently downgraded to a trial by an email mismatch server-side.
+     */
+    lockedEmail?: string;
 }
 
-export function SignUpForm({ redirectTo = DEFAULT_REDIRECT }: SignUpFormProps) {
+export function SignUpForm({
+    redirectTo = DEFAULT_REDIRECT,
+    inviteToken,
+    lockedEmail,
+}: SignUpFormProps) {
     const router = useRouter();
     const [isLoading, setIsLoading] = useState(false);
     const [isGoogleLoading, setIsGoogleLoading] = useState(false);
     const [name, setName] = useState('');
-    const [email, setEmail] = useState('');
+    const [email, setEmail] = useState(lockedEmail ?? '');
     const [password, setPassword] = useState('');
     const [error, setError] = useState<string | null>(null);
+    const isEmailLocked = lockedEmail !== undefined;
 
     async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
@@ -38,6 +53,9 @@ export function SignUpForm({ redirectTo = DEFAULT_REDIRECT }: SignUpFormProps) {
             name,
             email,
             password,
+            // Spread keeps the key out of normal signups entirely; better-auth
+            // forwards extra body keys to the server hook (see lib/auth/server.ts).
+            ...(inviteToken !== undefined && { inviteToken }),
         });
 
         setIsLoading(false);
@@ -60,21 +78,28 @@ export function SignUpForm({ redirectTo = DEFAULT_REDIRECT }: SignUpFormProps) {
 
     return (
         <div className="space-y-6">
-            <Button
-                variant="outline"
-                className="w-full bg-transparent"
-                onClick={onGoogleSignUp}
-                disabled={isGoogleLoading || isLoading}
-            >
-                {isGoogleLoading ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                    <GoogleIcon className="mr-2 h-4 w-4" />
-                )}
-                Continue with Google
-            </Button>
+            {/* OAuth is a redirect flow — it can't carry the invite token in
+                the signup body, so a Google signup here would silently land
+                the tester on a trial. Hide it for invite redemptions. */}
+            {inviteToken === undefined && (
+                <>
+                    <Button
+                        variant="outline"
+                        className="w-full bg-transparent"
+                        onClick={onGoogleSignUp}
+                        disabled={isGoogleLoading || isLoading}
+                    >
+                        {isGoogleLoading ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                            <GoogleIcon className="mr-2 h-4 w-4" />
+                        )}
+                        Continue with Google
+                    </Button>
 
-            <OAuthDivider />
+                    <OAuthDivider />
+                </>
+            )}
 
             <form onSubmit={onSubmit} className="space-y-4">
                 {error && (
@@ -105,9 +130,21 @@ export function SignUpForm({ redirectTo = DEFAULT_REDIRECT }: SignUpFormProps) {
                         placeholder="you@example.com"
                         required
                         disabled={isLoading}
+                        readOnly={isEmailLocked}
+                        aria-readonly={isEmailLocked || undefined}
+                        className={
+                            isEmailLocked
+                                ? 'bg-muted text-muted-foreground'
+                                : undefined
+                        }
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                     />
+                    {isEmailLocked && (
+                        <p className="text-xs text-muted-foreground">
+                            Your invite is for this email address.
+                        </p>
+                    )}
                 </div>
                 <div className="space-y-2">
                     <Label htmlFor="password">Password</Label>

--- a/apps/web/components/dashboard/subscriptionPlans.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.ts
@@ -73,7 +73,7 @@ const STATUS_BADGES: Record<Subscription['status'], StatusBadge> = {
     canceled: { label: 'Canceled', variant: 'destructive' },
     unpaid: { label: 'Unpaid', variant: 'destructive' },
     incomplete: { label: 'Incomplete', variant: 'secondary' },
-    // Minimal badge for comped alpha testers; richer sponsored UI is #246
+    // Minimal badge for comped alpha testers; richer sponsored UI is #252
     sponsored: { label: 'Sponsored', variant: 'default' },
 };
 

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -61,6 +61,7 @@ export const PAGES: PageEntry[] = [
     { route: '/', title: 'Landing', auth: 'public' },
     { route: '/sign-in', title: 'Sign in', auth: 'public' },
     { route: '/sign-up', title: 'Sign up', auth: 'public' },
+    { route: '/invite/[token]', title: 'Invite redemption', auth: 'public' },
     { route: '/dashboard', title: 'Dashboard overview', auth: 'user' },
     { route: '/dashboard/files', title: 'Files', auth: 'user' },
     { route: '/dashboard/upload', title: 'Upload', auth: 'user' },
@@ -141,6 +142,30 @@ export const USE_CASES: UseCaseEntry[] = [
         area: 'auth',
         routes: ['/sign-in', '/sign-up'],
         excluded: 'Google OAuth provider is not configured in any environment',
+    },
+    {
+        id: 'invite-redeem-sponsored',
+        title: 'Redeeming a valid invite at signup provisions sponsored access',
+        area: 'auth',
+        routes: ['/invite/[token]', '/dashboard/settings'],
+    },
+    {
+        id: 'invite-invalid-state',
+        title: 'Invalid, expired, or used invite links show a friendly message',
+        area: 'auth',
+        routes: ['/invite/[token]'],
+    },
+    {
+        id: 'invite-email-locked',
+        title: 'Email-bound invite pre-fills the signup email read-only',
+        area: 'auth',
+        routes: ['/invite/[token]'],
+    },
+    {
+        id: 'sponsored-no-trial-ui',
+        title: 'Sponsored users see no trial badge or countdown',
+        area: 'auth',
+        routes: ['/dashboard/settings'],
     },
 
     /* ---------------------------------------------------------------- */

--- a/apps/web/e2e/smoke/invite.spec.ts
+++ b/apps/web/e2e/smoke/invite.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Sponsored invite redemption (#246). Runs unauthenticated (bare smoke
+ * project) like auth-flows.spec.ts: redemption happens at signup, so these
+ * tests create their own sessions and never touch the shared storage states.
+ */
+import { test, expect } from '@playwright/test';
+import {
+    findUserByEmail,
+    insertInvite,
+    deleteInvite,
+    deleteUserByEmail,
+    type Invite,
+} from '@nexus/db/test-db';
+import { ADMIN_USER } from '../helpers/auth';
+import { createTestDb } from '../helpers/connection';
+import { setupConsoleErrorTracking } from '../utils';
+
+// Unique per run so a crashed previous run can't collide; cleaned in afterAll.
+const SIGNUP_EMAIL = `sponsored-e2e-${Date.now()}@test.local`;
+const BOUND_EMAIL = `invite-bound-e2e-${Date.now()}@test.local`;
+const SIGNUP_PASSWORD = 'sponsored-e2e-password-123';
+
+test.describe('invite redemption', () => {
+    let db: ReturnType<typeof createTestDb>;
+    let openInvite: Invite;
+    let redeemableInvite: Invite;
+    let boundInvite: Invite;
+    let expiredInvite: Invite;
+
+    test.beforeAll(async () => {
+        // These tests run outside the fixture chain (no worker `db` fixture),
+        // so hold a direct connection for seeding and cleanup.
+        db = createTestDb();
+        // Seeded invites need a real creator; the shared admin user is
+        // guaranteed by the setup project.
+        const admin = await findUserByEmail(db, ADMIN_USER.email);
+        if (!admin) throw new Error('Shared admin e2e user not found');
+
+        openInvite = await insertInvite(db, { createdBy: admin.id });
+        // The redemption test consumes its invite; tests run fully parallel,
+        // so it gets its own row — sharing openInvite would let scheduling
+        // order decide whether the render test sees a pending invite.
+        redeemableInvite = await insertInvite(db, { createdBy: admin.id });
+        boundInvite = await insertInvite(db, {
+            createdBy: admin.id,
+            email: BOUND_EMAIL,
+        });
+        expiredInvite = await insertInvite(db, {
+            createdBy: admin.id,
+            expiresAt: new Date(Date.now() - 60_000),
+        });
+    });
+
+    test.afterAll(async () => {
+        try {
+            await deleteInvite(db, openInvite.id);
+            await deleteInvite(db, redeemableInvite.id);
+            await deleteInvite(db, boundInvite.id);
+            await deleteInvite(db, expiredInvite.id);
+            await deleteUserByEmail(db, SIGNUP_EMAIL);
+        } finally {
+            await db.$client.end({ timeout: 5 });
+        }
+    });
+
+    test(
+        'valid invite renders the sponsored signup without console errors',
+        { tag: ['@page:/invite/[token]'] },
+        async ({ page }) => {
+            const errors = setupConsoleErrorTracking(page);
+
+            await page.goto(`/invite/${openInvite.token}`);
+
+            await expect(
+                page.getByRole('heading', { name: /you.re invited/i })
+            ).toBeVisible();
+            await expect(page.getByText('Sponsored access')).toBeVisible();
+            await expect(
+                page.getByRole('button', { name: 'Create account' })
+            ).toBeVisible();
+
+            expect(errors).toEqual([]);
+        }
+    );
+
+    test(
+        'email-bound invite pre-fills the email read-only',
+        { tag: ['@page:/invite/[token]', '@uc:invite-email-locked'] },
+        async ({ page }) => {
+            await page.goto(`/invite/${boundInvite.token}`);
+
+            const emailInput = page.getByLabel('Email');
+            await expect(emailInput).toHaveValue(BOUND_EMAIL);
+            await expect(emailInput).toHaveAttribute('readonly', '');
+            await expect(
+                page.getByText('Your invite is for this email address.')
+            ).toBeVisible();
+        }
+    );
+
+    test(
+        'invalid and expired links show a friendly message instead of signup',
+        { tag: ['@page:/invite/[token]', '@uc:invite-invalid-state'] },
+        async ({ page }) => {
+            await page.goto('/invite/definitely-not-a-real-token');
+            await expect(
+                page.getByRole('heading', { name: /isn.t valid/i })
+            ).toBeVisible();
+            await expect(page.getByLabel('Password')).toHaveCount(0);
+
+            await page.goto(`/invite/${expiredInvite.token}`);
+            await expect(
+                page.getByRole('heading', { name: /has expired/i })
+            ).toBeVisible();
+            await expect(page.getByLabel('Password')).toHaveCount(0);
+        }
+    );
+
+    test(
+        'redeeming an invite provisions sponsored access with no trial UI',
+        {
+            tag: [
+                '@page:/invite/[token]',
+                '@uc:invite-redeem-sponsored',
+                '@uc:sponsored-no-trial-ui',
+            ],
+        },
+        async ({ page }) => {
+            await page.goto(`/invite/${redeemableInvite.token}`);
+
+            await page.getByLabel('Name').fill('Sponsored E2E');
+            await page.getByLabel('Email').fill(SIGNUP_EMAIL);
+            await page.getByLabel('Password').fill(SIGNUP_PASSWORD);
+            await page.getByRole('button', { name: 'Create account' }).click();
+
+            await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
+
+            // Settings shows the Sponsored badge and — the #246 assertion —
+            // no trial UI anywhere on the page (badge or countdown copy).
+            await page.goto('/dashboard/settings');
+            await expect(
+                page.getByText('Sponsored', { exact: true })
+            ).toBeVisible({ timeout: 15_000 });
+            await expect(page.getByText(/trial/i)).toHaveCount(0);
+
+            // The invite is single-use: revisiting the link must say so.
+            await page.goto(`/invite/${redeemableInvite.token}`);
+            await expect(
+                page.getByRole('heading', { name: /already been used/i })
+            ).toBeVisible();
+        }
+    );
+});

--- a/apps/web/lib/auth/inviteCookie.ts
+++ b/apps/web/lib/auth/inviteCookie.ts
@@ -1,8 +1,0 @@
-/**
- * Cookie carrying an invite token from the `/invite/[token]` redemption page
- * (#246) to the signup create-hook in `lib/auth/server.ts`, where a valid
- * pending invite provisions a sponsored subscription instead of a trial.
- * Lives outside `server.ts` so the client-side page can import it without
- * pulling in the server auth instance.
- */
-export const INVITE_TOKEN_COOKIE = 'nexus_invite_token';

--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -1,7 +1,6 @@
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import * as schema from '@nexus/db/schema';
-import { INVITE_TOKEN_COOKIE } from '@/lib/auth/inviteCookie';
 import { db } from '@/server/db';
 import { subscriptionService } from '@/server/services/subscriptions';
 import { logger } from '@/server/lib/logger';
@@ -55,10 +54,17 @@ export const auth = betterAuth({
                 // falls back to a trial internally; only trial-provisioning
                 // failure rethrows.)
                 after: async (user, context) => {
-                    // Set by the /invite/[token] redemption page (#246);
-                    // absent for normal signups.
+                    // Sent in the signup body by the /invite/[token]
+                    // redemption page (#246); absent for normal signups.
+                    // better-auth's sign-up body schema passes unknown keys
+                    // through to this endpoint context, and its user-input
+                    // parser drops them, so the token never touches the
+                    // user row.
+                    const bodyToken: unknown = context?.body?.inviteToken;
                     const inviteToken =
-                        context?.getCookie(INVITE_TOKEN_COOKIE) ?? null;
+                        typeof bodyToken === 'string' && bodyToken !== ''
+                            ? bodyToken
+                            : null;
                     try {
                         await subscriptionService.provisionSignupSubscription(
                             db,

--- a/apps/web/server/services/invites.test.ts
+++ b/apps/web/server/services/invites.test.ts
@@ -158,6 +158,95 @@ describe('inviteService.createInvite', () => {
     });
 });
 
+describe('inviteService.getInviteRedemption', () => {
+    let db: MockDb;
+    let mocks: MockDbMocks;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+    });
+
+    it('returns valid with a null email for an unbound pending invite', async () => {
+        mocks.invites.findFirst.mockResolvedValue(createInviteFixture());
+
+        const result = await inviteService.getInviteRedemption(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({ status: 'valid', email: null });
+    });
+
+    it('returns the bound email for an email-bound pending invite', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ email: 'tester@example.com' })
+        );
+
+        const result = await inviteService.getInviteRedemption(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({
+            status: 'valid',
+            email: 'tester@example.com',
+        });
+    });
+
+    it('treats a pending invite with a future expiry as valid', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ expiresAt: new Date(Date.now() + 60_000) })
+        );
+
+        const result = await inviteService.getInviteRedemption(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({ status: 'valid', email: null });
+    });
+
+    it('returns invalid for an unknown token', async () => {
+        mocks.invites.findFirst.mockResolvedValue(undefined);
+
+        const result = await inviteService.getInviteRedemption(db, 'missing');
+
+        expect(result).toEqual({ status: 'invalid' });
+    });
+
+    it('returns expired for a pending invite past its expiry', async () => {
+        mocks.invites.findFirst.mockResolvedValue(
+            createInviteFixture({ expiresAt: new Date(Date.now() - 60_000) })
+        );
+
+        const result = await inviteService.getInviteRedemption(
+            db,
+            TEST_INVITE_TOKEN
+        );
+
+        expect(result).toEqual({ status: 'expired' });
+    });
+
+    it.each(['redeemed', 'revoked'] as const)(
+        'returns %s for a %s invite',
+        async (status) => {
+            mocks.invites.findFirst.mockResolvedValue(
+                createInviteFixture({ status })
+            );
+
+            const result = await inviteService.getInviteRedemption(
+                db,
+                TEST_INVITE_TOKEN
+            );
+
+            expect(result).toEqual({ status });
+        }
+    );
+});
+
 describe('inviteService.revokeInvite', () => {
     let db: MockDb;
     let mocks: MockDbMocks;

--- a/apps/web/server/services/invites.ts
+++ b/apps/web/server/services/invites.ts
@@ -70,6 +70,30 @@ async function createInvite(
     return { invite, url };
 }
 
+/**
+ * Everything the public redemption page needs to render: whether the link is
+ * usable and, for email-bound invites, the address to lock the signup form
+ * to. Non-valid states are distinguished so the page can explain what
+ * happened. Read-only — claiming stays in the signup create-hook, and the
+ * provisioning path re-checks all of this authoritatively.
+ */
+export type InviteRedemption =
+    | { status: 'valid'; email: string | null }
+    | { status: 'invalid' | 'expired' | 'redeemed' | 'revoked' };
+
+async function getInviteRedemption(
+    db: DB,
+    token: string
+): Promise<InviteRedemption> {
+    const invite = await createInviteRepo(db).findByToken(token);
+    if (!invite) return { status: 'invalid' };
+    if (invite.status !== 'pending') return { status: invite.status };
+    if (invite.expiresAt && invite.expiresAt <= new Date()) {
+        return { status: 'expired' };
+    }
+    return { status: 'valid', email: invite.email };
+}
+
 async function revokeInvite(db: DB, id: string): Promise<Invite> {
     const repo = createInviteRepo(db);
     const revoked = await repo.revoke(id);
@@ -89,5 +113,6 @@ async function revokeInvite(db: DB, id: string): Promise<Invite> {
 
 export const inviteService = {
     createInvite,
+    getInviteRedemption,
     revokeInvite,
 } as const;

--- a/packages/db/src/test-db/index.ts
+++ b/packages/db/src/test-db/index.ts
@@ -26,3 +26,4 @@ export type { UploadBatch } from '../repositories/uploadBatches';
 export type { Retrieval } from '../repositories/retrievals';
 export type { Subscription } from '../repositories/subscriptions';
 export type { Job, NewJob } from '../repositories/jobs';
+export type { Invite } from '../repositories/invites';

--- a/packages/db/src/test-db/inserts.ts
+++ b/packages/db/src/test-db/inserts.ts
@@ -25,6 +25,7 @@ import {
     createSubscriptionFixture,
     createStorageUsageFixture,
     createJobFixture,
+    createInviteFixture,
     type User,
     type StorageUsage,
 } from '../repositories/fixtures';
@@ -33,6 +34,7 @@ import type { UploadBatch } from '../repositories/uploadBatches';
 import type { Retrieval } from '../repositories/retrievals';
 import type { Subscription } from '../repositories/subscriptions';
 import type { Job } from '../repositories/jobs';
+import type { Invite } from '../repositories/invites';
 
 /**
  * Writes ONLY the `user` row — no BetterAuth `account`/password. A user that
@@ -133,6 +135,24 @@ export async function insertStorageUsage(
         })
         .returning();
     return usage!;
+}
+
+/**
+ * `createdBy` references a real user row — e2e callers must pass an existing
+ * user's id (the fixture's `TEST_ADMIN_USER_ID` default only exists in unit
+ * tests' mocked DB).
+ */
+export async function insertInvite(
+    db: DB,
+    overrides: Partial<Invite> = {}
+): Promise<Invite> {
+    const row = createInviteFixture(overrides);
+    if (overrides.id === undefined) row.id = crypto.randomUUID();
+    // token is UNIQUE; derive from the (now unique) id so back-to-back
+    // inserts don't clash on the factory's fixed default.
+    if (overrides.token === undefined) row.token = `test-invite-${row.id}`;
+    const [invite] = await db.insert(schema.invites).values(row).returning();
+    return invite!;
 }
 
 export async function insertJob(

--- a/packages/db/src/test-db/queries.ts
+++ b/packages/db/src/test-db/queries.ts
@@ -80,6 +80,10 @@ export async function deleteJob(db: DB, id: string): Promise<void> {
         .where(eq(schema.backgroundJobs.id, id));
 }
 
+export async function deleteInvite(db: DB, id: string): Promise<void> {
+    await db.delete(schema.invites).where(eq(schema.invites.id, id));
+}
+
 /**
  * Upserts the user's subscription to a fresh trial. Used by global setup (the
  * shared e2e users are reused across runs and may pre-date the signup trial


### PR DESCRIPTION
## Summary

Builds the redemption UX for sponsored-access invites: the public `/invite/[token]` landing page (the target of #247's invite emails, previously a 404), token threading through the signup request body into the merged #239 provisioning hook, and a UI-level guarantee that sponsored users never see trial UI.

The issue left open whether BetterAuth forwards an arbitrary `inviteToken` body key to the database hook. Verified against the installed `better-auth@1.4.10` source: the sign-up body schema ends in `.and(z.record(z.string(), z.any()))` (extra keys survive), the `create.after` hook receives the endpoint context (which carries `.body`), and `parseUserInput` drops unknown keys from the user row. So the token rides the same request that creates the user, per the AC, and the never-wired cookie mechanism from #239 (`inviteCookie.ts`) is deleted.

Closes #246

## Changes

- New `/invite/[token]` server component in the `(auth)` layout: validates the token via a new read-only `inviteService.getInviteRedemption` (direct service call, `force-dynamic` so redeemed/revoked/expired links stop working immediately) and renders distinct friendly messages for invalid / expired / already-used / revoked links
- `SignUpForm` gains `inviteToken` and `lockedEmail` props: the token is spread into the `signUp.email` body, email-bound invites render the email read-only (server backstop for mismatch stays in #239's provisioning), and the Google OAuth button is hidden for invite signups since a redirect flow can't carry the body token
- `lib/auth/server.ts` create-hook now reads `context.body.inviteToken` instead of the cookie; `lib/auth/inviteCookie.ts` deleted
- Unit tests for `getInviteRedemption` (all five states); e2e smoke spec covering render, locked email, invalid/expired messages, and a full redemption run asserting the `Sponsored` badge and **zero** trial copy on settings, plus single-use behavior on revisit
- `@nexus/db/test-db`: `insertInvite` / `deleteInvite` helpers and `Invite` type export
- Follow-up #252 filed for sponsored plan-card actions + richer sponsored UI (out of AC); `subscriptionPlans.ts` comment updated to point there

## Review notes

Self-review (conventions / quality / reuse agents) found and fixed: an e2e test-order flake (redemption test now uses its own invite under `fullyParallel`) and a duplicated sign-in link block (extracted `SignInPrompt`). The invite-validity predicate intentionally remains duplicated between `getInviteRedemption` (display) and `tryProvisionSponsoredSubscription` (authoritative) — documented defense-in-depth from #239.

## Test Plan

- [x] `pnpm check` green
- [x] `pnpm -F web test:e2e:smoke` 37/37 (includes 4 new invite tests; the redemption test exercises the real BetterAuth signup + Stripe test-mode customer creation end-to-end)
- [x] `pnpm -F web e2e:coverage --check` 100% pages/use-cases
- [x] Manual: create an email-bound invite via admin, click the emailed link, redeem, confirm sponsored settings