### PR TITLE
chore: provision prod Supabase project + split migration pipeline (#290)

### DIFF
--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -7,15 +7,25 @@ on:
 
 jobs:
     drift-check:
-        name: Check migration drift
+        name: Check migration drift (${{ matrix.env }})
         runs-on: ubuntu-latest
+        strategy:
+            # Check both DBs even if one drifts — one env's drift must not
+            # mask the other's result.
+            fail-fast: false
+            matrix:
+                include:
+                    - env: dev
+                      db-secret: DATABASE_URL
+                    - env: prod
+                      db-secret: DATABASE_URL_PROD
         steps:
             - name: Checkout
               uses: actions/checkout@v4
 
             - name: Read Node version
               id: node-version
-              run: echo "version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
@@ -29,7 +39,16 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Verify database secret is configured
+              env:
+                  DATABASE_URL: ${{ secrets[matrix.db-secret] }}
+              run: |
+                  if [ -z "$DATABASE_URL" ]; then
+                      echo "::error::secret ${{ matrix.db-secret }} is not configured (see docs/infra/supabase-manual-setup.md)"
+                      exit 1
+                  fi
+
             - name: Check migration drift
               run: pnpm -F db db:drift
               env:
-                  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+                  DATABASE_URL: ${{ secrets[matrix.db-secret] }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
     migrate:
-        name: Apply DB migrations
+        name: Apply DB migrations (dev)
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
@@ -20,7 +20,7 @@ jobs:
 
             - name: Read Node version
               id: node-version
-              run: echo "version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
@@ -38,6 +38,49 @@ jobs:
               run: pnpm -F db db:migrate
               env:
                   DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+    # Prod gates on the dev apply (same SQL against a schema-identical DB acts
+    # as a canary) but deliberately NOT on smoke-tests: e2e can fail for
+    # reasons unrelated to migrations (browsers, S3, Stripe), and gating prod
+    # on it would leave prod drifted whenever e2e flakes.
+    migrate-prod:
+        name: Apply DB migrations (prod)
+        needs: migrate
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Read Node version
+              id: node-version
+              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ steps.node-version.outputs.version }}
+                  cache: 'pnpm'
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Verify DATABASE_URL_PROD secret is configured
+              env:
+                  DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+              run: |
+                  if [ -z "$DATABASE_URL" ]; then
+                      echo "::error::secret DATABASE_URL_PROD is not configured (see docs/infra/supabase-manual-setup.md)"
+                      exit 1
+                  fi
+
+            - name: Apply migrations
+              run: pnpm -F db db:migrate
+              env:
+                  DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
 
     smoke-tests:
         name: Smoke Tests
@@ -66,7 +109,7 @@ jobs:
 
             - name: Read Node version
               id: node-version
-              run: echo "version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
@@ -82,7 +125,7 @@ jobs:
 
             - name: Get Playwright version
               id: playwright-version
