### PR TITLE
fix: retrieval fast path for STANDARD-class objects; batch ready-when-slowest (#257)

### DIFF
--- a/apps/web/lib/storage/glacier.ts
+++ b/apps/web/lib/storage/glacier.ts
@@ -1,5 +1,6 @@
 import { RestoreObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
 import { client, bucket } from './client';
+import { DEFAULT_RESTORE_DAYS_TO_KEEP } from './types';
 import type { RestoreTier, RestoreStatus } from './types';
 
 const tierMapping: Record<RestoreTier, 'Expedited' | 'Standard' | 'Bulk'> = {
@@ -17,7 +18,7 @@ const tierMapping: Record<RestoreTier, 'Expedited' | 'Standard' | 'Bulk'> = {
 export async function restore(
     key: string,
     tier: RestoreTier,
-    daysToKeep = 7
+    daysToKeep = DEFAULT_RESTORE_DAYS_TO_KEEP
 ): Promise<void> {
     const command = new RestoreObjectCommand({
         Bucket: bucket,
@@ -40,7 +41,7 @@ export async function restore(
 export async function restoreMany(
     keys: string[],
     tier: RestoreTier,
-    daysToKeep = 7
+    daysToKeep = DEFAULT_RESTORE_DAYS_TO_KEEP
 ): Promise<void> {
     await Promise.all(keys.map((key) => restore(key, tier, daysToKeep)));
 }

--- a/apps/web/lib/storage/types.ts
+++ b/apps/web/lib/storage/types.ts
@@ -1,6 +1,14 @@
 // Re-export from canonical source in @nexus/db
 export { RESTORE_TIERS, type RestoreTier } from '@nexus/db/schema';
 
+/**
+ * Days a restored Glacier copy stays accessible. Also the length of the
+ * synthetic download window for standard-tier retrievals, which skip S3
+ * restore entirely — keep the two in lockstep so both tiers present the
+ * same window.
+ */
+export const DEFAULT_RESTORE_DAYS_TO_KEEP = 7;
+
 export interface RestoreStatus {
     status: 'not-started' | 'in-progress' | 'completed';
     /** Present only when status === 'completed' */

--- a/apps/web/server/services/retrieval.integration.test.ts
+++ b/apps/web/server/services/retrieval.integration.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+    createDb,
+    insertUser,
+    insertFile,
+    insertRetrieval,
+    deleteUserData,
+    type Connection,
+} from '@nexus/db/test-db';
+import { createRetrievalRepo } from '@nexus/db/repo/retrievals';
+import { InvalidStateError } from '@/server/errors';
+import { retrievalService } from './retrieval';
+
+// Exercises the active-retrieval predicate against a real database: `ready`
+// rows past `expiresAt` are expired by query, not by stored status — no S3
+// expiry event ever fires for standard-tier fast-path rows.
+
+const db: Connection = createDb(process.env.DATABASE_URL!);
+
+const HOUR_MS = 60 * 60 * 1000;
+const past = () => new Date(Date.now() - HOUR_MS);
+const future = () => new Date(Date.now() + HOUR_MS);
+
+let userId: string;
+
+beforeAll(async () => {
+    const user = await insertUser(db);
+    userId = user.id;
+});
+
+afterAll(async () => {
+    await deleteUserData(db, userId);
+});
+
+describe('active-retrieval expiry predicate', () => {
+    it('a lapsed ready retrieval no longer blocks a fresh request', async () => {
+        const file = await insertFile(db, { userId, storageTier: 'standard' });
+        const lapsed = await insertRetrieval(db, {
+            userId,
+            fileId: file.id,
+            status: 'ready',
+            readyAt: past(),
+            expiresAt: past(),
+        });
+
+        const retrieval = await retrievalService.requestRetrieval(
+            db,
+            userId,
+            file.id
+        );
+
+        // Fresh row, ready immediately via the standard-tier fast path
+        expect(retrieval.id).not.toBe(lapsed.id);
+        expect(retrieval.status).toBe('ready');
+        expect(retrieval.expiresAt!.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('getDownloadUrl rejects a lapsed ready retrieval', async () => {
+        const file = await insertFile(db, { userId, storageTier: 'standard' });
+        await insertRetrieval(db, {
+            userId,
+            fileId: file.id,
+            status: 'ready',
+            readyAt: past(),
+            expiresAt: past(),
+        });
+
+        await expect(
+            retrievalService.getDownloadUrl(db, userId, file.id)
+        ).rejects.toThrow(InvalidStateError);
+    });
+
+    it('active queries exclude lapsed rows but keep unexpired, event-less, and in-flight ones', async () => {
+        const repo = createRetrievalRepo(db);
+        const [lapsedFile, unexpiredFile, noExpiryFile, pendingFile] =
+            await Promise.all([
+                insertFile(db, { userId }),
+                insertFile(db, { userId }),
+                insertFile(db, { userId }),
+                insertFile(db, { userId }),
+            ]);
+
+        await insertRetrieval(db, {
+            userId,
+            fileId: lapsedFile.id,
+            status: 'ready',
+            expiresAt: past(),
+        });
+        const unexpired = await insertRetrieval(db, {
+            userId,
+            fileId: unexpiredFile.id,
+            status: 'ready',
+            expiresAt: future(),
+        });
+        // No expiresAt (e.g. a malformed restore-completed event): treated as
+        // still active — better a stale entry than a download cut off early.
+        const noExpiry = await insertRetrieval(db, {
+            userId,
+            fileId: noExpiryFile.id,
+            status: 'ready',
+            expiresAt: null,
+        });
+        const pending = await insertRetrieval(db, {
+            userId,
+            fileId: pendingFile.id,
+            status: 'pending',
+        });
+
+        const fileIds = [
+            lapsedFile.id,
+            unexpiredFile.id,
+            noExpiryFile.id,
+            pendingFile.id,
+        ];
+        const byFileIds = await repo.findByFileIds(fileIds);
+        expect(new Set(byFileIds.map((r) => r.id))).toEqual(
+            new Set([unexpired.id, noExpiry.id, pending.id])
+        );
+
+        expect(await repo.findByFileId(lapsedFile.id)).toBeUndefined();
+
+        const active = await repo.findActiveByUserWithFiles(userId);
+        const activeForTheseFiles = active.filter((r) =>
+            fileIds.includes(r.fileId)
+        );
+        expect(new Set(activeForTheseFiles.map((r) => r.id))).toEqual(
+            new Set([unexpired.id, noExpiry.id, pending.id])
+        );
+    });
+});

--- a/apps/web/server/services/retrieval.test.ts
+++ b/apps/web/server/services/retrieval.test.ts
@@ -98,8 +98,34 @@ describe('retrieval service', () => {
             ).rejects.toThrow(NotFoundError);
         });
 
-        it('throws InvalidStateError when file is not in Glacier tier', async () => {
+        it('marks standard-tier file ready immediately without calling RestoreObject', async () => {
+            const restoreManySpy = vi.spyOn(mockS3.glacier, 'restoreMany');
             const file = createFileFixture({ storageTier: 'standard' });
+            const retrieval = createRetrievalFixture({ status: 'ready' });
+
+            mocks.files.findMany.mockResolvedValue([file]);
+            mocks.retrievals.findMany.mockResolvedValue([]);
+            mocks.returning.mockResolvedValue([retrieval]);
+
+            const result = await retrievalService.requestRetrieval(
+                db,
+                TEST_USER_ID,
+                TEST_FILE_ID
+            );
+
+            expect(result).toEqual(retrieval);
+            expect(restoreManySpy).not.toHaveBeenCalled();
+            expect(mocks.values).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    status: 'ready',
+                    readyAt: expect.any(Date),
+                    expiresAt: expect.any(Date),
+                }),
+            ]);
+        });
+
+        it('throws InvalidStateError when file is not available', async () => {
+            const file = createFileFixture({ status: 'uploading' });
 
             mocks.files.findMany.mockResolvedValue([file]);
             mocks.retrievals.findMany.mockResolvedValue([]);
@@ -196,7 +222,61 @@ describe('retrieval service', () => {
             ).rejects.toThrow(NotFoundError);
         });
 
-        it('throws InvalidStateError when any file is not in Glacier tier', async () => {
+        it('restores only archived files in a mixed-tier request; standard files are ready immediately', async () => {
+            const restoreManySpy = vi.spyOn(mockS3.glacier, 'restoreMany');
+            const files = [
+                createFileFixture({
+                    id: 'file1',
+                    s3Key: 'user/file1',
+                    storageTier: 'glacier',
+                }),
+                createFileFixture({
+                    id: 'file2',
+                    s3Key: 'user/file2',
+                    storageTier: 'standard',
+                }),
+            ];
+            const newRetrievals = [
+                createRetrievalFixture({ id: 'r1', fileId: 'file1' }),
+                createRetrievalFixture({
+                    id: 'r2',
+                    fileId: 'file2',
+                    status: 'ready',
+                }),
+            ];
+
+            mocks.files.findMany.mockResolvedValue(files);
+            mocks.retrievals.findMany.mockResolvedValue([]);
+            mocks.returning.mockResolvedValue(newRetrievals);
+
+            const result = await retrievalService.requestBulkRetrieval(
+                db,
+                TEST_USER_ID,
+                ['file1', 'file2'],
+                'standard'
+            );
+
+            expect(result).toHaveLength(2);
+            expect(restoreManySpy).toHaveBeenCalledExactlyOnceWith(
+                ['user/file1'],
+                'standard',
+                expect.any(Number)
+            );
+            expect(mocks.values).toHaveBeenCalledWith([
+                expect.objectContaining({
+                    fileId: 'file1',
+                    status: 'pending',
+                }),
+                expect.objectContaining({
+                    fileId: 'file2',
+                    status: 'ready',
+                    readyAt: expect.any(Date),
+                    expiresAt: expect.any(Date),
+                }),
+            ]);
+        });
+
+        it('throws InvalidStateError when any file is not available', async () => {
             const files = [
                 createFileFixture({
                     id: 'file1',
@@ -204,7 +284,7 @@ describe('retrieval service', () => {
                 }),
                 createFileFixture({
                     id: 'file2',
-                    storageTier: 'standard',
+                    status: 'deleted',
                 }),
             ];
 
@@ -321,23 +401,166 @@ describe('retrieval service', () => {
             ).rejects.toThrow(InvalidStateError);
         });
 
-        it('throws InvalidStateError when any file is not in a Glacier tier', async () => {
+        it('marks an all-standard batch ready immediately without calling RestoreObject', async () => {
+            const restoreManySpy = vi.spyOn(mockS3.glacier, 'restoreMany');
             const batch = createUploadBatchFixture();
             const files = [
-                createFileFixture({ id: 'f1', storageTier: 'glacier' }),
-                createFileFixture({ id: 'f2', storageTier: 'standard' }),
+                createFileFixture({
+                    id: 'f1',
+                    batchId: batch.id,
+                    storageTier: 'standard',
+                }),
+                createFileFixture({
+                    id: 'f2',
+                    batchId: batch.id,
+                    storageTier: 'standard',
+                }),
             ];
+            const newRetrievals = [
+                createRetrievalFixture({
+                    id: 'r1',
+                    fileId: 'f1',
+                    batchId: batch.id,
+                    status: 'ready',
+                }),
+                createRetrievalFixture({
+                    id: 'r2',
+                    fileId: 'f2',
+                    batchId: batch.id,
+                    status: 'ready',
+                }),
+            ];
+
+            mocks.uploadBatches.findFirst.mockResolvedValue(batch);
+            mocks.files.findMany.mockResolvedValue(files);
+            mocks.retrievals.findMany.mockResolvedValue([]);
+            mocks.returning.mockResolvedValue(newRetrievals);
+
+            const result = await retrievalService.requestBatchRetrieval(
+                db,
+                TEST_USER_ID,
+                batch.id
+            );
+
+            expect(result).toHaveLength(2);
+            expect(restoreManySpy).not.toHaveBeenCalled();
+            expect(mocks.values).toHaveBeenCalledWith([
+                expect.objectContaining({ fileId: 'f1', status: 'ready' }),
+                expect.objectContaining({ fileId: 'f2', status: 'ready' }),
+            ]);
+        });
+    });
+
+    describe('getBatchRetrievalStatus', () => {
+        it('is not ready while any file in the batch is still restoring', async () => {
+            const batch = createUploadBatchFixture();
+            const files = [
+                createFileFixture({ id: 'f1', batchId: batch.id }),
+                createFileFixture({ id: 'f2', batchId: batch.id }),
+            ];
+            const retrievals = [
+                createRetrievalFixture({
+                    id: 'r1',
+                    fileId: 'f1',
+                    batchId: batch.id,
+                    status: 'ready',
+                }),
+                createRetrievalFixture({
+                    id: 'r2',
+                    fileId: 'f2',
+                    batchId: batch.id,
+                    status: 'in_progress',
+                }),
+            ];
+
+            mocks.uploadBatches.findFirst.mockResolvedValue(batch);
+            mocks.files.findMany.mockResolvedValue(files);
+            mocks.retrievals.findMany.mockResolvedValue(retrievals);
+
+            const result = await retrievalService.getBatchRetrievalStatus(
+                db,
+                TEST_USER_ID,
+                batch.id
+            );
+
+            expect(result).toEqual({
+                totalFiles: 2,
+                readyFiles: 1,
+                isReady: false,
+            });
+        });
+
+        it('is ready when every file in the batch has a ready retrieval', async () => {
+            const batch = createUploadBatchFixture();
+            const files = [
+                createFileFixture({ id: 'f1', batchId: batch.id }),
+                createFileFixture({ id: 'f2', batchId: batch.id }),
+            ];
+            // f1 was retrieved individually before the batch request — its
+            // row has no batchId but must still count toward readiness.
+            const retrievals = [
+                createRetrievalFixture({
+                    id: 'r1',
+                    fileId: 'f1',
+                    batchId: null,
+                    status: 'ready',
+                }),
+                createRetrievalFixture({
+                    id: 'r2',
+                    fileId: 'f2',
+                    batchId: batch.id,
+                    status: 'ready',
+                }),
+            ];
+
+            mocks.uploadBatches.findFirst.mockResolvedValue(batch);
+            mocks.files.findMany.mockResolvedValue(files);
+            mocks.retrievals.findMany.mockResolvedValue(retrievals);
+
+            const result = await retrievalService.getBatchRetrievalStatus(
+                db,
+                TEST_USER_ID,
+                batch.id
+            );
+
+            expect(result).toEqual({
+                totalFiles: 2,
+                readyFiles: 2,
+                isReady: true,
+            });
+        });
+
+        it('is not ready when no retrievals were requested', async () => {
+            const batch = createUploadBatchFixture();
+            const files = [createFileFixture({ id: 'f1', batchId: batch.id })];
+
             mocks.uploadBatches.findFirst.mockResolvedValue(batch);
             mocks.files.findMany.mockResolvedValue(files);
             mocks.retrievals.findMany.mockResolvedValue([]);
 
+            const result = await retrievalService.getBatchRetrievalStatus(
+                db,
+                TEST_USER_ID,
+                batch.id
+            );
+
+            expect(result).toEqual({
+                totalFiles: 1,
+                readyFiles: 0,
+                isReady: false,
+            });
+        });
+
+        it('throws NotFoundError when batch missing or not owned', async () => {
+            mocks.uploadBatches.findFirst.mockResolvedValue(undefined);
+
             await expect(
-                retrievalService.requestBatchRetrieval(
+                retrievalService.getBatchRetrievalStatus(
                     db,
                     TEST_USER_ID,
-                    batch.id
+                    TEST_BATCH_ID
                 )
-            ).rejects.toThrow(InvalidStateError);
+            ).rejects.toThrow(NotFoundError);
         });
     });
 

--- a/apps/web/server/services/retrieval.ts
+++ b/apps/web/server/services/retrieval.ts
@@ -4,12 +4,12 @@ import { createRetrievalRepo, type Retrieval } from '@nexus/db/repo/retrievals';
 import { createUploadBatchRepo } from '@nexus/db/repo/uploadBatches';
 import { NotFoundError, InvalidStateError } from '@/server/errors';
 import { s3 } from '@/lib/storage';
+// Value import from ./types (not the package root) so unit tests that mock
+// '@/lib/storage' don't erase the constant.
+import { DEFAULT_RESTORE_DAYS_TO_KEEP } from '@/lib/storage/types';
 import type { RestoreTier } from '@/lib/storage';
 
 const DOWNLOAD_URL_EXPIRY_SECONDS = 3600; // 1 hour
-
-// Only objects stored in Glacier-class tiers can be restored
-const GLACIER_TIERS: File['storageTier'][] = ['glacier', 'deep_archive'];
 
 // `batchId` is stamped on every new row so batch-level progress can be
 // queried later; bulk callers pass null.
@@ -27,38 +27,69 @@ async function restoreFiles(
     const existingFileIds = new Set(existingRetrievals.map((r) => r.fileId));
     const filesToRestore = files.filter((f) => !existingFileIds.has(f.id));
 
-    const nonGlacierFile = filesToRestore.find(
-        (f) => !GLACIER_TIERS.includes(f.storageTier)
+    const unavailableFile = filesToRestore.find(
+        (f) => f.status !== 'available'
     );
-    if (nonGlacierFile) {
+    if (unavailableFile) {
         throw new InvalidStateError(
-            `File is not in a Glacier storage tier (current: ${nonGlacierFile.storageTier})`
+            `File is not available for retrieval (current status: ${unavailableFile.status})`
         );
     }
 
-    if (filesToRestore.length > 0) {
+    if (filesToRestore.length === 0) {
+        return existingRetrievals;
+    }
+
+    // Standard-class objects are downloadable as-is — RestoreObject would
+    // fail with InvalidObjectState — so they skip S3 and become ready
+    // immediately, entering the same download-window state as completed
+    // Deep Archive restores.
+    const archivedFiles = filesToRestore.filter(
+        (f) => f.storageTier !== 'standard'
+    );
+    const standardFiles = filesToRestore.filter(
+        (f) => f.storageTier === 'standard'
+    );
+
+    if (archivedFiles.length > 0) {
         await s3.glacier.restoreMany(
-            filesToRestore.map((f) => f.s3Key),
-            tier
+            archivedFiles.map((f) => f.s3Key),
+            tier,
+            DEFAULT_RESTORE_DAYS_TO_KEEP
         );
-
-        const now = new Date();
-        const newRetrievals = await retrievalRepo.insertMany(
-            filesToRestore.map((f) => ({
-                id: crypto.randomUUID(),
-                fileId: f.id,
-                userId,
-                batchId,
-                tier,
-                status: 'pending' as const,
-                initiatedAt: now,
-            }))
-        );
-
-        return [...existingRetrievals, ...newRetrievals];
     }
 
-    return existingRetrievals;
+    // Standard items get a synthetic window the same length as the real S3
+    // restore window, so both tiers present the same ready/expiry state. It
+    // is a UI concept for them — no S3 expiry event will ever fire.
+    const now = new Date();
+    const readyWindowEnd = new Date(
+        now.getTime() + DEFAULT_RESTORE_DAYS_TO_KEEP * 24 * 60 * 60 * 1000
+    );
+    const newRetrievals = await retrievalRepo.insertMany([
+        ...archivedFiles.map((f) => ({
+            id: crypto.randomUUID(),
+            fileId: f.id,
+            userId,
+            batchId,
+            tier,
+            status: 'pending' as const,
+            initiatedAt: now,
+        })),
+        ...standardFiles.map((f) => ({
+            id: crypto.randomUUID(),
+            fileId: f.id,
+            userId,
+            batchId,
+            tier,
+            status: 'ready' as const,
+            initiatedAt: now,
+            readyAt: now,
+            expiresAt: readyWindowEnd,
+        })),
+    ]);
+
+    return [...existingRetrievals, ...newRetrievals];
 }
 
 async function requestRetrieval(
@@ -89,12 +120,11 @@ async function requestBulkRetrieval(
     return restoreFiles(db, userId, files, tier, null);
 }
 
-async function requestBatchRetrieval(
+async function findOwnedBatchFiles(
     db: DB,
     userId: string,
-    batchId: string,
-    tier: RestoreTier = 'standard'
-): Promise<Retrieval[]> {
+    batchId: string
+): Promise<File[]> {
     const batchRepo = createUploadBatchRepo(db);
     const batch = await batchRepo.findByUserAndId(userId, batchId);
     if (!batch) {
@@ -102,12 +132,56 @@ async function requestBatchRetrieval(
     }
 
     const fileRepo = createFileRepo(db);
-    const files = await fileRepo.findByUserAndBatch(userId, batchId);
+    return fileRepo.findByUserAndBatch(userId, batchId);
+}
+
+async function requestBatchRetrieval(
+    db: DB,
+    userId: string,
+    batchId: string,
+    tier: RestoreTier = 'standard'
+): Promise<Retrieval[]> {
+    const files = await findOwnedBatchFiles(db, userId, batchId);
     if (files.length === 0) {
         throw new InvalidStateError('Batch contains no files');
     }
 
     return restoreFiles(db, userId, files, tier, batchId);
+}
+
+export interface BatchRetrievalStatus {
+    totalFiles: number;
+    readyFiles: number;
+    isReady: boolean;
+}
+
+// A batch is ready only when every file in it has a ready retrieval —
+// all-or-nothing, paced by the slowest item. Readiness is computed over the
+// batch's files rather than batch-stamped retrieval rows: a file retrieved
+// individually before the batch request keeps its existing row (batchId
+// null), and it must still count.
+async function getBatchRetrievalStatus(
+    db: DB,
+    userId: string,
+    batchId: string
+): Promise<BatchRetrievalStatus> {
+    const files = await findOwnedBatchFiles(db, userId, batchId);
+
+    const retrievalRepo = createRetrievalRepo(db);
+    const retrievals = await retrievalRepo.findByFileIds(
+        files.map((f) => f.id)
+    );
+    const readyFileIds = new Set(
+        retrievals.filter((r) => r.status === 'ready').map((r) => r.fileId)
+    );
+
+    const readyFiles = files.filter((f) => readyFileIds.has(f.id)).length;
+
+    return {
+        totalFiles: files.length,
+        readyFiles,
+        isReady: files.length > 0 && readyFiles === files.length,
+    };
 }
 
 interface DownloadUrlResult {
@@ -147,5 +221,6 @@ export const retrievalService = {
     requestRetrieval,
     requestBulkRetrieval,
     requestBatchRetrieval,
+    getBatchRetrievalStatus,
     getDownloadUrl,
 } as const;

--- a/apps/web/server/services/s3-restore.ts
+++ b/apps/web/server/services/s3-restore.ts
@@ -35,7 +35,9 @@ async function resolveRetrieval(
         return null;
     }
 
-    const retrieval = await retrievalRepo.findByFileId(file.id);
+    // Unfiltered lookup: the expiry event arrives at/after `expiresAt`, when
+    // the active-filtered queries no longer see the row.
+    const retrieval = await retrievalRepo.findLatestByFileId(file.id);
     if (!retrieval) {
         log.warn(
             { fileId: file.id, s3Key },

--- a/apps/web/server/trpc/routers/retrievals.ts
+++ b/apps/web/server/trpc/routers/retrievals.ts
@@ -1,4 +1,6 @@
+import { z } from 'zod';
 import { createRetrievalRepo } from '@nexus/db/repo/retrievals';
+import { retrievalService } from '@/server/services/retrieval';
 import { protectedProcedure, router } from '../init';
 
 export const retrievalsRouter = router({
@@ -11,4 +13,14 @@ export const retrievalsRouter = router({
         const retrievalRepo = createRetrievalRepo(ctx.db);
         return retrievalRepo.findActiveByUserWithFiles(ctx.session.user.id);
     }),
+
+    batchStatus: protectedProcedure
+        .input(z.object({ batchId: z.string().uuid() }))
+        .query(({ ctx, input }) =>
+            retrievalService.getBatchRetrievalStatus(
+                ctx.db,
+                ctx.session.user.id,
+                input.batchId
+            )
+        ),
 });

--- a/packages/db/src/repositories/retrievals.ts
+++ b/packages/db/src/repositories/retrievals.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, or, inArray, isNull, gt, desc } from 'drizzle-orm';
 import type { DB } from '../connection';
 import * as schema from '../schema';
 import { createRepository } from './create';
@@ -6,18 +6,29 @@ import { createRepository } from './create';
 export type Retrieval = typeof schema.retrievals.$inferSelect;
 export type NewRetrieval = typeof schema.retrievals.$inferInsert;
 
-// 'ready' included because the restored copy is still available for download
-const ACTIVE_STATUSES: Retrieval['status'][] = [
-    'pending',
-    'in_progress',
-    'ready',
-];
+// A retrieval is active while it's queued, restoring, or ready with an
+// unexpired download window. `ready` rows past `expiresAt` are expired by
+// predicate rather than by stored status: standard-tier fast-path rows never
+// get an S3 expiry event, and Deep Archive rows can miss theirs. A lapsed row
+// no longer blocks a fresh retrieval of the same file.
+function activeRetrievalFilter() {
+    return or(
+        inArray(schema.retrievals.status, ['pending', 'in_progress']),
+        and(
+            eq(schema.retrievals.status, 'ready'),
+            or(
+                isNull(schema.retrievals.expiresAt),
+                gt(schema.retrievals.expiresAt, new Date())
+            )
+        )
+    );
+}
 
 function findByFileId(db: DB, fileId: string): Promise<Retrieval | undefined> {
     return db.query.retrievals.findFirst({
         where: and(
             eq(schema.retrievals.fileId, fileId),
-            inArray(schema.retrievals.status, ACTIVE_STATUSES)
+            activeRetrievalFilter()
         ),
     });
 }
@@ -27,8 +38,21 @@ function findByFileIds(db: DB, fileIds: string[]): Promise<Retrieval[]> {
     return db.query.retrievals.findMany({
         where: and(
             inArray(schema.retrievals.fileId, fileIds),
-            inArray(schema.retrievals.status, ACTIVE_STATUSES)
+            activeRetrievalFilter()
         ),
+    });
+}
+
+// Unfiltered lookup for S3 webhook resolution: the ObjectRestore:Delete
+// event arrives at/after `expiresAt`, when the row is already invisible to
+// the active-filtered queries — it must still be found to record `expired`.
+function findLatestByFileId(
+    db: DB,
+    fileId: string
+): Promise<Retrieval | undefined> {
+    return db.query.retrievals.findFirst({
+        where: eq(schema.retrievals.fileId, fileId),
+        orderBy: desc(schema.retrievals.createdAt),
     });
 }
 
@@ -71,10 +95,7 @@ async function findActiveByUserWithFiles(
         .from(schema.retrievals)
         .innerJoin(schema.files, eq(schema.retrievals.fileId, schema.files.id))
         .where(
-            and(
-                eq(schema.retrievals.userId, userId),
-                inArray(schema.retrievals.status, ACTIVE_STATUSES)
-            )
+            and(eq(schema.retrievals.userId, userId), activeRetrievalFilter())
         )
         .orderBy(schema.retrievals.createdAt);
 
@@ -116,6 +137,7 @@ async function updateStatus(
 export const createRetrievalRepo = createRepository({
     findByFileId,
     findByFileIds,
+    findLatestByFileId,
     findByUser,
     findActiveByUserWithFiles,
     insert,


### PR DESCRIPTION
## Summary

The retrieval service trusted the DB tier and called `RestoreObject` on everything it considered archived, which fails with S3 `InvalidObjectState` for STANDARD-class objects. Standard-tier items now skip S3 entirely and are marked ready at request time, entering the same download-window state as completed Deep Archive restores — including real expiry: `ready` rows past `expiresAt` are treated as expired by query predicate, so the tier difference stays invisible. Batch readiness is all-or-nothing via a new `retrievals.batchStatus` query. Prep for #255 — inert until that issue starts inserting `standard` rows.

Closes #257

## Changes

- `restoreFiles` splits requests by storage tier: archived files go through `s3.glacier.restoreMany` as before; standard files are inserted directly as `ready` with `readyAt` and a synthetic 7-day `expiresAt` (same window as the DA restore default)
- Active-retrieval queries (`findByFileId`, `findByFileIds`, `findActiveByUserWithFiles`) expire `ready` rows past `expiresAt` by predicate — no S3 event or cron needed. A lapsed window stops blocking a fresh retrieval (standard files re-ready instantly) and stops allowing downloads. Also covers DA rows whose `ObjectRestore:Delete` event never arrives
- Webhook resolution switches to an unfiltered `findLatestByFileId`: the expiry event arrives at/after `expiresAt`, when the row is already invisible to the active-filtered queries, but must still be found to record `expired`
- The old glacier-tier guard (which rejected standard files) is replaced by a `file.status !== 'available'` guard — uploading/deleted files are the genuinely invalid states
- New `retrievalService.getBatchRetrievalStatus` + `retrievals.batchStatus` tRPC query. Readiness is computed over the batch's files (not batch-stamped retrieval rows), so a file retrieved individually before the batch request (null `batchId`) still counts
- `DEFAULT_RESTORE_DAYS_TO_KEEP` shared constant in `lib/storage/types.ts` replaces the duplicated `7` in `glacier.ts` defaults and the synthetic window
- Tests: unit (fast path, mixed bulk, all-standard batch, batch ready-when-slowest, unavailable-status rejection) + integration (`retrieval.integration.test.ts`: lapsed row doesn't block re-retrieval, lapsed download rejected, active queries exclude lapsed / keep unexpired, event-less, and in-flight rows)

## Test Plan

- [x] `pnpm check` (lint + build + unit tests)
- [x] `pnpm -F web test:integration` — new predicate tests + existing s3-restore webhook tests pass against dev DB
- [x] Manual (dev, real S3): flipped `brave_910H5N0oxa.jpg` (49KB, confirmed STANDARD via HeadObject) to `standard`, retrieved through the real service — ready in 623ms with 7-day window, presigned download returned HTTP 200 with exact byte count, no `InvalidObjectState`

Note: `lib/jobs/publish.integration.test.ts` fails intermittently — pre-existing race unrelated to this PR (it publishes to the live dev SQS queue and the real worker marks the job `failed` for the nonexistent test user before the assertion re-reads it). Worth its own issue.