### PR TITLE
fix: create one upload batch per session, not per file (#268)

### DIFF
--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -76,6 +76,9 @@ interface InternalUploadFile extends UploadFile {
     // Identity field a reopened handle must match before we trust it to resume.
     lastModified?: number;
     fileId?: string;
+    // Session batch the file belongs to — set once per Upload click and kept
+    // across failures so a retry/resume rejoins the same batch.
+    batchId?: string;
     uploadId?: string;
     chunkSize?: number;
     totalParts?: number;
@@ -99,6 +102,9 @@ export function useUpload() {
     const invalidateFileList = useInvalidateFileList();
 
     const uploadMutation = useMutation(trpc.files.upload.mutationOptions());
+    const createBatchMutation = useMutation(
+        trpc.files.createBatch.mutationOptions()
+    );
     const confirmMutation = useMutation(
         trpc.files.confirmUpload.mutationOptions()
     );
@@ -128,9 +134,13 @@ export function useUpload() {
     );
 
     const uploadSingleFile = useCallback(
-        async (uploadFile: InternalUploadFile) => {
+        // batchId is threaded explicitly (not read back via filesRef) because a
+        // just-issued updateFile isn't visible until the next render commit.
+        // Callers without a session batch (retry) fall back to the row's own.
+        async (uploadFile: InternalUploadFile, batchId?: string) => {
             const file = uploadFile.file;
             if (!file) return;
+            const sessionBatchId = batchId ?? uploadFile.batchId;
             const abortController = new AbortController();
             updateFile(uploadFile.id, {
                 status: 'uploading',
@@ -142,6 +152,7 @@ export function useUpload() {
                     name: file.name,
                     sizeBytes: file.size,
                     mimeType: file.type || undefined,
+                    batchId: sessionBatchId,
                 });
 
                 updateFile(uploadFile.id, { fileId });
@@ -183,9 +194,13 @@ export function useUpload() {
     );
 
     const uploadMultipartFile = useCallback(
-        async (uploadFile: InternalUploadFile) => {
+        // Same explicit batchId threading as uploadSingleFile; only the
+        // fresh-start branch uses it (a resume already committed membership
+        // server-side at the original init).
+        async (uploadFile: InternalUploadFile, batchId?: string) => {
             const file = uploadFile.file;
             if (!file) return;
+            const sessionBatchId = batchId ?? uploadFile.batchId;
 
             const abortController = new AbortController();
             updateFile(uploadFile.id, {
@@ -212,6 +227,7 @@ export function useUpload() {
                         name: file.name,
                         sizeBytes: file.size,
                         mimeType: file.type || undefined,
+                        batchId: sessionBatchId,
                     });
                     fileId = result.fileId;
                     uploadId = result.uploadId;
@@ -238,12 +254,15 @@ export function useUpload() {
                         // Persist the handle (when we have one) so an interruption
                         // is zero-touch resumable, not just re-add resumable.
                         fileHandle: uploadFile.fileHandle,
+                        // Persist the batch so a post-reload resume rejoins it.
+                        batchId: sessionBatchId,
                     });
                     updateFile(uploadFile.id, {
                         fileId,
                         uploadId,
                         chunkSize,
                         totalParts,
+                        batchId: sessionBatchId,
                     });
                 } else {
                     // Resume: reconcile against S3 (authoritative even if local
@@ -422,15 +441,34 @@ export function useUpload() {
     );
 
     const runUpload = useCallback(
-        (uploadFile: InternalUploadFile) =>
+        (uploadFile: InternalUploadFile, batchId?: string) =>
             uploadFile.size >= MULTIPART_THRESHOLD
-                ? uploadMultipartFile(uploadFile)
-                : uploadSingleFile(uploadFile),
+                ? uploadMultipartFile(uploadFile, batchId)
+                : uploadSingleFile(uploadFile, batchId),
         [uploadMultipartFile, uploadSingleFile]
     );
 
     const processQueue = useCallback(async () => {
         setIsUploading(true);
+
+        // One batch per Upload click: every pending file in this pass joins
+        // it, so a multi-file selection lands in a single upload_batches row.
+        // Created fresh per invocation — files queued later get a new batch on
+        // the next click. On failure we proceed without an id and each file
+        // falls back to the server's auto-created single-file batch.
+        let batchId: string | undefined;
+        // Rows that already have a batch (retries, re-added resumables) keep
+        // it, so only mint a session batch when some file still needs one.
+        const hasPending = filesRef.current.some(
+            (f) => f.status === 'pending' && f.file && !f.batchId
+        );
+        if (hasPending) {
+            try {
+                ({ batchId } = await createBatchMutation.mutateAsync());
+            } catch {
+                batchId = undefined;
+            }
+        }
 
         for (const file of filesRef.current) {
             if (file.status !== 'pending') continue;
@@ -441,11 +479,17 @@ export function useUpload() {
                 continue;
             }
 
-            await runUpload(current);
+            // Retried/resumed rows keep their original batch; only rows
+            // without one join this session's batch. Written to the row for
+            // retry/persistence, but threaded to runUpload explicitly — the
+            // ref won't reflect this update until the next render commit.
+            const rowBatchId = current.batchId ?? batchId;
+            updateFile(current.id, { batchId: rowBatchId });
+            await runUpload(current, rowBatchId);
         }
 
         setIsUploading(false);
-    }, [runUpload]);
+    }, [runUpload, createBatchMutation, updateFile]);
 
     // Surface interrupted uploads found in IndexedDB on mount as `resumable`
     // rows. Records that persisted a File System Access handle (and run on a
@@ -480,6 +524,7 @@ export function useUpload() {
                         fileHandle: r.fileHandle,
                         lastModified: r.lastModified,
                         fileId: r.fileId,
+                        batchId: r.batchId,
                         uploadId: r.uploadId,
                         chunkSize: r.chunkSize,
                         totalParts: r.totalParts,
@@ -572,6 +617,7 @@ export function useUpload() {
                         file,
                         fileHandle: handle,
                         fileId: match.fileId,
+                        batchId: match.batchId,
                         uploadId: match.uploadId,
                         chunkSize: match.chunkSize,
                         totalParts: match.totalParts,

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -314,6 +314,13 @@ export const USE_CASES: UseCaseEntry[] = [
         manual: 'Writes real S3 objects + DB rows in the dev environment; exercised by the validate tier',
     },
     {
+        id: 'upload-multi-file-single-batch',
+        title: 'Multi-file upload in one click creates a single batch',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+        manual: 'Writes real S3 objects + DB rows in the dev environment; exercised by the validate tier',
+    },
+    {
         id: 'upload-batch-grouping',
         title: 'Upload creates a batch visible on the files page',
         area: 'upload',

--- a/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
+++ b/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
@@ -14,6 +14,8 @@
  *    with fallback name `Upload YYYY-MM-DD HH:MM`, `files.batch_id` set,
  *    `storage_usage` incremented by the file's bytes.
  *  - Dashboard "Storage Usage" widget renders after the upload.
+ *  - Multi-file upload in one click (#268): both files land in a single
+ *    `upload_batches` row and share the `${userId}/${batchId}/` key prefix.
  *  - Quota soft cap: with `storage_usage` parked at 105%, attempting an
  *    upload through the UI surfaces an error and creates no DB row.
  *
@@ -165,6 +167,94 @@ test.describe('upload batches + storage quota', () => {
                 path: `${SCREENSHOTS}/05-grouped-files-page.png`,
                 fullPage: true,
             });
+        }
+    );
+
+    test(
+        'multi-file upload in one click creates a single shared batch',
+        {
+            tag: [
+                '@page:/dashboard/upload',
+                '@uc:upload-multi-file-single-batch',
+            ],
+        },
+        async ({ page, db, seedUserId: userId }) => {
+            // Reset so "exactly one batch" is a strict assertion rather than a
+            // delta over the single-file test's leftover batch. Runs before
+            // the quota test, which re-parks usage itself.
+            await resetUserState(db, userId);
+
+            await page.goto('/dashboard/upload');
+            await expect(
+                page.getByRole('heading', { name: 'Upload Files', exact: true })
+            ).toBeVisible();
+
+            const stamp = Date.now();
+            const filesToUpload = [
+                {
+                    name: `validate-multi-a-${stamp}.txt`,
+                    mimeType: 'text/plain',
+                    buffer: Buffer.from('multi-file batch validate: file a\n'),
+                },
+                {
+                    name: `validate-multi-b-${stamp}.txt`,
+                    mimeType: 'text/plain',
+                    buffer: Buffer.from('multi-file batch validate: file b!\n'),
+                },
+            ];
+
+            await page.setInputFiles('input[type="file"]', filesToUpload);
+            await expect(page.getByText('Selected Files (2)')).toBeVisible();
+            await page.screenshot({
+                path: `${SCREENSHOTS}/06-multi-after-select.png`,
+                fullPage: true,
+            });
+
+            await page
+                .getByRole('button', { name: /^Upload \d+ files?$/ })
+                .click();
+            await expect(
+                page.getByText('Uploaded', { exact: true })
+            ).toHaveCount(2, { timeout: 30_000 });
+            await page.screenshot({
+                path: `${SCREENSHOTS}/07-multi-after-upload.png`,
+                fullPage: true,
+            });
+
+            // ---- DB assertions ----
+            // One click → one batch (not one per file, the #268 regression).
+            const batches = await db.query.uploadBatches.findMany({
+                where: (b, { eq }) => eq(b.userId, userId),
+            });
+            expect(batches).toHaveLength(1);
+            const batch = batches[0];
+            expect(batch.name).toMatch(
+                /^Upload \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/
+            );
+
+            const names = filesToUpload.map((f) => f.name);
+            const files = await db.query.files.findMany({
+                where: (f, { eq, and, inArray }) =>
+                    and(eq(f.userId, userId), inArray(f.name, names)),
+            });
+            expect(files).toHaveLength(2);
+            for (const file of files) {
+                expect(file.status).toBe('available');
+                expect(file.batchId).toBe(batch.id);
+                expect(file.s3Key).toBe(
+                    `${userId}/${batch.id}/${file.id}/${file.name}`
+                );
+            }
+
+            const totalBytes = filesToUpload.reduce(
+                (sum, f) => sum + f.buffer.byteLength,
+                0
+            );
+            const usage = await db.query.storageUsage.findFirst({
+                where: (u, { eq }) => eq(u.userId, userId),
+            });
+            expect(usage?.usedBytes).toBe(totalBytes);
+            expect(usage?.fileCount).toBe(2);
         }
     );
 

--- a/apps/web/lib/upload/uploadStore.test.ts
+++ b/apps/web/lib/upload/uploadStore.test.ts
@@ -59,6 +59,12 @@ describe('uploadStore', () => {
         expect((await getUpload('file-1'))?.fileHandle).toEqual(fileHandle);
     });
 
+    it('round-trips a persisted batchId', async () => {
+        await putUpload(makeRecord({ batchId: 'batch-1' }));
+
+        expect((await getUpload('file-1'))?.batchId).toBe('batch-1');
+    });
+
     it('lists all records', async () => {
         await putUpload(makeRecord({ fileId: 'a' }));
         await putUpload(makeRecord({ fileId: 'b' }));

--- a/apps/web/lib/upload/uploadStore.ts
+++ b/apps/web/lib/upload/uploadStore.ts
@@ -33,6 +33,11 @@ export interface ResumableUpload {
     completedParts: CompletedPart[];
     createdAt: number;
     updatedAt: number;
+    // Session batch the file joined at init, so a retry/resume after reload
+    // rejoins the original batch instead of falling back to a new one.
+    // Optional plain field (not an index) — no DB_VERSION bump needed; absent
+    // on pre-batch records.
+    batchId?: string;
     // Chromium-only: the File System Access handle for zero-touch resume. It's
     // structured-cloneable, so IndexedDB persists it directly — no schema bump.
     // Absent on other browsers and pre-handle records, which fall back to re-add.

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -229,6 +229,26 @@ describe('files service', () => {
         });
     });
 
+    describe('createBatch', () => {
+        it('inserts a batch with the fallback name and returns its id', async () => {
+            const batch = createUploadBatchFixture();
+            mocks.returning.mockResolvedValueOnce([batch]);
+
+            const result = await fileService.createBatch(db, TEST_USER_ID);
+
+            expect(result).toEqual({ batchId: batch.id });
+            expect(mocks.insert).toHaveBeenCalledTimes(1);
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: TEST_USER_ID,
+                    name: expect.stringMatching(
+                        /^Upload \d{4}-\d{2}-\d{2} \d{2}:\d{2}$/
+                    ),
+                })
+            );
+        });
+    });
+
     describe('formatFallbackBatchName', () => {
         it('formats UTC timestamp at minute precision', () => {
             // 2026-05-08T14:32:11.000Z

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -2,7 +2,10 @@ import type { DB } from '@nexus/db';
 import { createFileRepo, type File } from '@nexus/db/repo/files';
 import { createStorageUsageRepo } from '@nexus/db/repo/storage-usage';
 import type { Subscription } from '@nexus/db/repo/subscriptions';
-import { createUploadBatchRepo } from '@nexus/db/repo/uploadBatches';
+import {
+    createUploadBatchRepo,
+    type UploadBatch,
+} from '@nexus/db/repo/uploadBatches';
 import { NotFoundError, InvalidStateError } from '@/server/errors';
 import { s3 } from '@/lib/storage';
 import { quotaService } from './quota';
@@ -29,25 +32,45 @@ export function formatFallbackBatchName(date: Date): string {
     return `Upload ${iso.slice(0, 10)} ${iso.slice(11, 16)}`;
 }
 
+// Single insert point for new batches; the name falls back to the timestamp
+// label when the caller doesn't supply one.
+async function insertBatch(
+    db: DB,
+    userId: string,
+    name?: string
+): Promise<UploadBatch> {
+    const batchRepo = createUploadBatchRepo(db);
+    return batchRepo.insert({
+        id: crypto.randomUUID(),
+        userId,
+        name: name ?? formatFallbackBatchName(new Date()),
+    });
+}
+
 async function resolveBatchId(
     db: DB,
     userId: string,
     input: UploadInput
 ): Promise<string> {
-    const batchRepo = createUploadBatchRepo(db);
     if (input.batchId) {
+        const batchRepo = createUploadBatchRepo(db);
         const existing = await batchRepo.findByUserAndId(userId, input.batchId);
         if (!existing) {
             throw new NotFoundError('UploadBatch', input.batchId);
         }
         return existing.id;
     }
-    const batch = await batchRepo.insert({
-        id: crypto.randomUUID(),
-        userId,
-        name: input.batchName ?? formatFallbackBatchName(new Date()),
-    });
-    return batch.id;
+    return (await insertBatch(db, userId, input.batchName)).id;
+}
+
+interface CreateBatchResult {
+    batchId: string;
+}
+
+// Pre-create a session batch so every file in a multi-file upload joins the
+// same batch (the per-file initiate calls pass this id back as input.batchId).
+async function createBatch(db: DB, userId: string): Promise<CreateBatchResult> {
+    return { batchId: (await insertBatch(db, userId)).id };
 }
 
 interface InitiateUploadResult {
@@ -391,6 +414,7 @@ async function deleteUserFile(
 }
 
 export const fileService = {
+    createBatch,
     initiateUpload,
     confirmUpload,
     initiateMultipartUpload,

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -89,6 +89,12 @@ export const filesRouter = router({
             return fileRepo.findByUserAndId(ctx.session.user.id, input.id);
         }),
 
+    // Pre-create a session batch (fallback-named) so a multi-file upload can
+    // pass one batchId to every per-file initiate call.
+    createBatch: protectedProcedure.mutation(({ ctx }) =>
+        fileService.createBatch(ctx.db, ctx.session.user.id)
+    ),
+
     upload: protectedProcedure
         .input(uploadInputSchema)
         .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary

Uploading N files in one click was creating N single-file `upload_batches` rows because the upload client never passed `batchId` — every file took the server's per-file fallback in `resolveBatchId`. The fix is client-side per the issue's decisions: `processQueue` now pre-creates one batch per Upload click via a new no-input `files.createBatch` mutation and threads the returned `batchId` through every file's initiate call. The id is stored on the in-memory queue row (so retries rejoin their batch) and persisted in the IndexedDB `ResumableUpload` record (so resume-after-reload keeps membership). If `createBatch` fails, uploads proceed without a `batchId` and degrade to today's per-file server fallback.

Closes #268

## Changes

- `apps/web/server/services/files.ts` — new `createBatch(db, userId)` returning `{ batchId }`; shared `insertBatch` helper now backs both it and `resolveBatchId`'s fallback branch (same fallback name via `formatFallbackBatchName`)
- `apps/web/server/trpc/routers/files.ts` — `files.createBatch` mutation, no input, thin delegation
- `apps/web/components/dashboard/useUpload.ts` — one batch minted per `processQueue` invocation (only when batch-less pending files exist), threaded as an explicit argument to avoid the `filesRef` render-commit staleness race; `batchId` on `InternalUploadFile`; rows keep their original batch on retry/re-add (`current.batchId ?? sessionBatchId`)
- `apps/web/lib/upload/uploadStore.ts` — optional `batchId` on `ResumableUpload` (plain field, no `DB_VERSION` bump), written at multipart init and rehydrated on mount + re-add
- Unit tests: `createBatch` service (insert shape, fallback-name regex) and `uploadStore` `batchId` round-trip
- `apps/web/e2e/validate/upload-batches-and-quota.spec.ts` — new multi-file case asserting exactly one batch row, both files sharing `batchId` and the `${userId}/${batchId}/` s3Key prefix (placed serial-safe before the quota test, with its own state reset)
- `apps/web/e2e/coverage/manifest.ts` — registered `upload-multi-file-single-batch` (validate tier, `manual:` acknowledgment)

Known edge (accepted per issue's fallback decision): if `createBatch` succeeds but every file initiate then fails (e.g. quota), one empty batch row is orphaned — it never renders (grouping joins from file rows), and a later successful retry reclaims it.

## Test Plan

- [x] `pnpm check` green (lint + build + unit)
- [x] `pnpm -F web test:e2e:smoke` 38/38, `pnpm -F web test:e2e:flows` 21/21, `pnpm -F web e2e:coverage --check` 100%
- [ ] Post-merge: run the new validate case (`upload-multi-file-single-batch`) via `/validate` against dev — the validate tier is destructive and was deliberately not run here

## Evidence

Captured independently of the implementing agent via a temporary Playwright spec (dark mode, tRPC `files.upload` intercepted at the network layer — flows-tier pattern, no S3 writes pre-merge). Observed payloads:

- Session 1 (one click, two files): both `files.upload` payloads carried `batchId 758091c9-02fe-42b0-a2a9-6c5b9c2aa788`
- Session 2 (second click, two new files): both carried a **new** id `4b6a3629-51d5-4838-86df-9c3b52460274`
- Retry of a session-1 file: re-fired with the **original** `758091c9…`

https://github.com/user-attachments/assets/52d1e586-a8c2-4172-bf69-5369ec280211

Two files queued for a single Upload click:

![two files queued, one Upload 2 files button](https://github.com/user-attachments/assets/f5a03069-fa0b-45f4-854f-ab0ff2d765a2)

File list rendering a two-file session as one group with one Restore batch button (DB seeded with the post-fix shape: one batch, two files):

![one group with one Restore batch button](https://github.com/user-attachments/assets/e4b3c15c-2cd0-4f23-9fd9-f47f68ea9197)