### PR TITLE
fix: S3 webhook handlers never match real events — unprefixed eventName (#271)

### DIFF
--- a/apps/web/app/api/webhooks/s3-restore/route.integration.test.ts
+++ b/apps/web/app/api/webhooks/s3-restore/route.integration.test.ts
@@ -194,7 +194,7 @@ describe('POST /api/webhooks/s3-restore', () => {
 
         const body = createSnsNotification(
             messageId,
-            's3:ObjectRestore:Completed',
+            'ObjectRestore:Completed',
             s3Key,
             {
                 restoreEventData: {
@@ -237,7 +237,7 @@ describe('POST /api/webhooks/s3-restore', () => {
 
         const body = createSnsNotification(
             messageId,
-            's3:ObjectRestore:Completed',
+            'ObjectRestore:Completed',
             s3Key,
             {
                 restoreEventData: {
@@ -295,7 +295,7 @@ describe('POST /api/webhooks/s3-restore', () => {
 
         const body = createSnsNotification(
             messageId,
-            's3:ObjectRestore:Delete',
+            'ObjectRestore:Delete',
             s3Key
         );
 
@@ -336,7 +336,7 @@ describe('POST /api/webhooks/s3-restore', () => {
 
         const body = createSnsNotification(
             messageId,
-            's3:LifecycleTransition',
+            'LifecycleTransition',
             s3Key,
             undefined,
             { transitionEventData: { destinationStorageClass: 'DEEP_ARCHIVE' } }
@@ -390,7 +390,7 @@ describe('POST /api/webhooks/s3-restore', () => {
 
         const body = createSnsNotification(
             messageId,
-            's3:ObjectRestore:Post',
+            'ObjectRestore:Post',
             'some/unknown/key'
         );
 

--- a/apps/web/lib/sns/types.ts
+++ b/apps/web/lib/sns/types.ts
@@ -36,7 +36,7 @@ export interface S3EventRecord {
             lifecycleRestorationExpiryTime: string;
         };
     };
-    // Present on s3:LifecycleTransition events
+    // Present on LifecycleTransition events
     lifecycleEventData?: {
         transitionEventData: {
             destinationStorageClass: string;

--- a/apps/web/server/services/s3-restore.test.ts
+++ b/apps/web/server/services/s3-restore.test.ts
@@ -33,7 +33,7 @@ const RESTORE_EXPIRY = '2026-07-10T12:00:00.000Z';
 
 function makeRecord(overrides: Partial<S3EventRecord> = {}): S3EventRecord {
     return {
-        eventName: 's3:ObjectRestore:Completed',
+        eventName: 'ObjectRestore:Completed',
         s3: {
             bucket: { name: 'test-bucket' },
             object: { key: 'uploads/test-file.jpg' },
@@ -128,7 +128,7 @@ describe('s3RestoreService.dispatch', () => {
             destinationStorageClass?: string
         ): S3EventRecord {
             return makeRecord({
-                eventName: 's3:LifecycleTransition',
+                eventName: 'LifecycleTransition',
                 glacierEventData: undefined,
                 lifecycleEventData: destinationStorageClass
                     ? { transitionEventData: { destinationStorageClass } }
@@ -198,7 +198,7 @@ describe('s3RestoreService.dispatch', () => {
         it('sends no email on restore expiry', async () => {
             const handled = await s3RestoreService.dispatch(
                 mockDb.db,
-                makeRecord({ eventName: 's3:ObjectRestore:Delete' })
+                makeRecord({ eventName: 'ObjectRestore:Delete' })
             );
 
             expect(handled).toBe(true);
@@ -208,7 +208,7 @@ describe('s3RestoreService.dispatch', () => {
         it('sends no email for unhandled event types', async () => {
             const handled = await s3RestoreService.dispatch(
                 mockDb.db,
-                makeRecord({ eventName: 's3:ObjectCreated:Put' })
+                makeRecord({ eventName: 'ObjectCreated:Put' })
             );
 
             expect(handled).toBe(false);

--- a/apps/web/server/services/s3-restore.ts
+++ b/apps/web/server/services/s3-restore.ts
@@ -11,10 +11,14 @@ const log = logger.child({ service: 's3-restore' });
 
 type S3RestoreEventHandler = (db: DB, record: S3EventRecord) => Promise<void>;
 
+// Delivered `eventName` values are UNPREFIXED (`ObjectRestore:Completed`),
+// unlike the `s3:`-prefixed event types used when configuring bucket
+// notifications. Keys here must match the wire format — see the captured
+// payloads in webhook_events / docs/guides/webhooks.md.
 const handlers: Record<string, S3RestoreEventHandler> = {
-    's3:ObjectRestore:Completed': handleRestoreCompleted,
-    's3:ObjectRestore:Delete': handleRestoreExpired,
-    's3:LifecycleTransition': handleLifecycleTransition,
+    'ObjectRestore:Completed': handleRestoreCompleted,
+    'ObjectRestore:Delete': handleRestoreExpired,
+    LifecycleTransition: handleLifecycleTransition,
 };
 
 // S3 encodes spaces as `+` in event notification keys

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -498,9 +498,14 @@ curl -X POST http://localhost:3000/api/webhooks/s3-restore \
     "MessageId": "msg-456",
     "TopicArn": "arn:aws:sns:us-east-1:123456789:nexus-events",
     "Subject": "Amazon S3 Notification",
-    "Message": "{\"Records\":[{\"eventName\":\"s3:ObjectRestore:Completed\",\"s3\":{\"bucket\":{\"name\":\"nexus-storage-files-dev\"},\"object\":{\"key\":\"user-123/file-456/document.pdf\"}}}]}"
+    "Message": "{\"Records\":[{\"eventName\":\"ObjectRestore:Completed\",\"s3\":{\"bucket\":{\"name\":\"nexus-storage-files-dev\"},\"object\":{\"key\":\"user-123/file-456/document.pdf\"}}}]}"
   }'
 ```
+
+> **Wire format:** the delivered `eventName` is **unprefixed**
+> (`ObjectRestore:Completed`, `LifecycleTransition`) even though the bucket
+> notification config subscribes with `s3:`-prefixed event types. Payloads
+> replayed with the prefix will silently match no handler (#271).
 
 > **Note:** These manual tests skip signature verification. In the SNS route handler, you can bypass verification in development by checking `NODE_ENV` — but never skip it in production.
 

--- a/docs/infra/aws-manual-setup.md
+++ b/docs/infra/aws-manual-setup.md
@@ -229,6 +229,8 @@ aws s3api put-bucket-notification-configuration \
     }'
 ```
 
+> **Naming gotcha:** the `s3:` prefix is only used here, at configuration time. The events S3 actually delivers carry an **unprefixed** `eventName` (`ObjectRestore:Completed`, `LifecycleTransition`). Handler code must match the unprefixed form — keying on the config-time names silently drops every event (#271).
+
 > **Warning:** `put-bucket-notification-configuration` replaces the entire notification config. If the bucket already has other notifications configured, include them in the same command. Check existing config first with `aws s3api get-bucket-notification-configuration --bucket "$BUCKET"`.
 
 ### SNS Verification Commands

--- a/packages/db/src/schema/storage.ts
+++ b/packages/db/src/schema/storage.ts
@@ -86,7 +86,7 @@ export const files = pgTable(
         s3Key: text('s3_key').notNull().unique(),
         // Defaults to 'standard' because that's where every upload lands in
         // S3; the bucket lifecycle rule transitions objects to Deep Archive
-        // and the s3:LifecycleTransition webhook flips this column to match.
+        // and the LifecycleTransition webhook flips this column to match.
         storageTier: storageTierEnum('storage_tier')
             .notNull()
             .default('standard'),


### PR DESCRIPTION
## Summary

The handler map in `s3-restore.ts` keyed on `s3:`-prefixed event names, but real AWS S3 notification payloads deliver `eventName` **unprefixed** (`ObjectRestore:Completed`, `LifecycleTransition`). `dispatch()` never matched a real event, so every event since the SNS stack was provisioned was silently dropped and marked `processed` — tier flips, restore-ready emails, and restore-expiry handling were all dead on the live path. Tests didn't catch it because fixtures encoded the same wrong assumption, keeping code and tests internally consistent.

The fix rekeys the handler map to the real wire names (verified against captured payloads in dev's `webhook_events`) and updates all fixtures to that shape. Deliberately no prefix-stripping shim in `dispatch()` — AWS never sends the prefixed form, and tolerating it would let wrong fixtures pass again.

Closes #271

## Changes

- Rekey the handler map in `apps/web/server/services/s3-restore.ts` to unprefixed event names, with a comment explaining the config-time (`s3:`-prefixed) vs delivered (unprefixed) naming split that caused the bug
- Update unit and integration test fixtures to the real payload shape, including the unhandled-event cases (`ObjectRestore:Post`, `ObjectCreated:Put`)
- Fix the wrong example payload in `docs/guides/webhooks.md` and add wire-format callouts there and in `docs/infra/aws-manual-setup.md` (the `s3:`-prefixed values in the bucket-notification config section are correct as-is and unchanged)
- Comment-only touch-ups in `lib/sns/types.ts` and `packages/db/src/schema/storage.ts`

## Dev cleanup (done)

- `backfill:storage-tier --apply` run against dev: corrected the one drifted row (`Slack-4.47.59-macOS.dmg`, `standard → deep_archive`, the #271 evidence row); follow-up dry run reports **0 mismatched tiers**
- Checked for retrievals stuck by the dropped `ObjectRestore:Completed` of 2026-07-04: none (that file's rows were already cleaned up)

## Test Plan

- [x] `pnpm check` green
- [x] `pnpm -F web test:integration` green — replayed real-shape `LifecycleTransition` flips `files.storage_tier`; real-shape `ObjectRestore:Completed` marks the retrieval ready (unit test asserts the ready email send)
- [ ] Post-deploy: verify the next real lifecycle/restore event on dev flips a row end-to-end (open post-merge item from #258/#255), and re-run `backfill:storage-tier` dry run to confirm no new drift accumulated between this run and deploy