### PR TITLE
fix: render standard-tier files as archived with Retrieve (#256)

### DIFF
--- a/apps/web/components/dashboard/file-browser.tsx
+++ b/apps/web/components/dashboard/file-browser.tsx
@@ -70,11 +70,10 @@ const SEARCH_DEBOUNCE_MS = 300;
 // counts must match the per-row status dots derived here.
 function deriveStatus(file: File): DerivedStatus {
     if (file.status === 'restoring') return 'retrieving';
-    if (
-        file.status === 'available' &&
-        (file.storageTier === 'glacier' || file.storageTier === 'deep_archive')
-    )
-        return 'archived';
+    // Every tier renders as archived: standard-tier rows (fresh uploads
+    // pre-transition, sub-128KB files) must not surface a Download action
+    // that getDownloadUrl can't serve without a ready retrieval (#256).
+    if (file.status === 'available') return 'archived';
     return 'available';
 }
 

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -236,8 +236,8 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/files'],
     },
     {
-        id: 'files-download-available',
-        title: 'Download an available file via presigned URL',
+        id: 'files-standard-tier-archived',
+        title: 'Standard-tier files render archived with Retrieve, no Download',
         area: 'files',
         routes: ['/dashboard/files'],
     },

--- a/apps/web/e2e/flows/files-browser.spec.ts
+++ b/apps/web/e2e/flows/files-browser.spec.ts
@@ -77,8 +77,9 @@ const test = base.extend<
                 createdAt: new Date(now - 1000),
                 updatedAt: new Date(now - 1000),
             });
