### PR TITLE
feat: scheduled S3 event-health check — drift, failed webhooks, stuck retrievals (#285)

### DIFF
--- a/.github/workflows/s3-event-health.yml
+++ b/.github/workflows/s3-event-health.yml
@@ -1,0 +1,110 @@
+name: S3 Event Health
+
+# Post-deploy watch for the S3 event pipeline (#285): tier drift, failed SNS
+# webhooks, stuck retrievals. A failed run is the alert. Also posts a one-time
+# success comment on PR #278 once the first real post-deploy event lands —
+# that step is temporary (#286 tracks the generalized pattern).
+
+on:
+    schedule:
+        - cron: '0 5 * * *'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    health:
+        name: Drift + webhook/retrieval health
+        runs-on: ubuntu-latest
+        env:
+            DATABASE_URL: ${{ secrets.DATABASE_URL }}
+            SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_REGION: ${{ secrets.AWS_REGION }}
+            S3_BUCKET: ${{ secrets.S3_BUCKET }}
+            SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
+            STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+            STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+            RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+            RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
+            BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+            NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+            NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLIC_KEY }}
+            NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Read Node version
+              id: node-version
+              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ steps.node-version.outputs.version }}
+                  cache: 'pnpm'
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            # The scripts load env via `tsx --env-file=.env.local`, which
+            # errors if the file is missing; real values come from the job
+            # env above (process env wins over the file).
+            - name: Create empty env file
+              run: touch apps/web/.env.local
+
+            - name: Check storage-tier drift
+              run: pnpm -F web backfill:storage-tier --check
+
+            - name: Resolve PR 278 merge time
+              id: merge
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  echo "merged_at=$(gh pr view 278 --repo "$GITHUB_REPOSITORY" --json mergedAt -q '.mergedAt // empty')" >> "$GITHUB_OUTPUT"
+
+            - name: Check webhook & retrieval health
+              id: health
+              run: |
+                  set -o pipefail
+                  ARGS=()
+                  if [ -n "${{ steps.merge.outputs.merged_at }}" ]; then
+                      ARGS=(--since "${{ steps.merge.outputs.merged_at }}")
+                  fi
+                  pnpm -F web check:s3-event-health "${ARGS[@]}" | tee health.log
+                  echo "handled_since=$(sed -n 's/^handled_events_since=//p' health.log)" >> "$GITHUB_OUTPUT"
+
+            # Temporary (#286 generalizes this): tick the post-deploy box on
+            # PR #278 once the first real event has been processed end-to-end.
+            # Remove this step after the comment lands.
+            - name: Post one-time verification comment on PR 278
+              if: steps.merge.outputs.merged_at != '' && steps.health.outputs.handled_since != '' && steps.health.outputs.handled_since != '0'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  HANDLED_SINCE: ${{ steps.health.outputs.handled_since }}
+                  MERGED_AT: ${{ steps.merge.outputs.merged_at }}
+              run: |
+                  MARKER="<!-- post-deploy-verified-278 -->"
+                  if gh pr view 278 --repo "$GITHUB_REPOSITORY" --json comments -q '.comments[].body' | grep -qF "$MARKER"; then
+                      echo "Verification comment already posted — skipping."
+                      exit 0
+                  fi
+                  cat > comment.md <<EOF
+                  $MARKER
+                  ✅ **Post-deploy verification passed** (automated by the s3-event-health workflow, #285)
+
+                  - $HANDLED_SINCE handled-type S3 event(s) processed since merge ($MERGED_AT)
+                  - \`backfill:storage-tier --check\`: no drift
+                  - No failed SNS webhook events, no stuck retrievals
+
+                  The remaining post-deploy test-plan item can be ticked.
+                  EOF
+                  gh pr comment 278 --repo "$GITHUB_REPOSITORY" --body-file comment.md

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,8 @@
         "test:integration": "vitest run --config vitest.integration.config.ts",
         "screenshots": "tsx scripts/screenshots.ts",
         "backfill:trial-subscriptions": "tsx --env-file=.env.local scripts/backfill-trial-subscriptions.ts",
-        "backfill:storage-tier": "tsx --env-file=.env.local scripts/backfill-storage-tier.ts"
+        "backfill:storage-tier": "tsx --env-file=.env.local scripts/backfill-storage-tier.ts",
+        "check:s3-event-health": "tsx --env-file=.env.local scripts/check-s3-event-health.ts"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.975.0",

--- a/apps/web/scripts/backfill-storage-tier.ts
+++ b/apps/web/scripts/backfill-storage-tier.ts
@@ -12,6 +12,7 @@
  * Usage:
  *   pnpm -F web backfill:storage-tier          # dry run (default)
  *   pnpm -F web backfill:storage-tier --apply  # actually update rows
+ *   pnpm -F web backfill:storage-tier --check  # dry run, exit 1 on drift (CI)
  */
 
 import { ne } from 'drizzle-orm';
@@ -24,6 +25,7 @@ import { files } from '@nexus/db/schema';
 
 async function main(): Promise<void> {
     const shouldApply = process.argv.includes('--apply');
+    const isCheck = process.argv.includes('--check');
 
     // Deleted rows keep their s3Key but the object is already removed —
     // reconciling them would only report every one as missing.
@@ -94,6 +96,12 @@ async function main(): Promise<void> {
 
     if (mismatches.length === 0) {
         console.log('\nNothing to update.');
+        return;
+    }
+
+    if (isCheck) {
+        console.log('\nCheck failed: storage tiers have drifted from S3.');
+        process.exitCode = 1;
         return;
     }
 

--- a/apps/web/scripts/check-s3-event-health.ts
+++ b/apps/web/scripts/check-s3-event-health.ts
@@ -1,0 +1,143 @@
+/**
+ * Health check for the S3 event pipeline (SNS webhook → DB side effects).
+ *
+ * Fails (exit 1) when:
+ *   - any SNS webhook event landed in status 'failed' in the last 7 days
+ *   - any retrieval has sat in 'pending'/'in_progress' for over 48 hours
+ *     (Deep Archive bulk restores complete within 48h — older is stuck)
+ *
+ * Tier drift is covered separately by `backfill:storage-tier --check`; the
+ * two together are the post-deploy watch for #278 (see #285).
+ *
+ * Usage:
+ *   pnpm -F web check:s3-event-health
+ *   pnpm -F web check:s3-event-health -- --since 2026-07-05T00:00:00Z
+ *
+ * With --since, prints `handled_events_since=<n>` — the count of processed
+ * handled-type S3 events after that time. CI uses it to detect that the
+ * first real post-deploy event arrived and post the success comment.
+ */
+
+import { and, count, eq, gte, inArray, lt } from 'drizzle-orm';
+
+import { db } from '@/server/db';
+import { retrievals, webhookEvents } from '@nexus/db/schema';
+
+const FAILED_WEBHOOK_WINDOW_DAYS = 7;
+const STUCK_RETRIEVAL_HOURS = 48;
+
+// Wire names as AWS delivers them (unprefixed) — must match the handler map
+// in server/services/s3-restore.ts.
+const HANDLED_EVENT_TYPES = [
+    'ObjectRestore:Completed',
+    'ObjectRestore:Delete',
+    'LifecycleTransition',
+];
+
+function parseSinceArg(): Date | null {
+    const index = process.argv.indexOf('--since');
+    if (index === -1) return null;
+    const raw = process.argv[index + 1];
+    const since = raw ? new Date(raw) : null;
+    if (!since || Number.isNaN(since.getTime())) {
+        throw new Error(`--since requires a valid ISO date, got: ${raw}`);
+    }
+    return since;
+}
+
+async function main(): Promise<void> {
+    const since = parseSinceArg();
+    let hasFailure = false;
+
+    const failedAfter = new Date(
+        Date.now() - FAILED_WEBHOOK_WINDOW_DAYS * 24 * 60 * 60 * 1000
+    );
+    const failedWebhooks = await db
+        .select({
+            id: webhookEvents.id,
+            eventType: webhookEvents.eventType,
+            error: webhookEvents.error,
+            createdAt: webhookEvents.createdAt,
+        })
+        .from(webhookEvents)
+        .where(
+            and(
+                eq(webhookEvents.source, 'sns'),
+                eq(webhookEvents.status, 'failed'),
+                gte(webhookEvents.createdAt, failedAfter)
+            )
+        );
+
+    console.log(
+        `Failed SNS webhook events (last ${FAILED_WEBHOOK_WINDOW_DAYS}d): ${failedWebhooks.length}`
+    );
+    for (const event of failedWebhooks) {
+        console.log(
+            `  ✗ ${event.createdAt.toISOString()}  ${event.eventType}  ${event.error ?? '(no error recorded)'}`
+        );
+    }
+    if (failedWebhooks.length > 0) hasFailure = true;
+
+    const stuckBefore = new Date(
+        Date.now() - STUCK_RETRIEVAL_HOURS * 60 * 60 * 1000
+    );
+    const stuckRetrievals = await db
+        .select({
+            id: retrievals.id,
+            fileId: retrievals.fileId,
+            status: retrievals.status,
+            tier: retrievals.tier,
+            createdAt: retrievals.createdAt,
+        })
+        .from(retrievals)
+        .where(
+            and(
+                inArray(retrievals.status, ['pending', 'in_progress']),
+                lt(retrievals.createdAt, stuckBefore)
+            )
+        );
+
+    console.log(
+        `Retrievals stuck >${STUCK_RETRIEVAL_HOURS}h:                ${stuckRetrievals.length}`
+    );
+    for (const retrieval of stuckRetrievals) {
+        console.log(
+            `  ✗ ${retrieval.createdAt.toISOString()}  ${retrieval.status} (${retrieval.tier})  retrieval=${retrieval.id} file=${retrieval.fileId}`
+        );
+    }
+    if (stuckRetrievals.length > 0) hasFailure = true;
+
+    if (since) {
+        const [handled] = await db
+            .select({ count: count() })
+            .from(webhookEvents)
+            .where(
+                and(
+                    eq(webhookEvents.source, 'sns'),
+                    eq(webhookEvents.status, 'processed'),
+                    inArray(webhookEvents.eventType, HANDLED_EVENT_TYPES),
+                    gte(webhookEvents.createdAt, since)
+                )
+            );
+        console.log(
+            `Handled-type events processed since ${since.toISOString()}: ${handled?.count ?? 0}`
+        );
+        console.log(`handled_events_since=${handled?.count ?? 0}`);
+    }
+
+    if (hasFailure) {
+        console.log('\nCheck failed: S3 event pipeline needs attention.');
+        process.exitCode = 1;
+    } else {
+        console.log('\nAll checks passed.');
+    }
+}
+
+main()
+    .catch((err) => {
+        console.error('Health check aborted:', err);
+        process.exitCode = 1;
+    })
+    // The pooled connection keeps the event loop alive; close it so the
+    // script exits instead of hanging after the summary prints.
+    .finally(() => db.$client.end());


### PR DESCRIPTION
## Summary

Automates the post-deploy item on #278: instead of a human remembering to verify the next real lifecycle/restore event days after deploy, a daily scheduled workflow checks the S3 event pipeline against dev and alerts by failing. Once #278 merges and the first real handled-type event is processed with everything green, it posts a one-time verification comment on #278.

Closes #285. Related to #278, #286.

## Changes

- `backfill:storage-tier` gains `--check`: dry run that exits 1 when tiers have drifted (the end-to-end signal that a lifecycle event was delivered but not applied — this is what would have caught #271)
- New `check:s3-event-health` script: fails on SNS webhook events in `status='failed'` (7-day window) and on retrievals stuck `pending`/`in_progress` >48h (Deep Archive bulk upper bound); with `--since` it also reports the count of processed handled-type events after that time
- New `s3-event-health.yml` workflow: daily at 05:00 UTC + `workflow_dispatch`, runs both checks; a failed run is the alert (GitHub emails on scheduled-workflow failure)
- One-time success comment on PR #278, gated on its `mergedAt` (dev already has 3 processed handled-type events from *before* the fix — they were dropped-but-marked-processed, which is why the merge-time gate matters) and deduped via an HTML marker. Step is explicitly temporary; #286 tracks the generalized checks-as-code pattern that replaces it.

## Notes

- `webhook_events.status='processed'` does not distinguish handled from silently dropped (the route marks unhandled events processed too), so the success assertion is the combination: event processed since merge **and** zero drift **and** no stuck retrievals.
- All required secrets (`DATABASE_URL`, AWS, Stripe, Resend, Supabase, `NEXT_PUBLIC_*`) already exist in repo secrets; `touch .env.local` satisfies `tsx --env-file` in CI while real values come from the job env.

## Test Plan

- [x] `pnpm check` green
- [x] `backfill:storage-tier --check` run against dev: 0 mismatches, exit 0
- [x] `check:s3-event-health --since 2026-07-01T00:00:00Z` run against dev: 0 failed webhooks, 0 stuck retrievals, `handled_events_since=3`, exit 0
- [x] `actionlint` clean on the new workflow; comment heredoc dry-run renders correctly
- [x] Post-merge: trigger via `workflow_dispatch` to confirm the job runs green in CI
