### PR TITLE
fix: make storageTier truthful — insert standard, flip on lifecycle event, backfill (#258)

### DIFF
--- a/apps/web/app/api/webhooks/s3-restore/route.integration.test.ts
+++ b/apps/web/app/api/webhooks/s3-restore/route.integration.test.ts
@@ -22,6 +22,9 @@ function createSnsNotification(
     s3Key: string,
     glacierEventData?: {
         restoreEventData: { lifecycleRestorationExpiryTime: string };
+    },
+    lifecycleEventData?: {
+        transitionEventData: { destinationStorageClass: string };
     }
 ) {
     const record: Record<string, unknown> = {
@@ -34,6 +37,10 @@ function createSnsNotification(
 
     if (glacierEventData) {
         record.glacierEventData = glacierEventData;
+    }
+
+    if (lifecycleEventData) {
+        record.lifecycleEventData = lifecycleEventData;
     }
 
     return {
@@ -315,6 +322,67 @@ describe('POST /api/webhooks/s3-restore', () => {
         // Verify webhook event was marked as processed
         expect(webhookRecord).toBeDefined();
         expect(webhookRecord!.status).toBe('processed');
+    });
+
+    it('flips the file storage tier on LifecycleTransition', async () => {
+        const messageId = `lifecycle-test-${crypto.randomUUID()}`;
+        const s3Key = `${testUserId}/${testFileId}/test-document.pdf`;
+
+        // Seeded as 'glacier'; the transition event should flip it
+        await db
+            .update(files)
+            .set({ storageTier: 'glacier' })
+            .where(eq(files.id, testFileId));
+
+        const body = createSnsNotification(
+            messageId,
+            's3:LifecycleTransition',
+            s3Key,
+            undefined,
+            { transitionEventData: { destinationStorageClass: 'DEEP_ARCHIVE' } }
+        );
+
+        const res = await postWebhook(body);
+        expect(res.status).toBe(200);
+
+        // Track for cleanup
+        const webhookRecord = await db.query.webhookEvents.findFirst({
+            where: and(
+                eq(webhookEvents.source, 'sns'),
+                eq(webhookEvents.externalId, messageId)
+            ),
+        });
+        if (webhookRecord) createdWebhookEventIds.push(webhookRecord.id);
+
+        const file = await db.query.files.findFirst({
+            where: eq(files.id, testFileId),
+        });
+
+        expect(file).toBeDefined();
+        expect(file!.storageTier).toBe('deep_archive');
+
+        expect(webhookRecord).toBeDefined();
+        expect(webhookRecord!.status).toBe('processed');
+    });
+
+    it('inserts files rows with a standard storage tier by default', async () => {
+        const fileId = `test-file-default-${crypto.randomUUID()}`;
+        await db.insert(files).values({
+            id: fileId,
+            userId: testUserId,
+            name: 'default-tier.pdf',
+            size: 2048,
+            s3Key: `${testUserId}/${fileId}/default-tier.pdf`,
+        });
+
+        try {
+            const file = await db.query.files.findFirst({
+                where: eq(files.id, fileId),
+            });
+            expect(file!.storageTier).toBe('standard');
+        } finally {
+            await db.delete(files).where(eq(files.id, fileId));
+        }
     });
 
     it('handles unknown event types gracefully', async () => {

--- a/apps/web/lib/sns/types.ts
+++ b/apps/web/lib/sns/types.ts
@@ -36,6 +36,12 @@ export interface S3EventRecord {
             lifecycleRestorationExpiryTime: string;
         };
     };
+    // Present on s3:LifecycleTransition events
+    lifecycleEventData?: {
+        transitionEventData: {
+            destinationStorageClass: string;
+        };
+    };
 }
 
 export interface S3EventNotification {

--- a/apps/web/lib/storage/objects.ts
+++ b/apps/web/lib/storage/objects.ts
@@ -1,4 +1,4 @@
-import { DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { DeleteObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { client, bucket } from './client';
 
 /**
@@ -9,4 +9,39 @@ import { client, bucket } from './client';
 export async function remove(key: string): Promise<void> {
     const command = new DeleteObjectCommand({ Bucket: bucket, Key: key });
     await client.send(command);
+}
+
+export interface ObjectSummary {
+    key: string;
+    size?: number;
+    storageClass?: string;
+}
+
+/**
+ * List every object in the bucket with its storage class, paging through
+ * results (S3 caps a single response at 1000 keys)
+ */
+export async function listAll(): Promise<ObjectSummary[]> {
+    const objects: ObjectSummary[] = [];
+    let continuationToken: string | undefined;
+
+    do {
+        const response = await client.send(
+            new ListObjectsV2Command({
+                Bucket: bucket,
+                ContinuationToken: continuationToken,
+            })
+        );
+        for (const object of response.Contents ?? []) {
+            if (!object.Key) continue;
+            objects.push({
+                key: object.Key,
+                size: object.Size,
+                storageClass: object.StorageClass,
+            });
+        }
+        continuationToken = response.NextContinuationToken;
+    } while (continuationToken);
+
+    return objects;
 }

--- a/apps/web/lib/storage/testing.ts
+++ b/apps/web/lib/storage/testing.ts
@@ -46,6 +46,9 @@ const glacierMocks = {
 
 const objectsMocks = {
     remove: async (): Promise<void> => {},
+    listAll: async (): Promise<
+        { key: string; size?: number; storageClass?: string }[]
+    > => [],
 };
 
 const multipartMocks = {

--- a/apps/web/lib/storage/types.ts
+++ b/apps/web/lib/storage/types.ts
@@ -1,6 +1,27 @@
 // Re-export from canonical source in @nexus/db
 export { RESTORE_TIERS, type RestoreTier } from '@nexus/db/schema';
 
+import type { storageTierEnum } from '@nexus/db/schema';
+
+export type StorageTier = (typeof storageTierEnum.enumValues)[number];
+
+/**
+ * Maps S3 StorageClass values (from event notifications and ListObjectsV2)
+ * to the files.storageTier enum. Classes Nexus never uses are intentionally
+ * unmapped — callers treat a miss as "log and skip", not an error.
+ */
+const S3_STORAGE_CLASS_TO_TIER: Record<string, StorageTier> = {
+    STANDARD: 'standard',
+    GLACIER: 'glacier',
+    DEEP_ARCHIVE: 'deep_archive',
+};
+
+export function resolveStorageTier(
+    storageClass: string | undefined
+): StorageTier | undefined {
+    return storageClass ? S3_STORAGE_CLASS_TO_TIER[storageClass] : undefined;
+}
+
 /**
  * Days a restored Glacier copy stays accessible. Also the length of the
  * synthetic download window for standard-tier retrievals, which skip S3

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,8 @@
         "e2e:coverage": "tsx scripts/e2e-coverage.ts",
         "test:integration": "vitest run --config vitest.integration.config.ts",
         "screenshots": "tsx scripts/screenshots.ts",
-        "backfill:trial-subscriptions": "tsx --env-file=.env.local scripts/backfill-trial-subscriptions.ts"
+        "backfill:trial-subscriptions": "tsx --env-file=.env.local scripts/backfill-trial-subscriptions.ts",
+        "backfill:storage-tier": "tsx --env-file=.env.local scripts/backfill-storage-tier.ts"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.975.0",

--- a/apps/web/scripts/backfill-storage-tier.ts
+++ b/apps/web/scripts/backfill-storage-tier.ts
@@ -1,0 +1,131 @@
+/**
+ * Reconcile files.storageTier with the real S3 StorageClass of each object.
+ *
+ * Rows written before #258 were inserted with the old 'glacier' default and
+ * never updated, so the column diverged from reality in both directions:
+ * sub-128KB objects stay STANDARD forever (the lifecycle rule skips them),
+ * and everything else actually sits in DEEP_ARCHIVE. This lists the bucket
+ * once and updates every row whose tier disagrees with S3.
+ *
+ * Idempotent: a re-run after a clean apply finds no mismatches.
+ *
+ * Usage:
+ *   pnpm -F web backfill:storage-tier          # dry run (default)
+ *   pnpm -F web backfill:storage-tier --apply  # actually update rows
+ */
+
+import { ne } from 'drizzle-orm';
+
+import { db } from '@/server/db';
+import { s3 } from '@/lib/storage';
+import { resolveStorageTier, type StorageTier } from '@/lib/storage/types';
+import { createFileRepo } from '@nexus/db/repo/files';
+import { files } from '@nexus/db/schema';
+
+async function main(): Promise<void> {
+    const shouldApply = process.argv.includes('--apply');
+
+    // Deleted rows keep their s3Key but the object is already removed —
+    // reconciling them would only report every one as missing.
+    const rows = await db
+        .select({
+            id: files.id,
+            s3Key: files.s3Key,
+            storageTier: files.storageTier,
+        })
+        .from(files)
+        .where(ne(files.status, 'deleted'));
+
+    const objects = await s3.objects.listAll();
+    const classByKey = new Map(objects.map((o) => [o.key, o.storageClass]));
+
+    const mismatches: {
+        id: string;
+        s3Key: string;
+        from: string;
+        to: StorageTier;
+    }[] = [];
+    let inSync = 0;
+    const missing: string[] = [];
+    const unmapped: { s3Key: string; storageClass: string | undefined }[] = [];
+
+    for (const row of rows) {
+        if (!classByKey.has(row.s3Key)) {
+            missing.push(row.s3Key);
+            continue;
+        }
+        const storageClass = classByKey.get(row.s3Key);
+        const tier = resolveStorageTier(storageClass);
+        if (!tier) {
+            unmapped.push({ s3Key: row.s3Key, storageClass });
+            continue;
+        }
+        if (tier === row.storageTier) {
+            inSync += 1;
+            continue;
+        }
+        mismatches.push({
+            id: row.id,
+            s3Key: row.s3Key,
+            from: row.storageTier,
+            to: tier,
+        });
+    }
+
+    const rowKeys = new Set(rows.map((r) => r.s3Key));
+    const orphans = objects.filter((o) => !rowKeys.has(o.key));
+
+    console.log(`DB rows checked:      ${rows.length}`);
+    console.log(`Already in sync:      ${inSync}`);
+    console.log(`Mismatched tiers:     ${mismatches.length}`);
+    console.log(`Missing in S3:        ${missing.length}`);
+    console.log(`Unmapped class:       ${unmapped.length}`);
+    console.log(`S3 objects w/o row:   ${orphans.length}`);
+
+    for (const m of mismatches) {
+        console.log(`  ~ ${m.s3Key}  ${m.from} -> ${m.to}`);
+    }
+    for (const key of missing) {
+        console.log(`  ? ${key}  (row has no S3 object)`);
+    }
+    for (const u of unmapped) {
+        console.log(`  ! ${u.s3Key}  (unmapped class: ${u.storageClass})`);
+    }
+
+    if (mismatches.length === 0) {
+        console.log('\nNothing to update.');
+        return;
+    }
+
+    if (!shouldApply) {
+        console.log('\nDry run (default). Re-run with --apply to update.');
+        return;
+    }
+
+    console.log('\nUpdating…');
+    const fileRepo = createFileRepo(db);
+    let ok = 0;
+    let failed = 0;
+    for (const m of mismatches) {
+        try {
+            await fileRepo.update(m.id, { storageTier: m.to });
+            console.log(`  ✓ ${m.s3Key}  ${m.from} -> ${m.to}`);
+            ok += 1;
+        } catch (err) {
+            console.error(`  ✗ ${m.s3Key} —`, err);
+            failed += 1;
+        }
+    }
+
+    console.log(`\nDone. ${ok} updated, ${failed} failed.`);
+    if (failed > 0) process.exitCode = 1;
+}
+
+main()
+    .catch((err) => {
+        console.error('Backfill aborted:', err);
+        process.exitCode = 1;
+    })
+    // The pooled connection keeps the event loop alive; close it so the
+    // script exits instead of hanging after the summary prints.
+    .finally(() => db.$client.end());

--- a/apps/web/server/services/s3-restore.test.ts
+++ b/apps/web/server/services/s3-restore.test.ts
@@ -123,6 +123,77 @@ describe('s3RestoreService.dispatch', () => {
         });
     });
 
+    describe('lifecycle transition', () => {
+        function makeTransitionRecord(
+            destinationStorageClass?: string
+        ): S3EventRecord {
+            return makeRecord({
+                eventName: 's3:LifecycleTransition',
+                glacierEventData: undefined,
+                lifecycleEventData: destinationStorageClass
+                    ? { transitionEventData: { destinationStorageClass } }
+                    : undefined,
+            });
+        }
+
+        it('flips the file storage tier to deep_archive', async () => {
+            const handled = await s3RestoreService.dispatch(
+                mockDb.db,
+                makeTransitionRecord('DEEP_ARCHIVE')
+            );
+
+            expect(handled).toBe(true);
+            expect(mockDb.mocks.set).toHaveBeenCalledWith({
+                storageTier: 'deep_archive',
+            });
+        });
+
+        it('logs and ignores events for unknown files', async () => {
+            mockDb.mocks.files.findFirst.mockResolvedValue(undefined);
+
+            const handled = await s3RestoreService.dispatch(
+                mockDb.db,
+                makeTransitionRecord('DEEP_ARCHIVE')
+            );
+
+            expect(handled).toBe(true);
+            expect(mockDb.mocks.set).not.toHaveBeenCalled();
+            expect(hoisted.logger.warn).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    s3Key: 'uploads/test-file.jpg',
+                }),
+                'Lifecycle transition for unknown file'
+            );
+        });
+
+        it('logs and skips unmapped destination storage classes', async () => {
+            const handled = await s3RestoreService.dispatch(
+                mockDb.db,
+                makeTransitionRecord('GLACIER_IR')
+            );
+
+            expect(handled).toBe(true);
+            expect(mockDb.mocks.set).not.toHaveBeenCalled();
+            expect(hoisted.logger.warn).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    fileId: TEST_FILE_ID,
+                    destinationStorageClass: 'GLACIER_IR',
+                }),
+                'Lifecycle transition to unmapped storage class'
+            );
+        });
+
+        it('logs and skips events with no transition data', async () => {
+            const handled = await s3RestoreService.dispatch(
+                mockDb.db,
+                makeTransitionRecord()
+            );
+
+            expect(handled).toBe(true);
+            expect(mockDb.mocks.set).not.toHaveBeenCalled();
+        });
+    });
+
     describe('non-completion events', () => {
         it('sends no email on restore expiry', async () => {
             const handled = await s3RestoreService.dispatch(

--- a/apps/web/server/services/s3-restore.ts
+++ b/apps/web/server/services/s3-restore.ts
@@ -5,6 +5,7 @@ import { env } from '@/lib/env';
 import { emailService } from '@/server/services/email';
 import { logger } from '@/server/lib/logger';
 import type { S3EventRecord } from '@/lib/sns/types';
+import { resolveStorageTier } from '@/lib/storage/types';
 
 const log = logger.child({ service: 's3-restore' });
 
@@ -13,6 +14,7 @@ type S3RestoreEventHandler = (db: DB, record: S3EventRecord) => Promise<void>;
 const handlers: Record<string, S3RestoreEventHandler> = {
     's3:ObjectRestore:Completed': handleRestoreCompleted,
     's3:ObjectRestore:Delete': handleRestoreExpired,
+    's3:LifecycleTransition': handleLifecycleTransition,
 };
 
 // S3 encodes spaces as `+` in event notification keys
@@ -131,6 +133,40 @@ async function handleRestoreExpired(
     log.info(
         { fileId: file.id, retrievalId: retrieval.id },
         'Retrieval marked as expired'
+    );
+}
+
+// Keeps files.storageTier truthful: uploads insert as 'standard' (the class
+// every upload lands in) and this flips the row when the bucket lifecycle
+// rule actually moves the object. Sub-128KB objects never transition, so
+// their rows stay 'standard' permanently — that's correct, not a miss.
+async function handleLifecycleTransition(
+    db: DB,
+    record: S3EventRecord
+): Promise<void> {
+    const fileRepo = createFileRepo(db);
+    const s3Key = decodeS3Key(record);
+    const file = await fileRepo.findByS3Key(s3Key);
+    if (!file) {
+        log.warn({ s3Key }, 'Lifecycle transition for unknown file');
+        return;
+    }
+
+    const destinationStorageClass =
+        record.lifecycleEventData?.transitionEventData?.destinationStorageClass;
+    const storageTier = resolveStorageTier(destinationStorageClass);
+    if (!storageTier) {
+        log.warn(
+            { fileId: file.id, s3Key, destinationStorageClass },
+            'Lifecycle transition to unmapped storage class'
+        );
+        return;
+    }
+
+    await fileRepo.update(file.id, { storageTier });
+    log.info(
+        { fileId: file.id, s3Key, storageTier },
+        'Storage tier updated from lifecycle transition'
     );
 }
 

--- a/docs/infra/aws-manual-setup.md
+++ b/docs/infra/aws-manual-setup.md
@@ -105,7 +105,7 @@ Add these to Vercel (Development environment):
 
 ## SNS Topic for S3 Restore Events
 
-Receives S3 Glacier restore lifecycle events (`s3:ObjectRestore:Post`, `s3:ObjectRestore:Completed`, `s3:ObjectRestore:Delete`) and delivers them to the webhook endpoint via HTTPS subscription.
+Receives S3 Glacier restore events (`s3:ObjectRestore:Post`, `s3:ObjectRestore:Completed`, `s3:ObjectRestore:Delete`) and lifecycle transition events (`s3:LifecycleTransition`, which keeps `files.storageTier` truthful when the lifecycle rule moves an object to Deep Archive) and delivers them to the webhook endpoint via HTTPS subscription.
 
 See [[../guides/webhooks|Webhook Handling]] for the webhook pattern and signature verification.
 
@@ -198,11 +198,16 @@ aws sns subscribe \
     --protocol https \
     --notification-endpoint "https://{domain}/api/webhooks/s3-restore" \
     --attributes "{
-        \"RawMessageDelivery\": \"true\",
         \"RedrivePolicy\": \"{\\\"deadLetterTargetArn\\\":\\\"$DLQ_ARN\\\"}\"
     }" \
     --region "$REGION"
 ```
+
+> **Do not enable `RawMessageDelivery`.** The webhook handler parses the full
+> SNS envelope (`Type`, `MessageId`, `Message`) and verifies its signature;
+> raw delivery strips the envelope and would break both. Dev subscribes
+> `https://nexus.thomasar.dev/api/webhooks/s3-restore` (provisioned
+> 2026-07-03).
 
 > **Note:** The endpoint must be deployed and respond to the SNS `SubscriptionConfirmation` request before the subscription becomes active. Replace `{domain}` with the actual Vercel deployment URL.
 
@@ -217,7 +222,8 @@ aws s3api put-bucket-notification-configuration \
             "Events": [
                 "s3:ObjectRestore:Post",
                 "s3:ObjectRestore:Completed",
-                "s3:ObjectRestore:Delete"
+                "s3:ObjectRestore:Delete",
+                "s3:LifecycleTransition"
             ]
         }]
     }'

--- a/packages/db/src/migrations/0013_past_mach_iv.sql
+++ b/packages/db/src/migrations/0013_past_mach_iv.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "files" ALTER COLUMN "storage_tier" SET DEFAULT 'standard';

--- a/packages/db/src/migrations/meta/0013_snapshot.json
+++ b/packages/db/src/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1543 @@
+{
+  "id": "1da516ea-dd58-45f3-a1b9-7eade906d167",
+  "prevId": "bb463d0a-8b8a-433e-a751-233722967db8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by_user_id": {
+          "name": "redeemed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_token_idx": {
+          "name": "invites_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_status_idx": {
+          "name": "invites_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_user_id_user_id_fk": {
+          "name": "invites_redeemed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "redeemed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.background_jobs": {
+      "name": "background_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "background_jobs_status_created_at_idx": {
+          "name": "background_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "storage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_user_id_idx": {
+          "name": "files_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_status_idx": {
+          "name": "files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_storage_tier_idx": {
+          "name": "files_storage_tier_idx",
+          "columns": [
+            {
+              "expression": "storage_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_batch_id_idx": {
+          "name": "files_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_user_id_created_at_idx": {
+          "name": "files_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_user_id_fk": {
+          "name": "files_user_id_user_id_fk",
+          "tableFrom": "files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_batch_id_upload_batches_id_fk": {
+          "name": "files_batch_id_upload_batches_id_fk",
+          "tableFrom": "files",
+          "tableTo": "upload_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_s3_key_unique": {
+          "name": "files_s3_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "s3_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrievals": {
+      "name": "retrievals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "retrieval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "retrieval_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retrievals_file_id_idx": {
+          "name": "retrievals_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_user_id_idx": {
+          "name": "retrievals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_status_idx": {
+          "name": "retrievals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_batch_id_idx": {
+          "name": "retrievals_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_expires_at_idx": {
+          "name": "retrievals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retrievals_file_id_files_id_fk": {
+          "name": "retrievals_file_id_files_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_user_id_user_id_fk": {
+          "name": "retrievals_user_id_user_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_batch_id_upload_batches_id_fk": {
+          "name": "retrievals_batch_id_upload_batches_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "upload_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_usage": {
+      "name": "storage_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_bytes": {
+          "name": "used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_usage_user_id_idx": {
+          "name": "storage_usage_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_usage_user_id_user_id_fk": {
+          "name": "storage_usage_user_id_user_id_fk",
+          "tableFrom": "storage_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_usage_user_id_unique": {
+          "name": "storage_usage_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_batches": {
+      "name": "upload_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upload_batches_user_id_idx": {
+          "name": "upload_batches_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_batches_user_id_user_id_fk": {
+          "name": "upload_batches_user_id_user_id_fk",
+          "tableFrom": "upload_batches",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "plan_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starter'"
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trialing'"
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_user_id_unique": {
+          "name": "subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "webhook_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_source_external_id_idx": {
+          "name": "webhook_events_source_external_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_status_created_at_idx": {
+          "name": "webhook_events_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "redeemed",
+        "revoked"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "available",
+        "restoring",
+        "deleted"
+      ]
+    },
+    "public.retrieval_status": {
+      "name": "retrieval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "ready",
+        "expired",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.retrieval_tier": {
+      "name": "retrieval_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "bulk",
+        "expedited"
+      ]
+    },
+    "public.storage_tier": {
+      "name": "storage_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "glacier",
+        "deep_archive"
+      ]
+    },
+    "public.plan_tier": {
+      "name": "plan_tier",
+      "schema": "public",
+      "values": [
+        "starter",
+        "pro",
+        "max",
+        "enterprise"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "incomplete",
+        "sponsored"
+      ]
+    },
+    "public.webhook_source": {
+      "name": "webhook_source",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "sns"
+      ]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "processed",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1783010307674,
       "tag": "0012_overjoyed_union_jack",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1783087572493,
+      "tag": "0013_past_mach_iv",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/storage.ts
+++ b/packages/db/src/schema/storage.ts
@@ -84,9 +84,12 @@ export const files = pgTable(
         size: bigint('size', { mode: 'number' }).notNull(),
         mimeType: text('mime_type'),
         s3Key: text('s3_key').notNull().unique(),
+        // Defaults to 'standard' because that's where every upload lands in
+        // S3; the bucket lifecycle rule transitions objects to Deep Archive
+        // and the s3:LifecycleTransition webhook flips this column to match.
         storageTier: storageTierEnum('storage_tier')
             .notNull()
-            .default('glacier'),
+            .default('standard'),
         status: fileStatusEnum('status').notNull().default('uploading'),
         ...timestamps(),
         lastAccessedAt: timestamp('last_accessed_at'),


### PR DESCRIPTION
## Summary

Makes `files.storageTier` reflect the object's real S3 storage class — the activation switch for #255, with the UI (#256/#260) and retrieval fast path (#257/#261) already merged as prerequisites.

Three parts: new rows default to `standard` (where every upload actually lands), an `s3:LifecycleTransition` SNS handler flips rows when the bucket lifecycle rule moves the object, and a backfill script reconciled the existing rows against real S3 storage classes.

Closes #258

**Infra findings (dev):** the issue said "Terraform", but the repo has no IaC — notifications are managed via the manual runbook. Bigger surprise: the *entire* SNS restore-events stack from `docs/infra/aws-manual-setup.md` (topic, DLQ, subscription, bucket notifications) did not exist in AWS; the webhook had never received a real event. I provisioned the full stack per the runbook (topic + DLQ + policies + HTTPS subscription to `https://nexus.thomasar.dev/api/webhooks/s3-restore`, auto-confirmed + bucket notifications with the 3 restore events and `s3:LifecycleTransition`). The runbook also had a latent bug — it subscribed with `RawMessageDelivery: true`, which strips the SNS envelope the handler parses and signature-verifies; every event would have been dropped. Provisioned with raw delivery off and fixed the doc.

## Changes

- Schema: `files.storageTier` default `glacier` → `standard` (migration `0013`, applied to dev)
- `s3:LifecycleTransition` handler in `s3RestoreService`: flips the row to the destination class; unknown keys and unmapped classes are logged and skipped
- `S3EventRecord` type extended with `lifecycleEventData`
- `s3.objects.listAll()`: paginated `ListObjectsV2` with storage class (+ testing stub)
- `resolveStorageTier()` shared by the webhook handler and backfill script
- Backfill script `pnpm -F web backfill:storage-tier` (dry-run default, `--apply`); closes its DB connection so it exits cleanly
- Runbook: added `s3:LifecycleTransition` to the notification events, removed the broken `RawMessageDelivery` attribute, noted the dev endpoint

## Backfill run (dev, 2026-07-03)

- Dry run: 79 rows checked, 40 mismatched, 38 missing in S3 (test rows whose objects are gone — skipped), 53 S3 objects without rows (orphans — reported only). Object totals reconcile with the issue's census (94).
- `--apply`: 40 updated, 0 failed. Re-run: 0 mismatches, no-op.

## Test Plan

- [x] Unit: lifecycle handler flips tier, ignores unknown files/classes/missing data (`s3-restore.test.ts`)
- [x] Integration: `LifecycleTransition` webhook flips row to `deep_archive`; inserts default to `standard` (`route.integration.test.ts`, real dev DB)
- [x] Backfill dry-run counts match census; apply corrects rows; re-run is a no-op
- [x] `pnpm check` green
- [x] Post-merge: upload >128KB file on dev → row `standard`, shows archived + Retrieve, retrieval instant pre-transition
- [ ] Post-merge (~24–48h): verify one real lifecycle event flips a row via the deployed webhook (transitions run daily)
