### PR TITLE
chore: env hygiene before the multi-env split (#292)

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -47,12 +47,8 @@ jobs:
         # e2e runs against a production build (next build + next start), so the
         # build step and the test step both need these at build/runtime.
         env:
-            NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
-            NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLIC_KEY }}
             NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
             DATABASE_URL: ${{ secrets.DATABASE_URL }}
-            SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/s3-event-health.yml
+++ b/.github/workflows/s3-event-health.yml
@@ -20,7 +20,6 @@ jobs:
         runs-on: ubuntu-latest
         env:
             DATABASE_URL: ${{ secrets.DATABASE_URL }}
-            SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -31,9 +30,6 @@ jobs:
             RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
             RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
             BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-            NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
-            NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLIC_KEY }}
             NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
         steps:
             - name: Checkout

--- a/README.md
+++ b/README.md
@@ -142,13 +142,14 @@ pnpm dev                                         # http://localhost:3000
 
 Validated at startup by [`apps/web/lib/env/schema.ts`](apps/web/lib/env/schema.ts) (the canonical list) and imported type-safely via `@/lib/env`. A missing or malformed variable fails the build, not a request.
 
-| Category | Variables                                                                                                                  |
-| -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Database | `DATABASE_URL`, `SUPABASE_SECRET_KEY`                                                                                      |
-| Auth     | `BETTER_AUTH_SECRET` (32+ chars)                                                                                           |
-| AWS      | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET`, `SQS_QUEUE_URL`                                   |
-| Stripe   | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`                                                                               |
-| Public   | `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, `NEXT_PUBLIC_STRIPE_PUBLIC_KEY`, `NEXT_PUBLIC_APP_URL` |
+| Category | Variables                                                                                |
+| -------- | ---------------------------------------------------------------------------------------- |
+| Database | `DATABASE_URL`                                                                           |
+| Auth     | `BETTER_AUTH_SECRET` (32+ chars)                                                         |
+| AWS      | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET`, `SQS_QUEUE_URL` |
+| Stripe   | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`                                             |
+| Email    | `RESEND_API_KEY`, `RESEND_FROM_EMAIL`                                                    |
+| Public   | `NEXT_PUBLIC_APP_URL`                                                                    |
 
 ## Commands
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,17 +1,17 @@
-# Database (Supabase Postgres)
+# Database (Supabase Postgres, pooled connection — port 6543)
 DATABASE_URL=postgresql://postgres:[YOUR-PASSWORD]@db.[YOUR-PROJECT].supabase.co:6543/postgres
 
 # BetterAuth
 BETTER_AUTH_SECRET=your-secret-key-at-least-32-characters-long
 
-# AWS (optional - for S3 storage)
+# AWS (S3 storage + SQS job queue)
 AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 AWS_REGION=us-east-1
 S3_BUCKET=my-app-bucket
+SQS_QUEUE_URL=https://sqs.us-east-1.amazonaws.com/123456789012/my-queue
 
-# Stripe (optional - for payments)
-NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_xxx
+# Stripe
 STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
 

--- a/apps/web/lib/env/schema.ts
+++ b/apps/web/lib/env/schema.ts
@@ -5,7 +5,6 @@ export const logErrorVerbositySchema = z.enum(['minimal', 'standard', 'full']);
 // Server-side env vars (not exposed to client)
 export const serverSchema = z.object({
     DATABASE_URL: z.string().url(),
-    SUPABASE_SECRET_KEY: z.string().min(1),
     AWS_ACCESS_KEY_ID: z.string().min(1),
     AWS_SECRET_ACCESS_KEY: z.string().min(1),
     AWS_REGION: z.string().min(1),
@@ -24,8 +23,5 @@ export const serverSchema = z.object({
 
 // Client-side env vars (NEXT_PUBLIC_ prefix)
 export const clientSchema = z.object({
-    NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
-    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().min(1),
-    NEXT_PUBLIC_STRIPE_PUBLIC_KEY: z.string().min(1),
     NEXT_PUBLIC_APP_URL: z.string().url(),
 });

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -36,6 +36,26 @@ pnpm -F worker test         # Run tests
 pnpm -F worker lint         # Lint
 ```
 
+## Environment
+
+The worker does not read `.env` files or Vercel env, and does not use the web
+app's Zod schema. Its environment is set per-environment on the Lambda
+function configuration:
+
+| Variable       | Purpose                                                    |
+| -------------- | ---------------------------------------------------------- |
+| `DATABASE_URL` | Postgres connection string (pooled, port 6543 — PgBouncer) |
+
+`DATABASE_URL` is validated at first invocation (`src/handler.ts`) and throws
+a descriptive error if missing. To set it:
+
+```bash
+aws lambda update-function-configuration \
+    --function-name nexus-worker \
+    --environment "Variables={DATABASE_URL=postgresql://...}" \
+    --region us-east-1
+```
+
 ## Deployment
 
 The build produces a single self-contained ES module (`dist/handler.js`) with all dependencies bundled. Deploy to Lambda:
