### PR TITLE
feat: sponsored subscription panel in settings (#252)

### DIFF
--- a/.claude/skills/work-delegate/SKILL.md
+++ b/.claude/skills/work-delegate/SKILL.md
@@ -42,9 +42,16 @@ Implement a GitHub issue as a delegator: you orchestrate and judge; an explore a
 
 6. **Self-review (never skip).** Spawn 3 parallel Task agents, each given the changed files and diff: `conventions-review`, `code-quality-review`, `reuse-review`. Present findings grouped by category and ask: fix all / fix selected / skip (note in PR). Continue the executor with ALL approved fixes in one message (it has the implementation context; its continues are cheap), then re-run `pnpm check`.
 
-7. **Commit & push.** Invoke the `/commit` skill (runs on a cheap model in a forked context). Message format: `<type>: <description> (#<n>)`. Stage only related files.
+7. **Gather evidence (delegator does this, not the executor).** Drive the actual feature and capture proof that the acceptance criteria hold. Evidence produced by the agent that wrote the code is a demo, not a check — independent hands on the feature is the point, and it makes step 5's verification durable instead of an assertion that evaporates. Proportional to the change:
+    - **UI change** — record a temporary Playwright capture spec in `apps/web/e2e/smoke/authenticated/` reusing the e2e fixtures: `test.use({ userRole: 'user', video: 'on', colorScheme: 'dark', viewport: { width: 1440, height: 900 } })`; drive before/after states via `@nexus/db/test-db` helpers with the existing `afterEach` reset; `page.waitForTimeout(~2s)` holds before each `page.screenshot()` so the video is readable. Three details people relearn the hard way: capture in **dark mode** (standing preference); **scope text assertions** to a container (`.locator('..')`) — values like a storage limit often render twice (panel + sidebar) and unscoped `getByText` fails on strict mode; **delete the spec** after recording so it's never committed. Upload video + stills with `/attach-video`.
+    - **Behavioral/backend change** — whatever proves the criterion: the new test's output, a before/after DB query, a `curl` against the dev server, a log excerpt showing the code path firing.
+    - **Refactor/test-only change** — the check output tails from step 4 are already enough; skip this step.
 
-8. **PR.** `gh pr create` with body:
+    One `## Evidence` section in the PR, and only artifacts that demonstrate an acceptance criterion — logs nobody reads are padding. (Post-merge validation against the dev environment is `/validate`'s job; this step is its cheaper pre-merge cousin — don't grow it into a duplicate.)
+
+8. **Commit & push.** Invoke the `/commit` skill (runs on a cheap model in a forked context). Message format: `<type>: <description> (#<n>)`. Stage only related files.
+
+9. **PR.** `gh pr create` with body:
 
     ```
     ## Summary
@@ -57,4 +64,7 @@ Implement a GitHub issue as a delegator: you orchestrate and judge; an explore a
 
     ## Test Plan
     - [ ] <how to verify>
+
+    ## Evidence
+    <inline video / stills / output proving the acceptance criteria — omit only for refactor/test-only changes>
     ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Nexus is a deep storage solution using AWS S3 tiers (Standard → Glacier) for c
 
 **REQUIRED before committing:** `pnpm check` (runs lint + build + test via Turborepo).
 **REQUIRED after modifying pages/components:** `pnpm -F web test:e2e:smoke`.
+**REQUIRED after adding a page, use-case, or e2e test:** `pnpm -F web e2e:coverage --check`.
+Full E2E tier table and test-selection gotchas: `apps/web/CLAUDE.md`.
 
 ## Database (Drizzle)
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -41,3 +41,9 @@ named even on green runs; treat them as bugs, not noise.
 Escape hatches: `--reporter=list` (full per-test output),
 `npx playwright show-report` (traces). Run a single spec/test with
 `npx playwright test <file> -g "<title>"`.
+
+**Never pass `--` before extra args to a pnpm test script.** pnpm forwards the
+`--` literally, and Playwright then silently mis-selects and runs the full
+suite: `pnpm -F web test:e2e:smoke -- subscription.spec.ts` runs all tests.
+Append args directly (`pnpm -F web test:e2e:smoke subscription.spec.ts`) or
+run the binary via `pnpm -F web exec playwright test <file>`.

--- a/apps/web/components/dashboard/SubscriptionSection.tsx
+++ b/apps/web/components/dashboard/SubscriptionSection.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Check, CreditCard, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/cn';
-import { formatDate } from '@/lib/format';
+import { formatBytes, formatDate } from '@/lib/format';
 import { useTRPC } from '@/lib/trpc/client';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -119,6 +119,25 @@ function SubscriptionView({
     const statusBadge = getStatusBadge(subscription.status);
     const canManageBilling = subscription.stripeSubscriptionId !== null;
 
+    // Sponsored accounts have no Stripe subscription, so checkout/portal
+    // actions are meaningless, and their storage limit is set per-invite
+    // rather than by tier — render a dedicated panel instead of the plan grid.
+    if (subscription.status === 'sponsored') {
+        return (
+            <>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex items-center gap-2">
+                        <Badge variant={statusBadge.variant}>
+                            {statusBadge.label}
+                        </Badge>
+                        <SubscriptionMeta subscription={subscription} />
+                    </div>
+                </div>
+                <SponsoredPanel storageLimit={subscription.storageLimit} />
+            </>
+        );
+    }
+
     return (
         <>
             <div className="flex flex-wrap items-center justify-between gap-3">
@@ -168,6 +187,28 @@ function SubscriptionView({
                 </Button>
             </div>
         </>
+    );
+}
+
+interface SponsoredPanelProps {
+    storageLimit: number;
+}
+
+function SponsoredPanel({ storageLimit }: SponsoredPanelProps) {
+    return (
+        <div className="rounded-lg border border-primary bg-primary/5 p-6">
+            <h3 className="font-semibold">Sponsored by Nexus</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+                Your account has full access — no billing required.
+            </p>
+            <p className="mt-4 text-2xl font-bold">
+                {formatBytes(storageLimit)}
+                <span className="text-sm font-normal text-muted-foreground">
+                    {' '}
+                    storage
+                </span>
+            </p>
+        </div>
     );
 }
 

--- a/apps/web/components/dashboard/subscriptionPlans.ts
+++ b/apps/web/components/dashboard/subscriptionPlans.ts
@@ -73,7 +73,7 @@ const STATUS_BADGES: Record<Subscription['status'], StatusBadge> = {
     canceled: { label: 'Canceled', variant: 'destructive' },
     unpaid: { label: 'Unpaid', variant: 'destructive' },
     incomplete: { label: 'Incomplete', variant: 'secondary' },
-    // Minimal badge for comped alpha testers; richer sponsored UI is #252
+    // Sponsored accounts are comped; richer treatment renders in SubscriptionView
     sponsored: { label: 'Sponsored', variant: 'default' },
 };
 

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -396,6 +396,12 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/settings'],
     },
     {
+        id: 'subscription-sponsored-panel',
+        title: 'Sponsored user sees the sponsored panel with no billing controls',
+        area: 'billing',
+        routes: ['/dashboard/settings'],
+    },
+    {
         id: 'stripe-checkout-completion',
         title: 'Complete a payment on Stripe Checkout',
         area: 'billing',

--- a/apps/web/e2e/smoke/authenticated/subscription.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/subscription.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../../fixtures';
 import {
     ensureTrialSubscription,
     markSubscriptionPaid,
+    markSubscriptionSponsored,
 } from '@nexus/db/test-db';
 import { interceptTrpcCalls } from '../../helpers/trpc';
 
@@ -143,6 +144,47 @@ test.describe('Subscription tier change', () => {
             await expect(
                 page.getByRole('button', { name: 'Manage billing' })
             ).toBeEnabled({ timeout: 15_000 });
+        }
+    );
+
+    test(
+        'sponsored user sees sponsored panel with no billing controls',
+        {
+            tag: [
+                '@page:/dashboard/settings',
+                '@uc:subscription-sponsored-panel',
+            ],
+        },
+        async ({ page, db, seedUserId, consoleErrors }) => {
+            await markSubscriptionSponsored(db, seedUserId);
+            await page.goto('/dashboard/settings');
+
+            const panel = page
+                .getByText('Sponsored by Nexus', { exact: true })
+                .locator('..');
+            await expect(panel).toBeVisible();
+            // 2 TB is the helper default, not PLAN_LIMITS.max (10 TB) —
+            // proves the panel reads subscription.storageLimit, not the
+            // tier constant.
+            await expect(panel.getByText('2 TB')).toBeVisible();
+
+            await expect(
+                page.getByRole('button', { name: 'Upgrade' })
+            ).toHaveCount(0);
+            await expect(
+                page.getByRole('button', { name: 'Downgrade' })
+            ).toHaveCount(0);
+            await expect(
+                page.getByRole('button', { name: 'Manage billing' })
+            ).toHaveCount(0);
+            await expect(
+                page.getByRole('group', { name: 'Billing interval' })
+            ).toHaveCount(0);
+            await expect(
+                page.getByRole('heading', { name: 'Starter', exact: true })
+            ).toHaveCount(0);
+
+            expect(consoleErrors).toEqual([]);
         }
     );
 });

--- a/packages/db/src/test-db/queries.ts
+++ b/packages/db/src/test-db/queries.ts
@@ -151,6 +151,33 @@ export async function markSubscriptionPaid(
         .where(eq(schema.subscriptions.userId, userId));
 }
 
+/**
+ * Flips a user's subscription to a comped sponsored account, mimicking invite
+ * provisioning (`planTier: 'max'`, no Stripe subscription, per-invite storage
+ * limit). Default limit is 2 TB — deliberately NOT `PLAN_LIMITS.max` (10 TB) —
+ * so UI tests prove the page reads the row, not a tier constant. Reset via
+ * `ensureTrialSubscription` after.
+ */
+export async function markSubscriptionSponsored(
+    db: DB,
+    userId: string,
+    options?: { storageLimit?: number }
+): Promise<void> {
+    await db
+        .update(schema.subscriptions)
+        .set({
+            status: 'sponsored',
+            planTier: 'max',
+            stripeSubscriptionId: null,
+            currentPeriodStart: null,
+            currentPeriodEnd: null,
+            cancelAtPeriodEnd: false,
+            trialEnd: null,
+            storageLimit: options?.storageLimit ?? 2 * 1024 ** 4,
+        })
+        .where(eq(schema.subscriptions.userId, userId));
+}
+
 export interface JobCounts {
     pending: number;
     processing: number;


### PR DESCRIPTION
## Summary
Sponsored subscriptions (`status: 'sponsored'`, no Stripe subscription, per-invite `storageLimit`) previously rendered the standard plan grid with active Downgrade buttons routing to the Stripe billing portal — which cannot work — and labeled the plan "Max / 10 TB" even when the invite set a different limit. `SubscriptionView` now renders a dedicated "Sponsored by Nexus" panel instead of the plan grid: the account's actual storage limit (formatted from the row), no plan cards, no billing-interval toggle, no Manage-billing footer. The status-badge row is kept.

No API/schema changes; `subscriptionPlans.ts` logic is untouched (component-level branch only), so the "unit tests for any subscriptionPlans.ts logic changes" criterion is satisfied by no logic changes — only a stale `#252` forward-reference comment was updated there.

Closes #252

## Changes
- `SubscriptionSection.tsx`: early-return sponsored branch in `SubscriptionView` + new `SponsoredPanel` component (`formatBytes(subscription.storageLimit)`, current-plan visual language)
- `packages/db/src/test-db/queries.ts`: `markSubscriptionSponsored` helper mirroring `markSubscriptionPaid`; default limit 2 TB (deliberately not `PLAN_LIMITS.max`) so tests prove the UI reads the row, not the tier constant
- `subscription.spec.ts`: new E2E case `@uc:subscription-sponsored-panel` — asserts panel + "2 TB" visible, zero Upgrade/Downgrade/Manage-billing buttons, no billing-interval toggle, no plan-card headings, no console errors; resets via existing `afterEach` `ensureTrialSubscription`
- `e2e/coverage/manifest.ts`: registered the new use-case
- `subscriptionPlans.ts`: comment-only update (stale forward reference)
- `.claude/skills/work-delegate/SKILL.md`: new evidence-gathering step (delegator drives the feature and posts proof on the PR; dark-mode capture-spec pattern codified)
- `CLAUDE.md` + `apps/web/CLAUDE.md`: e2e coverage gate surfaced at root (was only in the web CLAUDE.md); warning that pnpm forwards `--` literally, making Playwright silently run the full suite instead of the targeted spec

## Test Plan
- [x] `pnpm check` green (10/10 tasks)
- [x] `pnpm -F web test:e2e:smoke` green (38/38, includes the new sponsored case)
- [x] `pnpm -F web e2e:coverage --check` — 14/14 pages, 62/62 use-cases
- [ ] Manual: redeem a sponsored invite with a custom storage limit, open /dashboard/settings, confirm panel shows that limit and no billing controls

## Evidence

Recorded against the seeded e2e user on this branch (`markSubscriptionSponsored` default, 2 TB — deliberately not the 10 TB Max constant). The sidebar's "2.44 KB of 2 TB" independently confirms the panel reads the row value.

https://github.com/user-attachments/assets/5828378a-c933-44f8-9209-ebe60e1cb48d

**Before — trial user (unchanged):** plan grid with Upgrade buttons, billing-interval toggle, Manage-billing footer.

![Trial user sees the normal plan grid](https://github.com/user-attachments/assets/b6f5710f-3c98-44ce-8c91-66ba767a8cc9)

**After — sponsored user:** Sponsored badge + "Sponsored by Nexus" panel with the account's actual 2 TB limit; no plan cards, no toggle, no billing footer.

![Sponsored user sees the sponsored panel](https://github.com/user-attachments/assets/06c92596-fe63-4e9e-ac1e-ef45d0e7b1a0)


