### PR TITLE
fix: flaky settings smoke test — 15s timeout on plan-card assertion (#254)

### DIFF
--- a/apps/web/e2e/smoke/auth-flows.spec.ts
+++ b/apps/web/e2e/smoke/auth-flows.spec.ts
@@ -9,7 +9,11 @@ import { deleteUserByEmail } from '@nexus/db/test-db';
 import { createTestDb } from '../helpers/connection';
 
 // Unique per run so a crashed previous run can't collide; cleaned in afterAll.
-const SIGNUP_EMAIL = `signup-e2e-${Date.now()}@test.local`;
+// The pid matters: fullyParallel spreads this file's tests across workers, and
+// afterAll runs in each of them. Workers spawn together, so Date.now() alone
+// can collide across workers — then another worker's afterAll cascade-deletes
+// this worker's signup user (and its session) mid-test.
+const SIGNUP_EMAIL = `signup-e2e-${Date.now()}-${process.pid}@test.local`;
 const SIGNUP_PASSWORD = 'signup-e2e-password-123';
 
 test.describe('auth flows', () => {

--- a/apps/web/e2e/smoke/authenticated/dashboard.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/dashboard.spec.ts
@@ -77,12 +77,15 @@ test.describe('Dashboard Pages', () => {
 
             // Subscription section renders once tRPC resolves; seeded users get a
             // starter trial row so all three checkout tiers should be visible.
+            // The card header renders before the query resolves, so the first
+            // heading gates on subscriptions.current — give it the suite's 15s
+            // cold-start allowance (see auth-flows/invite specs).
             await expect(
                 page.getByText('Manage your storage plan')
             ).toBeVisible();
             await expect(
                 page.getByRole('heading', { name: 'Starter', exact: true })
-            ).toBeVisible();
+            ).toBeVisible({ timeout: 15_000 });
             await expect(
                 page.getByRole('heading', { name: 'Pro', exact: true })
             ).toBeVisible();

--- a/apps/web/e2e/smoke/invite.spec.ts
+++ b/apps/web/e2e/smoke/invite.spec.ts
@@ -16,8 +16,10 @@ import { createTestDb } from '../helpers/connection';
 import { setupConsoleErrorTracking } from '../utils';
 
 // Unique per run so a crashed previous run can't collide; cleaned in afterAll.
-const SIGNUP_EMAIL = `sponsored-e2e-${Date.now()}@test.local`;
-const BOUND_EMAIL = `invite-bound-e2e-${Date.now()}@test.local`;
+// The pid guards against cross-worker Date.now() collisions — see the note in
+// auth-flows.spec.ts (another worker's afterAll would delete this user).
+const SIGNUP_EMAIL = `sponsored-e2e-${Date.now()}-${process.pid}@test.local`;
+const BOUND_EMAIL = `invite-bound-e2e-${Date.now()}-${process.pid}@test.local`;
 const SIGNUP_PASSWORD = 'sponsored-e2e-password-123';
 
 test.describe('invite redemption', () => {


### PR DESCRIPTION
Closes #254

Two fixes: the timeout race from the issue, plus a second smoke flake that surfaced (and was root-caused) while validating.

## 1. Settings plan-card timeout (the issue)

The settings smoke test's plan-card headings render only after `subscriptions.current` resolves; the default 5s expect timeout occasionally loses to the e2e server's cold start. This gives the first post-query assertion (the `Starter` heading) the suite's established 15s timeout, matching `auth-flows.spec.ts` and `invite.spec.ts`. Once that heading is visible the query has resolved, so the remaining assertions keep the default.

The issue's alternative (await skeleton disappearance / `Manage your storage plan`'s siblings) doesn't work as a gate: that text is in the card header, which renders before the query resolves. Gating on the first heading is equivalent to awaiting the skeleton's disappearance.

**Latency sanity check (per acceptance criteria):** `subscriptions.current` → `subscriptionService.getCurrentSubscription` → `repo.findByUserId`, a `findFirst` on `subscriptions.user_id`, which has a unique constraint (unique index). Single-row indexed lookup — the first-hit latency is cold-start cost (DB connection setup, first query over the pool), not a slow query.

## 2. Cross-worker cascade-delete race in signup specs

During validation, `auth-flows.spec.ts` › "sign up with email lands on dashboard and provisions a trial" failed once: signup landed on `/dashboard`, then every dashboard query returned `UNAUTHORIZED` and the settings navigation bounced to `/sign-in` — the session was gone mid-test.

**Root cause:** `SIGNUP_EMAIL` is `signup-e2e-${Date.now()}@test.local`, computed at module load, and `afterAll` deletes that user. With `fullyParallel`, this file's tests spread across workers and `afterAll` runs in each of them. Workers spawn together after the setup project finishes, so two workers can load the module in the same millisecond and compute the identical email. The worker running only the quick wrong-password test finishes first, its `afterAll` deletes the shared email, and the user delete cascades to the session — killing the signup test's session mid-flight (better-auth then clears the cookie on the next `getSession`, hence the bounce to `/sign-in`).

**Proof:** hardcoding a shared email (simulating the collision) reproduces the exact failure signature deterministically — same test, same 8 `UNAUTHORIZED` queries (verified in the webserver log), same bounce.

**Fix:** append `process.pid` to the generated emails in `auth-flows.spec.ts` and `invite.spec.ts` (same pattern, same vulnerability). Worker pids can't collide, so each worker's `afterAll` can only ever delete its own user.

## Testing

- `pnpm -F web test:e2e:smoke` green 4/4 consecutive runs after the fix (37/37 each)
- `pnpm check` green