### PR TITLE
fix: stop publish integration test racing the live dev worker (#262)

### DIFF
--- a/apps/web/lib/jobs/publish.integration.test.ts
+++ b/apps/web/lib/jobs/publish.integration.test.ts
@@ -31,7 +31,12 @@ describe('jobs.publish() integration', () => {
             where: eq(backgroundJobs.id, job.id),
         });
 
+        // Only assert on what publish() owns: the row exists with the inserted
+        // fields. The live dev worker may have already consumed the message and
+        // transitioned status, so re-asserting 'pending' here races it (#262);
+        // the returned row above already proves the insert used 'pending'.
         expect(found).toBeDefined();
-        expect(found!.status).toBe('pending');
+        expect(found!.type).toBe('delete-account');
+        expect(found!.payload).toEqual({ userId: 'integration-test-user' });
     });
 });

--- a/docs/guides/background-jobs.md
+++ b/docs/guides/background-jobs.md
@@ -313,7 +313,7 @@ pnpm -F web test:integration
 - Asserts that a `background_jobs` record is created with status `pending` and that the SQS publish resolves without error
 - Cleans up test DB records in `afterAll`
 
-> **Note:** The dev Lambda event source mapping is active, so test messages will be consumed by the real worker. Since the test only asserts on the publish side, this doesn't affect test correctness.
+> **Note:** The dev Lambda event source mapping is active, so test messages will be consumed by the real worker, which may transition the job's status (e.g. to `failed`) at any point after publish. The test therefore asserts only on publish-owned state — the returned row and the inserted fields — never on `status` re-read from the DB (#262).
 
 ## Related
 


### PR DESCRIPTION
## Summary

`publish.integration.test.ts` re-read the job row and asserted `status === 'pending'`, but the live dev Lambda consumes the message and (via the unimplemented `delete-account` stub) marks the job `failed` — sometimes before the re-read. The test now asserts only on state `publish()` owns: the returned row (which proves the insert used `pending`) and the persisted immutable fields (`type`, `payload`) on the re-read. Doc note in `background-jobs.md` updated to match; it previously claimed the live consumer "doesn't affect test correctness".

Closes #262

## Changes

- Replace the racy `status` re-read assertion with `type`/`payload` assertions, with a comment explaining why
- Correct the integration-test note in `docs/guides/background-jobs.md`

## Side effect (not fixed here)

Each test run still leaves a message that fails 3 retries into the dev DLQ (handler is a stub). Tracked in #263.

## Test Plan

- [x] `pnpm -F web test:integration` — 4 consecutive runs, all green (worker warm from run 2 on, the condition that previously flaked)
- [x] `pnpm check`