-              run: echo "version=$(pnpm -F web exec playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+              run: echo "version=$(pnpm -F web exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
             - name: Cache Playwright browsers
               uses: actions/cache@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -92,7 +92,7 @@ jobs:
                         MARKER,
                         '## :warning: This PR contains DB migration(s)',
                         '',
-                        'On merge, `post-merge.yml` applies these to production before smoke tests run. If apply fails, the workflow fails loudly.',
+                        'On merge, `post-merge.yml` applies these to the dev database, then to prod once the dev apply succeeds; smoke tests run against dev. If either apply fails, the workflow fails loudly.',
                         '',
                         sqlBlocks,
                         '',

--- a/.github/workflows/s3-event-health.yml
+++ b/.github/workflows/s3-event-health.yml
@@ -16,10 +16,23 @@ permissions:
 
 jobs:
     health:
-        name: Drift + webhook/retrieval health
+        name: Drift + webhook/retrieval health (${{ matrix.env }})
         runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - env: dev
+                      db-secret: DATABASE_URL
+                    - env: prod
+                      db-secret: DATABASE_URL_PROD
+        # Only DATABASE_URL is matrixed. AWS/Stripe/etc. stay dev-scoped: no
+        # prod S3 bucket exists yet, so on prod the storage-tier check
+        # compares an empty prod DB against dev AWS credentials (trivially
+        # green). Provisioning prod AWS resources + secrets is a follow-up
+        # for when the prod bucket exists.
         env:
-            DATABASE_URL: ${{ secrets.DATABASE_URL }}
+            DATABASE_URL: ${{ secrets[matrix.db-secret] }}
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -32,6 +45,14 @@ jobs:
             BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
             NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
         steps:
+            # DATABASE_URL comes from the job env above (matrixed secret).
+            - name: Verify database secret is configured
+              run: |
+                  if [ -z "$DATABASE_URL" ]; then
+                      echo "::error::secret ${{ matrix.db-secret }} is not configured (see docs/infra/supabase-manual-setup.md)"
+                      exit 1
+                  fi
+
             - name: Checkout
               uses: actions/checkout@v4
 
@@ -61,6 +82,7 @@ jobs:
               run: pnpm -F web backfill:storage-tier --check
 
             - name: Resolve PR 278 merge time
+              if: matrix.env == 'dev'
               id: merge
               env:
                   GH_TOKEN: ${{ github.token }}
@@ -82,7 +104,7 @@ jobs:
             # PR #278 once the first real event has been processed end-to-end.
             # Remove this step after the comment lands.
             - name: Post one-time verification comment on PR 278
-              if: steps.merge.outputs.merged_at != '' && steps.health.outputs.handled_since != '' && steps.health.outputs.handled_since != '0'
+              if: matrix.env == 'dev' && steps.merge.outputs.merged_at != '' && steps.health.outputs.handled_since != '' && steps.health.outputs.handled_since != '0'
               env:
                   GH_TOKEN: ${{ github.token }}
                   HANDLED_SINCE: ${{ steps.health.outputs.handled_since }}

--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -8,11 +8,30 @@ on:
 
 jobs:
     ping:
-        name: Ping database
+        name: Ping database (${{ matrix.env }})
         runs-on: ubuntu-latest
+        strategy:
+            # Both Supabase projects are on the free (pausing) plan — ping
+            # both, and keep pinging one even if the other fails.
+            fail-fast: false
+            matrix:
+                include:
+                    - env: dev
+                      db-secret: DATABASE_URL
+                    - env: prod
+                      db-secret: DATABASE_URL_PROD
 
         steps:
+            - name: Verify database secret is configured
+              env:
+                  DATABASE_URL: ${{ secrets[matrix.db-secret] }}
+              run: |
+                  if [ -z "$DATABASE_URL" ]; then
+                      echo "::error::secret ${{ matrix.db-secret }} is not configured (see docs/infra/supabase-manual-setup.md)"
+                      exit 1
+                  fi
+
             - name: Run trivial query
               env:
-                  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+                  DATABASE_URL: ${{ secrets[matrix.db-secret] }}
               run: psql "$DATABASE_URL" -c 'select 1' -v ON_ERROR_STOP=1

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,6 +1,11 @@
 # Database (Supabase Postgres, pooled connection — port 6543)
 DATABASE_URL=postgresql://postgres:[YOUR-PASSWORD]@db.[YOUR-PROJECT].supabase.co:6543/postgres
 
+# Environment marker. Dev-tooling guard: the seed CLI (pnpm -F db db:seed)
+# refuses to run unless this is set to a non-production value. Set via
+# Vercel env (pnpm env:pull) — see docs/infra/supabase-manual-setup.md.
+DB_ENV=development
+
 # BetterAuth
 BETTER_AUTH_SECRET=your-secret-key-at-least-32-characters-long
 

--- a/docs/guides/database-workflow.md
+++ b/docs/guides/database-workflow.md
@@ -1,7 +1,7 @@
 ---
 title: Database Workflow
 created: 2025-12-30
-updated: 2025-12-30
+updated: 2026-07-05
 status: active
 tags:
     - guide
@@ -18,9 +18,9 @@ How to work with the database using Drizzle ORM.
 
 ## Environment Strategy
 
-**Single environment approach:** All development runs against the cloud Supabase database. No local database setup.
+**Two cloud databases, no local setup:** development work runs against the shared dev Supabase project; a separate prod project is migrated by CI (`post-merge.yml`) on merge to main. Local tooling never touches prod — see [[environment-setup|Environment Setup]] and [[../infra/supabase-manual-setup|Supabase Manual Setup]].
 
-- `.env.local` contains cloud credentials (pulled from Vercel)
+- `.env.local` contains cloud dev credentials (pulled from Vercel)
 - Run `pnpm env:pull` to get credentials
 - Requires internet connection for development
 

--- a/docs/guides/environment-setup.md
+++ b/docs/guides/environment-setup.md
@@ -1,7 +1,7 @@
 ---
 title: Environment Setup
 created: 2025-12-30
-updated: 2026-01-03
+updated: 2026-07-05
 status: active
 tags:
     - guide
@@ -18,15 +18,17 @@ Environment variable management and configuration strategy for Nexus.
 
 ## Overview
 
-Nexus uses a **single environment** approach for simplicity:
+Nexus runs on **two Supabase projects** — dev and prod — with a cloud-only development model:
 
-- **Cloud-only development** - Local dev connects to cloud Supabase (no local Docker)
-- **Single `.env.local`** - Contains cloud credentials pulled from Vercel
-- **Vercel as source of truth** - Variables configured once in Vercel dashboard
+- **Two databases** - A shared dev project (local dev, CI, previews, e2e) and a separate prod project used only by the Vercel Production deployment. See [[../infra/supabase-manual-setup|Supabase Manual Setup]].
+- **Cloud-only development** - Local dev connects to the cloud dev Supabase (no local Docker)
+- **Single `.env.local`** - Contains cloud **dev** credentials pulled from Vercel; local tooling never touches prod
+- **Vercel as source of truth** - Variables configured once in Vercel dashboard, per environment
 - **Type-safe validation** - Zod validates at runtime
+- **Migrations to both** - `post-merge.yml` applies migrations to dev, then to prod once the dev apply succeeds
 
 > [!note] Why cloud-only?
-> Managing multiple environment files (local, dev, staging, prod) adds complexity. For MVP, we use the cloud dev environment for all local development. This requires an internet connection but eliminates env file juggling.
+> Managing local database containers adds complexity. We use the cloud dev environment for all local development. This requires an internet connection but eliminates env file juggling. Prod is reached only by the Vercel Production deployment and by CI workflows via the `DATABASE_URL_PROD` GitHub Actions secret.
 
 ## Quick Start
 
@@ -43,7 +45,9 @@ This creates `apps/web/.env.local` with all variables from your Vercel Developme
 `apps/web/.env.local` is the single env source for all local tooling —
 `packages/db` (drizzle-kit, seed CLI), `tooling/capture`, and the e2e suite
 all load it via hardcoded relative paths. This is a deliberate dev-only
-assumption: deployed code (Vercel, Lambda) never reads `.env` files.
+assumption: deployed code (Vercel, Lambda) never reads `.env` files. Because
+it is pulled from the Vercel **Development** environment, it always points at
+the dev database — local tooling never touches prod.
 
 ## File Structure
 
@@ -61,12 +65,18 @@ apps/web/
 
 Direct PostgreSQL connection for Drizzle ORM queries.
 
-| Variable       | Type   | Description                  |
-| -------------- | ------ | ---------------------------- |
-| `DATABASE_URL` | Server | PostgreSQL connection string |
+| Variable       | Type   | Description                                                                    |
+| -------------- | ------ | ------------------------------------------------------------------------------ |
+| `DATABASE_URL` | Server | PostgreSQL connection string (dev DB locally; prod DB in Vercel Production)    |
+| `DB_ENV`       | Server | Environment marker (`development` / `production`) — fail-closed seed-CLI guard |
 
-> [!note] Connection Pooling
-> For production, use the pooled connection string (port 6543) instead of direct connection (port 5432).
+> [!warning] Connection Pooling
+> **Every environment** must use the transaction-pooler connection string (port 6543), not the direct connection (port 5432). `packages/db/src/connection.ts` sets `prepare: false` unconditionally, which assumes transaction-pooler mode.
+
+> [!note] DB_ENV guard
+> The seed CLI (`pnpm -F db db:seed`) refuses to run unless `DB_ENV` is set to a non-production value. Missing `DB_ENV` also refuses (fail-closed). Set `DB_ENV=development` in the Vercel Development environment so `pnpm env:pull` writes it into `.env.local`.
+
+The `DATABASE_URL_PROD` GitHub Actions secret (not a Vercel/app variable) points CI workflows — post-merge prod migrate, drift check, keepalive, event health — at the prod database. See [[../infra/supabase-manual-setup|Supabase Manual Setup]].
 
 ### Authentication (BetterAuth)
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started
 created: 2025-12-29
-updated: 2026-01-23
+updated: 2026-07-05
 status: active
 tags:
     - guide
@@ -27,7 +27,7 @@ git clone <repo-url>
 cd nexus
 pnpm install
 vercel link && pnpm env:pull
-pnpm -F web db:migrate
+pnpm -F db db:migrate
 pnpm dev
 ```
 
@@ -111,7 +111,7 @@ pnpm -F web db:migrate
 ```
 
 > [!note] Cloud-First Database
-> We use Supabase's cloud PostgreSQL directly—no local database container needed. Your `DATABASE_URL` points to the shared development database.
+> We use Supabase's cloud PostgreSQL directly—no local database container needed. Your `DATABASE_URL` points to the shared **development** database. Production has its own Supabase project that local tooling never touches — see [[../infra/supabase-manual-setup|Supabase Manual Setup]].
 
 See [[database-workflow|Database Workflow]] for schema changes and migration commands.
 

--- a/docs/infra/supabase-manual-setup.md
+++ b/docs/infra/supabase-manual-setup.md
@@ -32,7 +32,7 @@ Both projects are on the free (pausing) plan, so both are pinged by `.github/wor
 
 1. [Supabase dashboard](https://supabase.com/dashboard) → **New project** in the same organization as the dev project.
 2. Name: `nexus-prod`.
-3. Region: match the dev project's region (and `us-east-1` AWS resources).
+3. Region: `sa-east-1` (São Paulo) — chosen 2026-07 because the alpha testers are in Brazil. Note this deliberately differs from dev (`us-east-1`) and from the shared AWS resources; cross-region S3 latency is acceptable until prod AWS resources exist (see Follow-Ups).
 4. Generate a strong database password and store it in the password manager — it is embedded in the connection string below.
 
 No data migration is needed: prod starts empty and gets its schema from the migration pipeline (see below).
@@ -106,7 +106,7 @@ gh workflow run supabase-keepalive.yml
 ## Follow-Ups
 
 - **Repoint the Vercel production deployment** at the prod project: after setting the Production env vars above, redeploy production so it picks up the prod `DATABASE_URL`. Until then, the production deployment still points at dev.
-- **Prod AWS resources**: `s3-event-health.yml` runs its prod leg with dev AWS credentials (no prod S3 bucket exists yet — trivially green while prod is empty). Provision prod AWS resources and secrets when a prod bucket exists; see [[aws-manual-setup|AWS Manual Setup]] for the dev pattern.
+- **Prod AWS resources**: `s3-event-health.yml` runs its prod leg with dev AWS credentials (no prod S3 bucket exists yet — trivially green while prod is empty). Provision prod AWS resources and secrets when a prod bucket exists; see [[aws-manual-setup|AWS Manual Setup]] for the dev pattern. Put them in `sa-east-1` to match the prod database and the Brazilian user base — uploads go browser → S3 directly, so bucket proximity to users matters more than proximity to dev infrastructure.
 
 ## Related
 

--- a/docs/infra/supabase-manual-setup.md
+++ b/docs/infra/supabase-manual-setup.md
@@ -1,0 +1,115 @@
+---
+title: Supabase Manual Setup
+created: 2026-07-05
+updated: 2026-07-05
+status: active
+tags:
+    - infra
+    - supabase
+    - database
+aliases:
+    - Supabase Manual Setup
+ai_summary: 'Manual Supabase provisioning runbook for the dev and prod database projects'
+---
+
+# Supabase Manual Setup
+
+This documents the manual Supabase setup for the two database environments. Created 2026-07-05 (#290, part of #289).
+
+> [!important] Ordering: create the secret before merging the workflows.
+> The `DATABASE_URL_PROD` GitHub Actions secret must exist **before** merging the PR that adds the prod workflow jobs (#290). Each prod-touching workflow starts with a preflight guard that fails fast — loudly, by design — when the secret resolves empty, so the first post-merge run after that PR fails until the secret is set.
+
+## Projects
+
+| Project       | Purpose                                              | Plan           |
+| ------------- | ---------------------------------------------------- | -------------- |
+| `nexus` (dev) | Shared development DB — local dev, CI, previews, e2e | Free (pausing) |
+| `nexus-prod`  | Production DB — Vercel Production deployment only    | Free (pausing) |
+
+Both projects are on the free (pausing) plan, so both are pinged by `.github/workflows/supabase-keepalive.yml` (Mon + Thu) to stay within Supabase's ~7-day inactivity window. Nightly migration drift (`migration-drift.yml`) and the S3 event-health DB checks (`s3-event-health.yml`) also run against both.
+
+## Create the Prod Project
+
+1. [Supabase dashboard](https://supabase.com/dashboard) → **New project** in the same organization as the dev project.
+2. Name: `nexus-prod`.
+3. Region: match the dev project's region (and `us-east-1` AWS resources).
+4. Generate a strong database password and store it in the password manager — it is embedded in the connection string below.
+
+No data migration is needed: prod starts empty and gets its schema from the migration pipeline (see below).
+
+## Connection String — Transaction Pooler (Port 6543) Required
+
+Dashboard → **Connect** → **Transaction pooler**. The URI looks like:
+
+```
+postgresql://postgres.[PROJECT-REF]:[PASSWORD]@aws-0-[REGION].pooler.supabase.com:6543/postgres
+```
+
+> [!warning] Port 6543 is load-bearing, not a preference.
+> `packages/db/src/connection.ts` sets `prepare: false` unconditionally because Supabase's transaction-mode pooler does not support prepared statements — statements can land on different pooled backends, which intermittently loses transactions. **Both dev and prod `DATABASE_URL`s must be transaction-pooler URLs (port 6543).** Do not use the direct connection (5432) or session pooler.
+
+## GitHub Actions Secret
+
+The existing `DATABASE_URL` secret stays pointed at **dev** (no rename). Add the prod pooler URL as a new secret:
+
+```bash
+gh secret set DATABASE_URL_PROD --app actions
+# paste the prod transaction-pooler URL when prompted
+```
+
+Consumed by:
+
+- `post-merge.yml` — `migrate-prod` job applies migrations to prod after the dev apply succeeds
+- `migration-drift.yml` — nightly drift check (prod matrix leg)
+- `supabase-keepalive.yml` — keepalive ping (prod matrix leg)
+- `s3-event-health.yml` — DB health checks (prod matrix leg)
+
+## Vercel Environment Variables
+
+| Vercel environment | Variable       | Value                              |
+| ------------------ | -------------- | ---------------------------------- |
+| Production         | `DATABASE_URL` | prod transaction-pooler URL (6543) |
+| Production         | `DB_ENV`       | `production`                       |
+| Development        | `DB_ENV`       | `development`                      |
+
+`DB_ENV` is the fail-closed marker for dev tooling: the seed CLI (`pnpm -F db db:seed`) refuses to run unless `DB_ENV` is set to a non-production value. Setting `DB_ENV=development` in the Vercel **Development** environment means `pnpm env:pull` writes it into `apps/web/.env.local` automatically. The dev `DATABASE_URL` in Vercel Development is unchanged.
+
+## Apply the Initial Schema
+
+Prod gets its schema from the same migration pipeline as dev. Either:
+
+```bash
+# Preferred: run the post-merge workflow (migrates dev, then prod)
+gh workflow run post-merge.yml
+```
+
+or one-off from a local shell:
+
+```bash
+DATABASE_URL='<prod-pooler-url>' pnpm -F db db:migrate
+```
+
+## Verification
+
+```bash
+# Connectivity (same query the keepalive workflow runs)
+psql '<prod-pooler-url>' -c 'select 1' -v ON_ERROR_STOP=1
+
+# Migration journal matches the repo
+DATABASE_URL='<prod-pooler-url>' pnpm -F db db:drift
+
+# Workflows see the secret (prod legs should be green)
+gh workflow run migration-drift.yml
+gh workflow run supabase-keepalive.yml
+```
+
+## Follow-Ups
+
+- **Repoint the Vercel production deployment** at the prod project: after setting the Production env vars above, redeploy production so it picks up the prod `DATABASE_URL`. Until then, the production deployment still points at dev.
+- **Prod AWS resources**: `s3-event-health.yml` runs its prod leg with dev AWS credentials (no prod S3 bucket exists yet — trivially green while prod is empty). Provision prod AWS resources and secrets when a prod bucket exists; see [[aws-manual-setup|AWS Manual Setup]] for the dev pattern.
+
+## Related
+
+- [[aws-manual-setup|AWS Manual Setup]]
+- [[../guides/environment-setup|Environment Setup]]
+- [[../guides/database-workflow|Database Workflow]]

--- a/packages/db/scripts/check-drift.mjs
+++ b/packages/db/scripts/check-drift.mjs
@@ -34,7 +34,9 @@ try {
     console.error(
         `DRIFT: repo has ${expected} migrations in _journal.json, DB has ${applied} applied.`
     );
-    console.error('Run `pnpm -F db db:migrate` against the prod DB.');
+    console.error(
+        'Run `pnpm -F db db:migrate` with DATABASE_URL pointed at this database.'
+    );
     process.exit(1);
 } finally {
     await sql.end();

--- a/packages/db/src/seed/cli.ts
+++ b/packages/db/src/seed/cli.ts
@@ -8,6 +8,7 @@ config({
 });
 
 import { createDb } from '../connection';
+import { checkSeedEnv } from './envGuard';
 import {
     SCENARIO_DEFINITIONS,
     runScenario,
@@ -18,6 +19,12 @@ import {
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
     console.error('DATABASE_URL is not set. Check apps/web/.env.local exists.');
+    process.exit(1);
+}
+
+const guard = checkSeedEnv(process.env.DB_ENV);
+if (!guard.isOk) {
+    console.error(guard.message);
     process.exit(1);
 }
 

--- a/packages/db/src/seed/envGuard.test.ts
+++ b/packages/db/src/seed/envGuard.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { checkSeedEnv } from './envGuard';
+
+describe('checkSeedEnv', () => {
+    it('refuses when DB_ENV is undefined', () => {
+        const result = checkSeedEnv(undefined);
+        expect(result.isOk).toBe(false);
+        if (!result.isOk) {
+            expect(result.message).toContain('DB_ENV is not set');
+            expect(result.message).toContain('DB_ENV=development');
+        }
+    });
+
+    it('refuses when DB_ENV is an empty string', () => {
+        const result = checkSeedEnv('');
+        expect(result.isOk).toBe(false);
+    });
+
+    it('refuses when DB_ENV is only whitespace', () => {
+        const result = checkSeedEnv('   ');
+        expect(result.isOk).toBe(false);
+    });
+
+    it('refuses when DB_ENV is production', () => {
+        const result = checkSeedEnv('production');
+        expect(result.isOk).toBe(false);
+        if (!result.isOk) {
+            expect(result.message).toContain('refusing to seed');
+        }
+    });
+
+    it('refuses production regardless of case and surrounding whitespace', () => {
+        expect(checkSeedEnv(' Production ').isOk).toBe(false);
+        expect(checkSeedEnv('PRODUCTION').isOk).toBe(false);
+    });
+
+    it('allows development', () => {
+        expect(checkSeedEnv('development').isOk).toBe(true);
+    });
+
+    it('allows other non-production values', () => {
+        expect(checkSeedEnv('preview').isOk).toBe(true);
+        expect(checkSeedEnv('test').isOk).toBe(true);
+    });
+});

--- a/packages/db/src/seed/envGuard.ts
+++ b/packages/db/src/seed/envGuard.ts
@@ -1,0 +1,34 @@
+export type SeedEnvCheck = { isOk: true } | { isOk: false; message: string };
+
+/**
+ * Fail-closed environment guard for the seed CLI.
+ *
+ * The seed CLI mutates whatever database DATABASE_URL points at, so it
+ * refuses to run unless DB_ENV explicitly marks the environment as
+ * non-production. Missing DB_ENV refuses (fail-closed) rather than assuming
+ * dev — see docs/guides/environment-setup.md.
+ */
+export function checkSeedEnv(dbEnv: string | undefined): SeedEnvCheck {
+    const normalized = dbEnv?.trim().toLowerCase();
+
+    if (!normalized) {
+        return {
+            isOk: false,
+            message:
+                'DB_ENV is not set. The seed CLI refuses to run without an explicit ' +
+                'environment marker.\n' +
+                'Set DB_ENV=development in apps/web/.env.local to seed the dev database.',
+        };
+    }
+
+    if (normalized === 'production') {
+        return {
+            isOk: false,
+            message:
+                'DB_ENV=production — refusing to seed a production database. ' +
+                'Seed data must never be written to prod.',
+        };
+    }
+
+    return { isOk: true };
+}


### PR DESCRIPTION
## Summary

Splits the migration pipeline off the single shared Supabase DB in preparation for a dedicated production project. Prod provisioning itself is manual (no Terraform in this repo yet); this PR ships the runbook, the workflow wiring against a new `DATABASE_URL_PROD` secret, and a fail-closed guard so seed data can never land in prod.

Closes #290

## Changes

- **New runbook** `docs/infra/supabase-manual-setup.md` (mirrors the AWS one): create the prod project, transaction-pooler (port 6543) connection string (required — `createDb` sets `prepare: false` unconditionally), `gh secret set DATABASE_URL_PROD`, Vercel Production env (`DATABASE_URL`, `DB_ENV=production`) and Development env (`DB_ENV=development`), initial schema, verification. Callout: the secret must exist **before** merging this PR.
- **post-merge.yml**: existing migrate job stays on dev; new `migrate-prod` job (`needs: migrate`) applies to prod via `DATABASE_URL_PROD`. Dev acts as a canary — broken SQL fails on dev before touching prod. Smoke tests stay pinned to dev (prod is empty; e2e mutates data) and don't gate prod migration (e2e flakiness shouldn't cause prod schema drift).
- **migration-drift.yml, supabase-keepalive.yml, s3-event-health.yml**: matrixed over dev/prod via `secrets[matrix.db-secret]`, `fail-fast: false`. Both Supabase projects are on the free (pausing) plan, so keepalive pings both. s3-event-health's AWS secrets stay dev-scoped (no prod bucket yet — noted in a comment); its one-time PR-278 steps are gated to the dev leg.
- **Preflight secret guards** in all four prod-touching workflows: a missing secret resolves to an empty string in Actions, so each job fails fast with an actionable `::error::` instead of an opaque connection error.
- **Seed guard (fail-closed)**: `pnpm -F db db:seed` refuses unless `DB_ENV` is an explicit non-production value — missing marker refuses, `production` refuses loudly. Pure `checkSeedEnv` in `packages/db/src/seed/envGuard.ts` + 7 unit tests. `DB_ENV=development` added to `.env.example`; deliberately not added to `apps/web/lib/env/schema.ts` (no app-runtime consumer).
- **Docs**: `environment-setup.md` rewritten off the "single environment" framing (local tooling still always targets dev); `getting-started.md` and `database-workflow.md` updated minimally; pr-check migration-flag comment now describes the dev→prod apply order.
- Incidental: `check-drift.mjs` error message generalized (it now runs against both DBs); `$GITHUB_OUTPUT` quoting fixes (pre-existing shellcheck findings in the two files already being edited, needed for actionlint-clean).

Follow-up filed: #297 (extract the repeated checkout/node/pnpm boilerplate into a composite action).

## Test Plan

- [ ] `pnpm check` green (10/10 tasks)
- [ ] `pnpm -F db test` — 74 passed, incl. 7 new `envGuard` tests
- [ ] `actionlint` clean on all five changed workflows
- [ ] After creating `DATABASE_URL_PROD`: dispatch `post-merge.yml` and confirm `migrate-prod` applies the schema; dispatch `migration-drift.yml` and confirm both legs green
- [ ] Before the secret exists, the prod legs fail on the preflight guard with an actionable message (by design)

## Evidence

Seed guard driven independently (not by the implementing agent), exact output and exit codes:

**`DB_ENV=production` → refuses, exit 1**
```
DB_ENV=production — refusing to seed a production database. Seed data must never be written to prod.
```

**`DB_ENV` unset (the real current state of `.env.local`) → refuses, exit 1**
```
DB_ENV is not set. The seed CLI refuses to run without an explicit environment marker.
Set DB_ENV=development in apps/web/.env.local to seed the dev database.
```

**`DB_ENV=development` → runs read-only summary against dev, exit 0**
```
Current seed data:
  Users: 0
  Files: 0
  Subscriptions: 0
  Retrievals: 0
```

Checks (re-run by the coordinator after the final fix round):
```
✓ All checks passed 10/10 tasks
Tests: 74 passed (7 files)
actionlint post-merge.yml migration-drift.yml supabase-keepalive.yml s3-event-health.yml pr-check.yml → OK
```