-            // One ungrouped standard file with a ready retrieval → derived
-            // status "available", Download action enabled.
+            // One ungrouped standard-tier file with a ready retrieval. Every
+            // tier derives status "archived" (#256), so this row must render
+            // identically to the deep_archive ones: Retrieve, no Download.
             const readyDoc = await insertFile(db, {
                 userId,
                 name: 'ready-doc-ccc.pdf',
@@ -132,8 +133,10 @@ test.describe('with a seeded library', () => {
             ).toBeVisible();
 
             await expect(page.getByText('3 files')).toBeVisible();
-            await expect(page.getByText('2 archived')).toBeVisible();
-            await expect(page.getByText('1 available')).toBeVisible();
+            // Standard tier counts as archived (#256); the "available" chip
+            // only renders for a non-zero count, so it must be absent.
+            await expect(page.getByText('3 archived')).toBeVisible();
+            await expect(page.getByText(/\d+ available/)).toBeHidden();
         }
     );
 
@@ -292,17 +295,6 @@ test.describe('with a seeded library', () => {
                 page.getByText(seededLibrary.archivedA.name)
             ).toBeVisible();
 
-            // Only the non-archived file selected → Retrieve disabled.
-            await page
-                .getByRole('button', {
-                    name: `Select ${seededLibrary.readyDoc.name}`,
-                })
-                .click();
-            await expect(
-                page.getByRole('button', { name: 'Retrieve' })
-            ).toBeDisabled();
-            await page.getByRole('button', { name: 'Clear selection' }).click();
-
             // Archived files selected → Retrieve fires the bulk mutation.
             await page
                 .getByRole('button', {
@@ -373,27 +365,40 @@ test.describe('with a seeded library', () => {
     );
 
     test(
-        'download opens a presigned URL for an available file',
-        { tag: ['@uc:files-download-available'] },
+        'standard-tier file renders archived with Retrieve, no Download',
+        { tag: ['@uc:files-standard-tier-archived'] },
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
                 page.getByText(seededLibrary.readyDoc.name)
             ).toBeVisible();
 
+            // Row renders identically to a deep_archive row (#256).
+            const row = page.locator('tr', {
+                hasText: seededLibrary.readyDoc.name,
+            });
+            await expect(row.getByText('archived')).toBeVisible();
+
+            // Selecting it counts toward the bulk Retrieve selection.
             await page
-                .locator('tr', { hasText: seededLibrary.readyDoc.name })
-                .getByRole('button', { name: 'Actions' })
+                .getByRole('button', {
+                    name: `Select ${seededLibrary.readyDoc.name}`,
+                })
                 .click();
+            await expect(
+                page.getByRole('button', { name: 'Retrieve' })
+            ).toBeEnabled();
+            await page.getByRole('button', { name: 'Clear selection' }).click();
 
-            const popupPromise = page.waitForEvent('popup');
-            await page.getByRole('menuitem', { name: 'Download' }).click();
-            const popup = await popupPromise;
-
-            // Presigned S3 GET — signature params prove it went through the
-            // presigner rather than a bare bucket URL.
-            expect(popup.url()).toContain('X-Amz-');
-            await popup.close();
+            // Actions menu offers Retrieve only — no Download for any tier.
+            await row.getByRole('button', { name: 'Actions' }).click();
+            await expect(
+                page.getByRole('menuitem', { name: 'Request retrieval' })
+            ).toBeVisible();
+            await expect(
+                page.getByRole('menuitem', { name: 'Download' })
+            ).toHaveCount(0);
+            await page.keyboard.press('Escape');
         }
     );
 

--- a/packages/db/src/repositories/files.ts
+++ b/packages/db/src/repositories/files.ts
@@ -171,7 +171,9 @@ async function countByUser(
  * apps/web/components/dashboard/file-browser.tsx — keep the two in lockstep
  * or UI counts will disagree with per-row status dots. Hidden statuses
  * (`uploading`, `deleted`) are always excluded since they don't fit any
- * bucket and would produce a NULL category from the CASE below.
+ * bucket and would produce a NULL category from the CASE below. The
+ * `available` bucket is currently always 0 — every tier renders as
+ * archived (#256) until the retrieval fast-path lands.
  */
 async function countStatusesByUser(
     db: DB,
@@ -182,10 +184,7 @@ async function countStatusesByUser(
             category: sql<keyof StatusCategoryCounts | null>`
                 CASE
                     WHEN ${schema.files.status} = 'restoring' THEN 'retrieving'
-                    WHEN ${schema.files.status} = 'available'
-                        AND ${schema.files.storageTier} IN ('glacier', 'deep_archive') THEN 'archived'
-                    WHEN ${schema.files.status} = 'available'
-                        AND ${schema.files.storageTier} = 'standard' THEN 'available'
+                    WHEN ${schema.files.status} = 'available' THEN 'archived'
                     ELSE NULL
                 END`.as('category'),
             count: sql<number>`count(*)::int`.as('count'),


### PR DESCRIPTION
## Summary
Removes the storage-tier branch in the file browser's status derivation so every tier renders as archived with a single Retrieve action. Prep for #255: once activation flips inserts to `standard`, fresh uploads and sub-128KB files would otherwise surface per-file Download buttons — a broken action anyway, since `getDownloadUrl` requires a `ready` retrieval row. Inert today: no `storageTier = 'standard'` rows exist in prod, so nothing user-visible changes until activation lands. Must merge before it.

Closes #256

## Changes
- `deriveStatus` (file-browser.tsx): any `available` file derives `archived` regardless of tier
- `countStatusesByUser` (packages/db): matching CASE change to keep the stats bar in lockstep with row dots; `available` bucket is now always 0 (chip never renders)
- e2e `files-browser.spec.ts`: stats bar asserts `3 archived` + no available chip; dropped the now-invalid "standard-only selection disables Retrieve" assertion; replaced the download test with `standard-tier file renders archived with Retrieve, no Download`
- Coverage manifest: `files-download-available` → `files-standard-tier-archived`

## Notes
- Scope is deliberately minimal branch removal: the Download menu item / `handleDownload` / `'available'` DerivedStatus stay as (unreachable) code for the retrieval fast-path sub-issue to rework, per discussion. Conventions self-review flagged the dead code; skipped by that decision.
- The backend Glacier-tier guard in `retrieval.ts` still rejects standard-tier retrievals (out of scope, fast-path sub-issue) — clicking Retrieve on a standard row would error, but no such rows exist until activation.
- Testing plan asked for a component/unit test; project convention is e2e for presentational components, so the assertions live in the flows spec.

## Test Plan
- [x] `pnpm check` (10/10)
- [x] `pnpm -F web test:e2e:smoke` (33/33)
- [x] `playwright test e2e/flows/files-browser.spec.ts` (15/15)
- [x] `pnpm -F web e2e:coverage --check` (55/55 use-cases, 13/13 pages)