### PR TITLE
feat: mark unhandled webhook events instead of silent success (#281)

### DIFF
--- a/apps/web/app/api/webhooks/s3-restore/route.integration.test.ts
+++ b/apps/web/app/api/webhooks/s3-restore/route.integration.test.ts
@@ -385,9 +385,10 @@ describe('POST /api/webhooks/s3-restore', () => {
         }
     });
 
-    it('handles unknown event types gracefully', async () => {
-        const messageId = `unknown-event-${crypto.randomUUID()}`;
+    it('marks expected-unhandled event types as processed', async () => {
+        const messageId = `allowlisted-event-${crypto.randomUUID()}`;
 
+        // ObjectRestore:Post fires on every restore initiation — allowlisted
         const body = createSnsNotification(
             messageId,
             'ObjectRestore:Post',
@@ -406,8 +407,33 @@ describe('POST /api/webhooks/s3-restore', () => {
         });
         if (webhookRecord) createdWebhookEventIds.push(webhookRecord.id);
 
-        // Event should still be recorded and marked as processed
         expect(webhookRecord).toBeDefined();
         expect(webhookRecord!.status).toBe('processed');
+    });
+
+    it('marks truly unknown event types as unhandled', async () => {
+        const messageId = `unknown-event-${crypto.randomUUID()}`;
+
+        const body = createSnsNotification(
+            messageId,
+            'ObjectCreated:Put',
+            'some/unknown/key'
+        );
+
+        const res = await postWebhook(body);
+        expect(res.status).toBe(200);
+
+        // Track for cleanup
+        const webhookRecord = await db.query.webhookEvents.findFirst({
+            where: and(
+                eq(webhookEvents.source, 'sns'),
+                eq(webhookEvents.externalId, messageId)
+            ),
+        });
+        if (webhookRecord) createdWebhookEventIds.push(webhookRecord.id);
+
+        // Recorded and surfaced as unhandled — but still a 200 response
+        expect(webhookRecord).toBeDefined();
+        expect(webhookRecord!.status).toBe('unhandled');
     });
 });

--- a/apps/web/app/api/webhooks/s3-restore/route.ts
+++ b/apps/web/app/api/webhooks/s3-restore/route.ts
@@ -88,19 +88,32 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
 
     try {
+        let hasUnhandledRecord = false;
         for (const record of s3Event.Records ?? []) {
             const isHandled = await s3RestoreService.dispatch(db, record);
 
             if (!isHandled) {
-                log.debug(
-                    { eventName: record.eventName },
-                    'Unhandled S3 event type'
-                );
+                if (
+                    s3RestoreService.expectedUnhandledEvents.has(
+                        record.eventName
+                    )
+                ) {
+                    log.debug(
+                        { eventName: record.eventName },
+                        'Expected-unhandled S3 event type'
+                    );
+                } else {
+                    hasUnhandledRecord = true;
+                    log.warn(
+                        { eventName: record.eventName },
+                        'Unhandled S3 event type'
+                    );
+                }
             }
         }
 
         await webhookRepo.update(webhookEvent.id, {
-            status: 'processed',
+            status: hasUnhandledRecord ? 'unhandled' : 'processed',
         });
 
         log.info(

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -67,6 +67,9 @@ describe('POST /api/webhooks/stripe', () => {
         // mockResolvedValue defaults set in createMockDb (e.g. returning -> []).
         mocks.returning.mockResolvedValue([]);
         mocks.webhookEvents.findFirst.mockResolvedValue(undefined);
+        // Dispatch resolves handled by default; tests override for the
+        // unhandled/failed outcomes.
+        dispatchWebhookEvent.mockResolvedValue(true);
     });
 
     afterEach(() => {
@@ -188,7 +191,7 @@ describe('POST /api/webhooks/stripe', () => {
                 error: 'previous downstream error',
             });
             mocks.webhookEvents.findFirst.mockResolvedValue(failedRecord);
-            dispatchWebhookEvent.mockResolvedValue(undefined);
+            dispatchWebhookEvent.mockResolvedValue(true);
 
             const response = await POST(makeRequest(sampleEvent));
 
@@ -208,7 +211,7 @@ describe('POST /api/webhooks/stripe', () => {
                     status: 'received',
                 })
             );
-            dispatchWebhookEvent.mockResolvedValue(undefined);
+            dispatchWebhookEvent.mockResolvedValue(true);
 
             const response = await POST(makeRequest(sampleEvent));
 
@@ -259,7 +262,7 @@ describe('POST /api/webhooks/stripe', () => {
         });
 
         it('marks event processed and returns 200 on success', async () => {
-            dispatchWebhookEvent.mockResolvedValue(undefined);
+            dispatchWebhookEvent.mockResolvedValue(true);
 
             const response = await POST(makeRequest(sampleEvent));
 
@@ -267,6 +270,22 @@ describe('POST /api/webhooks/stripe', () => {
             await expect(response.json()).resolves.toEqual({ received: true });
             expect(mocks.update).toHaveBeenCalled();
             expect(mocks.set).toHaveBeenCalledWith({ status: 'processed' });
+        });
+
+        it('marks event unhandled and returns 200 for unrecognized event types', async () => {
+            dispatchWebhookEvent.mockResolvedValue(false);
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            // Unhandled events still return 200 — visibility comes from the
+            // row status and the warn log, not the response code.
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({ received: true });
+            expect(mocks.set).toHaveBeenCalledWith({ status: 'unhandled' });
+            expect(hoisted.logger.warn).toHaveBeenCalledWith(
+                { eventId: sampleEvent.id, eventType: sampleEvent.type },
+                'Unhandled Stripe event type'
+            );
         });
 
         it('marks event failed with error message on dispatch error', async () => {

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -104,9 +104,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     log.info({ eventId: event.id, eventType: event.type }, 'Webhook received');
 
     try {
-        await subscriptionService.dispatchWebhookEvent(db, event);
+        const isHandled = await subscriptionService.dispatchWebhookEvent(
+            db,
+            event
+        );
 
-        await webhookRepo.update(webhookEvent.id, { status: 'processed' });
+        if (!isHandled) {
+            log.warn(
+                { eventId: event.id, eventType: event.type },
+                'Unhandled Stripe event type'
+            );
+        }
+
+        await webhookRepo.update(webhookEvent.id, {
+            status: isHandled ? 'processed' : 'unhandled',
+        });
 
         log.info(
             {

--- a/apps/web/scripts/check-s3-event-health.ts
+++ b/apps/web/scripts/check-s3-event-health.ts
@@ -2,7 +2,9 @@
  * Health check for the S3 event pipeline (SNS webhook → DB side effects).
  *
  * Fails (exit 1) when:
- *   - any SNS webhook event landed in status 'failed' in the last 7 days
+ *   - any SNS webhook event landed in status 'failed' or 'unhandled' in the
+ *     last 7 days (allowlisted expected events stay 'processed', so routine
+ *     ObjectRestore:Post deliveries don't trip this)
  *   - any retrieval has sat in 'pending'/'in_progress' for over 48 hours
  *     (Deep Archive bulk restores complete within 48h — older is stuck)
  *
@@ -21,18 +23,11 @@
 import { and, count, eq, gte, inArray, lt } from 'drizzle-orm';
 
 import { db } from '@/server/db';
+import { s3RestoreService } from '@/server/services/s3-restore';
 import { retrievals, webhookEvents } from '@nexus/db/schema';
 
 const FAILED_WEBHOOK_WINDOW_DAYS = 7;
 const STUCK_RETRIEVAL_HOURS = 48;
-
-// Wire names as AWS delivers them (unprefixed) — must match the handler map
-// in server/services/s3-restore.ts.
-const HANDLED_EVENT_TYPES = [
-    'ObjectRestore:Completed',
-    'ObjectRestore:Delete',
-    'LifecycleTransition',
-];
 
 function parseSinceArg(): Date | null {
     const index = process.argv.indexOf('--since');
@@ -56,6 +51,7 @@ async function main(): Promise<void> {
         .select({
             id: webhookEvents.id,
             eventType: webhookEvents.eventType,
+            status: webhookEvents.status,
             error: webhookEvents.error,
             createdAt: webhookEvents.createdAt,
         })
@@ -63,17 +59,17 @@ async function main(): Promise<void> {
         .where(
             and(
                 eq(webhookEvents.source, 'sns'),
-                eq(webhookEvents.status, 'failed'),
+                inArray(webhookEvents.status, ['failed', 'unhandled']),
                 gte(webhookEvents.createdAt, failedAfter)
             )
         );
 
     console.log(
-        `Failed SNS webhook events (last ${FAILED_WEBHOOK_WINDOW_DAYS}d): ${failedWebhooks.length}`
+        `Failed/unhandled SNS webhook events (last ${FAILED_WEBHOOK_WINDOW_DAYS}d): ${failedWebhooks.length}`
     );
     for (const event of failedWebhooks) {
         console.log(
-            `  ✗ ${event.createdAt.toISOString()}  ${event.eventType}  ${event.error ?? '(no error recorded)'}`
+            `  ✗ ${event.createdAt.toISOString()}  ${event.status}  ${event.eventType}  ${event.error ?? '(no error recorded)'}`
         );
     }
     if (failedWebhooks.length > 0) hasFailure = true;
@@ -115,7 +111,10 @@ async function main(): Promise<void> {
                 and(
                     eq(webhookEvents.source, 'sns'),
                     eq(webhookEvents.status, 'processed'),
-                    inArray(webhookEvents.eventType, HANDLED_EVENT_TYPES),
+                    inArray(
+                        webhookEvents.eventType,
+                        s3RestoreService.handledEventTypes
+                    ),
                     gte(webhookEvents.createdAt, since)
                 )
             );

--- a/apps/web/server/services/s3-restore.ts
+++ b/apps/web/server/services/s3-restore.ts
@@ -21,6 +21,17 @@ const handlers: Record<string, S3RestoreEventHandler> = {
     LifecycleTransition: handleLifecycleTransition,
 };
 
+// Events we subscribe to but deliberately don't act on. `ObjectRestore:Post`
+// fires at restore initiation on every restore — expected, not a coverage gap,
+// so routes must not flag it as unhandled.
+const expectedUnhandledEvents: ReadonlySet<string> = new Set([
+    'ObjectRestore:Post',
+]);
+
+// Wire names this service acts on — the single source of truth for consumers
+// like scripts/check-s3-event-health.ts.
+const handledEventTypes = Object.keys(handlers);
+
 // S3 encodes spaces as `+` in event notification keys
 function decodeS3Key(record: S3EventRecord): string {
     return decodeURIComponent(record.s3.object.key.replace(/\+/g, ' '));
@@ -185,4 +196,6 @@ async function dispatch(db: DB, record: S3EventRecord): Promise<boolean> {
 
 export const s3RestoreService = {
     dispatch,
+    expectedUnhandledEvents,
+    handledEventTypes,
 } as const;

--- a/apps/web/server/services/subscriptions.test.ts
+++ b/apps/web/server/services/subscriptions.test.ts
@@ -412,7 +412,7 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
                 })
             );
 
-            await subscriptionService.dispatchWebhookEvent(
+            const isHandled = await subscriptionService.dispatchWebhookEvent(
                 db,
                 makeSubscriptionEvent({
                     type: 'customer.subscription.deleted',
@@ -420,6 +420,7 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
                 })
             );
 
+            expect(isHandled).toBe(true);
             expect(mocks.values).toHaveBeenCalledWith(
                 expect.objectContaining({
                     status: 'canceled',
@@ -429,12 +430,13 @@ describe('subscriptionService.dispatchWebhookEvent', () => {
         });
     });
 
-    it('ignores unhandled event types without error', async () => {
-        await subscriptionService.dispatchWebhookEvent(
+    it('reports unhandled event types without error', async () => {
+        const isHandled = await subscriptionService.dispatchWebhookEvent(
             db,
             makeStripeEvent('some.other.event', {})
         );
 
+        expect(isHandled).toBe(false);
         expect(mocks.subscriptions.findFirst).not.toHaveBeenCalled();
         expect(mocks.insert).not.toHaveBeenCalled();
     });

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -550,35 +550,37 @@ async function handlePaymentFailed(
     );
 }
 
+// Returns whether the event type had a handler — the webhook route uses this
+// to mark unhandled events visibly instead of silently succeeding (#281).
 async function dispatchWebhookEvent(
     db: DB,
     event: Stripe.Event
-): Promise<void> {
+): Promise<boolean> {
     switch (event.type) {
         case 'checkout.session.completed':
             await handleCheckoutCompleted(
                 db,
                 event.data.object as Stripe.Checkout.Session
             );
-            break;
+            return true;
         case 'customer.subscription.created':
         case 'customer.subscription.updated':
             await handleSubscriptionUpsert(
                 db,
                 event.data.object as Stripe.Subscription
             );
-            break;
+            return true;
         case 'customer.subscription.deleted':
             await handleSubscriptionDeleted(
                 db,
                 event.data.object as Stripe.Subscription
             );
-            break;
+            return true;
         case 'invoice.payment_failed':
             await handlePaymentFailed(db, event.data.object as Stripe.Invoice);
-            break;
+            return true;
         default:
-            log.debug({ eventType: event.type }, 'Unhandled event type');
+            return false;
     }
 }
 

--- a/packages/db/src/migrations/0014_brainy_kang.sql
+++ b/packages/db/src/migrations/0014_brainy_kang.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."webhook_status" ADD VALUE 'unhandled';

--- a/packages/db/src/migrations/meta/0014_snapshot.json
+++ b/packages/db/src/migrations/meta/0014_snapshot.json
@@ -1,0 +1,1544 @@
+{
+  "id": "cdbe7fc3-4100-4351-ac76-3ce63c6595c2",
+  "prevId": "1da516ea-dd58-45f3-a1b9-7eade906d167",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by_user_id": {
+          "name": "redeemed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_token_idx": {
+          "name": "invites_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_status_idx": {
+          "name": "invites_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_user_id_user_id_fk": {
+          "name": "invites_redeemed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "redeemed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.background_jobs": {
+      "name": "background_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "background_jobs_status_created_at_idx": {
+          "name": "background_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "storage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_user_id_idx": {
+          "name": "files_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_status_idx": {
+          "name": "files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_storage_tier_idx": {
+          "name": "files_storage_tier_idx",
+          "columns": [
+            {
+              "expression": "storage_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_batch_id_idx": {
+          "name": "files_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_user_id_created_at_idx": {
+          "name": "files_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_user_id_fk": {
+          "name": "files_user_id_user_id_fk",
+          "tableFrom": "files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_batch_id_upload_batches_id_fk": {
+          "name": "files_batch_id_upload_batches_id_fk",
+          "tableFrom": "files",
+          "tableTo": "upload_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_s3_key_unique": {
+          "name": "files_s3_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "s3_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrievals": {
+      "name": "retrievals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "retrieval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "retrieval_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retrievals_file_id_idx": {
+          "name": "retrievals_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_user_id_idx": {
+          "name": "retrievals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_status_idx": {
+          "name": "retrievals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_batch_id_idx": {
+          "name": "retrievals_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_expires_at_idx": {
+          "name": "retrievals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retrievals_file_id_files_id_fk": {
+          "name": "retrievals_file_id_files_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_user_id_user_id_fk": {
+          "name": "retrievals_user_id_user_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_batch_id_upload_batches_id_fk": {
+          "name": "retrievals_batch_id_upload_batches_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "upload_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_usage": {
+      "name": "storage_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_bytes": {
+          "name": "used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_usage_user_id_idx": {
+          "name": "storage_usage_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_usage_user_id_user_id_fk": {
+          "name": "storage_usage_user_id_user_id_fk",
+          "tableFrom": "storage_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_usage_user_id_unique": {
+          "name": "storage_usage_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_batches": {
+      "name": "upload_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upload_batches_user_id_idx": {
+          "name": "upload_batches_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_batches_user_id_user_id_fk": {
+          "name": "upload_batches_user_id_user_id_fk",
+          "tableFrom": "upload_batches",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "plan_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starter'"
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trialing'"
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_user_id_unique": {
+          "name": "subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "webhook_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_source_external_id_idx": {
+          "name": "webhook_events_source_external_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_status_created_at_idx": {
+          "name": "webhook_events_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "redeemed",
+        "revoked"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "available",
+        "restoring",
+        "deleted"
+      ]
+    },
+    "public.retrieval_status": {
+      "name": "retrieval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "ready",
+        "expired",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.retrieval_tier": {
+      "name": "retrieval_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "bulk",
+        "expedited"
+      ]
+    },
+    "public.storage_tier": {
+      "name": "storage_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "glacier",
+        "deep_archive"
+      ]
+    },
+    "public.plan_tier": {
+      "name": "plan_tier",
+      "schema": "public",
+      "values": [
+        "starter",
+        "pro",
+        "max",
+        "enterprise"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "incomplete",
+        "sponsored"
+      ]
+    },
+    "public.webhook_source": {
+      "name": "webhook_source",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "sns"
+      ]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "processed",
+        "failed",
+        "unhandled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1783087572493,
       "tag": "0013_past_mach_iv",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1783269833835,
+      "tag": "0014_brainy_kang",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/webhooks.ts
+++ b/packages/db/src/schema/webhooks.ts
@@ -14,6 +14,7 @@ export const webhookStatusEnum = pgEnum('webhook_status', [
     'received',
     'processed',
     'failed',
+    'unhandled',
 ]);
 
 export const webhookEvents = pgTable(


### PR DESCRIPTION
## Summary

When `dispatch()` matched no handler, both webhook routes marked the `webhook_events` row `processed` and logged at debug — silent success. That's how #271 (handlers keyed with `s3:`-prefixed names while AWS delivers unprefixed ones) went unnoticed for weeks. This adds an `unhandled` status to `webhook_status`, marks unmatched events with it plus a `log.warn` on both the S3-restore and Stripe routes, and allowlists expected-unhandled events (`ObjectRestore:Post` fires on every restore) so they stay `processed` and the new status remains a meaningful signal. Responses stay 200 in all cases — SNS/Stripe retries remain reserved for infra failures.

From self-review, the scheduled health check (`check-s3-event-health.ts`) was also updated: it now trips on `unhandled` rows (previously only `failed`, which would have kept the exact silent-failure mode this issue targets), and its hardcoded `HANDLED_EVENT_TYPES` list was replaced with `s3RestoreService.handledEventTypes` derived from the handler map, removing a manually-synced list.

Closes #281

## Changes

- `packages/db`: `webhook_status` enum gains `unhandled` (generated migration `0014_brainy_kang.sql`)
- `apps/web/server/services/s3-restore.ts`: `expectedUnhandledEvents` allowlist (contains `ObjectRestore:Post`) next to the handler map; `handledEventTypes` exported as the single source of truth for handler keys
- `apps/web/app/api/webhooks/s3-restore/route.ts`: records neither handled nor allowlisted get `log.warn` per record and mark the row `unhandled`; allowlisted no-matches keep debug + `processed`
- `apps/web/server/services/subscriptions.ts`: `dispatchWebhookEvent` returns `Promise<boolean>` (was `void`); default-branch debug log removed — the route owns the warning now
- `apps/web/app/api/webhooks/stripe/route.ts`: acts on the boolean — `unhandled` + `log.warn` on false, `processed` on true, 200 either way
- `apps/web/scripts/check-s3-event-health.ts`: failure query now `inArray(status, ['failed', 'unhandled'])` with status shown per row; imports `handledEventTypes` from the service
- Tests: S3 integration unknown-event case split into allowlisted→`processed` and truly-unknown→`unhandled`; Stripe route test gains an unhandled case (status `unhandled`, 200, warn asserted); `subscriptions.test.ts` asserts the new boolean returns

## Test Plan

- [ ] `pnpm check` green
- [ ] `pnpm -F web test:integration` — S3 route: `ObjectRestore:Post` → `processed`, `ObjectCreated:Put` → `unhandled`, both 200
- [ ] `pnpm -F web check:s3-event-health` runs with the widened query

## Evidence

Independently re-run by the delegating session (not the implementing agent).

`log.warn` firing for a truly unknown S3 event during the integration run (level 40 = warn):

```
{"level":40,"handler":"s3-restore-webhook","eventName":"ObjectCreated:Put","msg":"Unhandled S3 event type"}
```

Integration tests against the real local DB — the `unhandled` assertion passing also proves the enum migration applied, since the row update would throw otherwise:

```
✓ marks expected-unhandled event types as processed 813ms
✓ marks truly unknown event types as unhandled 817ms
Test Files  3 passed (3)
     Tests  14 passed (14)
```

Full unit suite including the new Stripe unhandled case and boolean-return assertions:

```
Test Files  38 passed (38)
     Tests  415 passed (415)
```

Health-check script live against the local DB with the widened query:

```
Failed/unhandled SNS webhook events (last 7d): 0
Retrievals stuck >48h:                0

All checks passed.
```