@@ -55,4 +75,4 @@ aws lambda update-function-code \
 - **Runtime:** Node.js 22, ES modules
 - **Database:** Connects via Supabase PgBouncer (port 6543) with `prepare: false` to handle Lambda's concurrent execution model
 - **Bundler:** tsup (esbuild) — bundles all dependencies into a single file
-- **Infrastructure:** Managed via Terraform in `infra/terraform/`
+- **Infrastructure:** Provisioned manually — see `docs/infra/aws-manual-setup.md` (Terraform is planned but not yet in the repo)

--- a/apps/worker/src/handler.ts
+++ b/apps/worker/src/handler.ts
@@ -6,7 +6,22 @@ import { getHandler } from './registry';
 // Register all job handlers
 import './handlers/index';
 
-const db = createDb(process.env.DATABASE_URL!, { prepare: false });
+// Env comes from the Lambda function configuration (set per environment),
+// not Vercel — see README. Cached in module scope for warm-container reuse.
+let db: DB | undefined;
+
+function getDb(): DB {
+    if (!db) {
+        const url = process.env.DATABASE_URL;
+        if (!url) {
+            throw new Error(
+                'DATABASE_URL is not set. Configure it on the Lambda function (see apps/worker/README.md).'
+            );
+        }
+        db = createDb(url, { prepare: false });
+    }
+    return db;
+}
 
 export async function processRecord(
     db: DB,
@@ -42,6 +57,6 @@ export async function processRecord(
 
 export async function handler(event: SQSEvent): Promise<void> {
     for (const record of event.Records) {
-        await processRecord(db, record);
+        await processRecord(getDb(), record);
     }
 }

--- a/docs/guides/environment-setup.md
+++ b/docs/guides/environment-setup.md
@@ -40,6 +40,11 @@ pnpm env:pull
 
 This creates `apps/web/.env.local` with all variables from your Vercel Development environment.
 
+`apps/web/.env.local` is the single env source for all local tooling —
+`packages/db` (drizzle-kit, seed CLI), `tooling/capture`, and the e2e suite
+all load it via hardcoded relative paths. This is a deliberate dev-only
+assumption: deployed code (Vercel, Lambda) never reads `.env` files.
+
 ## File Structure
 
 ```
@@ -75,30 +80,46 @@ Secret key for session signing and token generation.
 
 File storage credentials for S3/Glacier operations.
 
-| Variable                | Type   | Description                    |
-| ----------------------- | ------ | ------------------------------ |
-| `AWS_ACCESS_KEY_ID`     | Server | IAM access key                 |
-| `AWS_SECRET_ACCESS_KEY` | Server | IAM secret key                 |
-| `AWS_REGION`            | Server | AWS region (e.g., `us-east-1`) |
-| `S3_BUCKET`             | Server | S3 bucket name                 |
+| Variable                | Type   | Description                       |
+| ----------------------- | ------ | --------------------------------- |
+| `AWS_ACCESS_KEY_ID`     | Server | IAM access key                    |
+| `AWS_SECRET_ACCESS_KEY` | Server | IAM secret key                    |
+| `AWS_REGION`            | Server | AWS region (e.g., `us-east-1`)    |
+| `S3_BUCKET`             | Server | S3 bucket name                    |
+| `SQS_QUEUE_URL`         | Server | Queue URL for S3 event processing |
 
 ### Stripe
 
-Payment processing credentials.
+Payment processing credentials. Server-side only — there is no Stripe.js on the client, so no publishable key is needed.
 
-| Variable                        | Type   | Description            |
-| ------------------------------- | ------ | ---------------------- |
-| `NEXT_PUBLIC_STRIPE_PUBLIC_KEY` | Public | Publishable key        |
-| `STRIPE_SECRET_KEY`             | Server | Secret key             |
-| `STRIPE_WEBHOOK_SECRET`         | Server | Webhook signing secret |
+| Variable                | Type   | Description            |
+| ----------------------- | ------ | ---------------------- |
+| `STRIPE_SECRET_KEY`     | Server | Secret key             |
+| `STRIPE_WEBHOOK_SECRET` | Server | Webhook signing secret |
+
+### Email (Resend)
+
+Transactional email credentials.
+
+| Variable            | Type   | Description                                    |
+| ------------------- | ------ | ---------------------------------------------- |
+| `RESEND_API_KEY`    | Server | Resend API key                                 |
+| `RESEND_FROM_EMAIL` | Server | From address (`Name <addr@domain>` also works) |
 
 ### App
 
 Application-level configuration.
 
-| Variable              | Type   | Description                 |
-| --------------------- | ------ | --------------------------- |
-| `NEXT_PUBLIC_APP_URL` | Public | Base URL of the application |
+| Variable              | Type   | Description                                                            |
+| --------------------- | ------ | ---------------------------------------------------------------------- |
+| `NEXT_PUBLIC_APP_URL` | Public | Base URL of the application                                            |
+| `LOG_ERROR_VERBOSITY` | Server | Optional: `minimal` \| `standard` \| `full` (defaults per environment) |
+
+### Worker (AWS Lambda)
+
+`apps/worker` does not use Vercel env or the web app's Zod schema. Its
+environment (`DATABASE_URL`) is set per-environment on the Lambda function
+configuration — see `apps/worker/README.md`.
 
 ## Type-Safe Access
 

--- a/docs/infra/aws-manual-setup.md
+++ b/docs/infra/aws-manual-setup.md
@@ -100,7 +100,7 @@ Add these to Vercel (Development environment):
 | ----------------------- | ------------------------- |
 | `AWS_ACCESS_KEY_ID`     | (stored in Vercel)        |
 | `AWS_SECRET_ACCESS_KEY` | (stored in Vercel)        |
-| `AWS_S3_BUCKET`         | `nexus-storage-files-dev` |
+| `S3_BUCKET`             | `nexus-storage-files-dev` |
 | `AWS_REGION`            | `us-east-1`               |
 
 ## SNS Topic for S3 Restore Events

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,4 +1,7 @@
 import { config } from 'dotenv';
+// Dev-only tool: the web app's .env.local is the single env source for all
+// local tooling (drizzle, seed CLI, capture, e2e). Deployed code never uses
+// this path — see docs/guides/environment-setup.md.
 config({ path: '../../apps/web/.env.local' });
 import { defineConfig } from 'drizzle-kit';
 

--- a/packages/db/src/seed/cli.ts
+++ b/packages/db/src/seed/cli.ts
@@ -1,6 +1,8 @@
 import { resolve } from 'node:path';
 import { config } from 'dotenv';
 
+// Dev-only tool: loads the web app's .env.local, the single env source for
+// all local tooling — see docs/guides/environment-setup.md.
 config({
     path: resolve(import.meta.dirname, '../../../../apps/web/.env.local'),
 });

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
     "tasks": {
         "build": {
             "dependsOn": ["^build"],
-            "outputs": [".next/**", "dist/**"]
+            "outputs": [".next/**", "dist/**"],
+            "env": ["NEXT_PUBLIC_*"]
         },
         "dev": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
Closes #292. Part of #289.

## What changed

- **Removed never-read env vars** from `apps/web/lib/env/schema.ts`: `SUPABASE_SECRET_KEY`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, `NEXT_PUBLIC_STRIPE_PUBLIC_KEY`. Verified no code reads them (no Supabase SDK or Stripe.js in the codebase). README and `docs/guides/environment-setup.md` tables updated to match.
- **`AWS_S3_BUCKET` → `S3_BUCKET`** in `docs/infra/aws-manual-setup.md`; also removed the stale `AWS_S3_BUCKET` line from my local `.env.local`.
- **Worker env story**: `apps/worker/src/handler.ts` now lazily creates the DB client and throws a descriptive error if `DATABASE_URL` is unset (was `process.env.DATABASE_URL!`). New "Environment" section in `apps/worker/README.md` documenting that Lambda env is set per-environment on the function config, not Vercel. Also fixed the README's stale claim that infra is "managed via Terraform in `infra/terraform/`" — no Terraform exists in the repo; setup is manual per `docs/infra/aws-manual-setup.md`.
- **`.env.example` synced** with the schema: added `SQS_QUEUE_URL`, dropped the removed vars, corrected the "optional" labels (AWS/Stripe are required by the schema).
- **`turbo.json`**: `build.env: ["NEXT_PUBLIC_*"]` so client-inlined vars key the build cache.
- **dotenv path assumption documented**: comments at the two hardcoded `apps/web/.env.local` load sites (`packages/db/drizzle.config.ts`, `packages/db/src/seed/cli.ts`) plus a note in `environment-setup.md`.

## Notes for reviewer

- **Turbo finding**: dry-run hash comparison showed turbo's *framework inference* was already hashing `NEXT_PUBLIC_APP_URL` for the Next.js package, so the feared stale-client-config cache hit was not live. The explicit `env` entry makes it robust (inference is implicit and can be disabled via `TURBO_FRAMEWORK_INFERENCE=false`) — verified the hash still changes with the explicit entry in place.
- **Vercel cleanup not done here**: the removed vars (`SUPABASE_SECRET_KEY`, `NEXT_PUBLIC_SUPABASE_*`, `NEXT_PUBLIC_STRIPE_PUBLIC_KEY`, `AWS_S3_BUCKET`) presumably still exist in the Vercel env store, so `pnpm env:pull` will keep re-adding them to `.env.local` (harmless — nothing validates or reads them). Deleting them from Vercel loses the stored values, so that's left as a manual step.

## Verification

- `pnpm check` — 10/10 tasks green
- `pnpm -F web test:e2e:smoke` — 37/37 (one pre-existing flaky test, `navigation.spec.ts` "admin nav items", failed once and passed on re-run; unrelated to env changes)