### PR TITLE
feat: alert on unhandled/failed webhook events via lib/alerts + Discord transport (#288)

### DIFF
--- a/.github/workflows/s3-event-health.yml
+++ b/.github/workflows/s3-event-health.yml
@@ -44,6 +44,11 @@ jobs:
             RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
             BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
             NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+            # Discord delivery for health-check findings (#288); unset secret
+            # degrades to a no-op. VERCEL_ENV labels the alert's environment —
+            # the same field Vercel sets at runtime.
+            DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_ALERT_WEBHOOK_URL }}
+            VERCEL_ENV: ${{ matrix.env }}
         steps:
             # DATABASE_URL comes from the job env above (matrixed secret).
             - name: Verify database secret is configured

--- a/apps/web/app/api/webhooks/s3-restore/route.ts
+++ b/apps/web/app/api/webhooks/s3-restore/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { createWebhookRepo } from '@nexus/db/repo/webhooks';
+import { alerts } from '@/lib/alerts';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { verifySnsMessage } from '@/lib/sns/webhooks';
@@ -88,7 +89,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
 
     try {
-        let hasUnhandledRecord = false;
+        const unhandledEventNames: string[] = [];
         for (const record of s3Event.Records ?? []) {
             const isHandled = await s3RestoreService.dispatch(db, record);
 
@@ -103,7 +104,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
                         'Expected-unhandled S3 event type'
                     );
                 } else {
-                    hasUnhandledRecord = true;
+                    unhandledEventNames.push(record.eventName);
                     log.warn(
                         { eventName: record.eventName },
                         'Unhandled S3 event type'
@@ -112,9 +113,24 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             }
         }
 
+        const hasUnhandledRecord = unhandledEventNames.length > 0;
         await webhookRepo.update(webhookEvent.id, {
             status: hasUnhandledRecord ? 'unhandled' : 'processed',
         });
+
+        if (hasUnhandledRecord) {
+            await alerts.send({
+                severity: 'warning',
+                title: 'Unhandled S3 event type',
+                message:
+                    'An SNS webhook delivered S3 event types no handler matches; the event row is marked unhandled.',
+                context: {
+                    source: 'sns',
+                    eventType: unhandledEventNames.join(', '),
+                    externalId: notification.MessageId,
+                },
+            });
+        }
 
         log.info(
             {
@@ -132,9 +148,24 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             'Webhook processing failed'
         );
 
+        const errorMessage =
+            error instanceof Error ? error.message : String(error);
         await webhookRepo.update(webhookEvent.id, {
             status: 'failed',
-            error: error instanceof Error ? error.message : String(error),
+            error: errorMessage,
+        });
+
+        await alerts.send({
+            severity: 'error',
+            title: 'S3 webhook processing failed',
+            message:
+                'Handler threw while processing an SNS webhook; the event row is marked failed.',
+            context: {
+                source: 'sns',
+                eventType,
+                externalId: notification.MessageId,
+                error: errorMessage,
+            },
         });
 
         return NextResponse.json({ received: true });

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -12,6 +12,7 @@ const hoisted = await vi.hoisted(async () => {
         ...createMockStripe(),
         mockDb: createMockDb(),
         dispatchWebhookEvent: vi.fn(),
+        alertsSend: vi.fn(),
     };
 });
 
@@ -23,6 +24,10 @@ vi.mock('@/lib/env', () => ({
 }));
 
 vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
+
+vi.mock('@/lib/alerts', () => ({
+    alerts: { send: hoisted.alertsSend },
+}));
 
 vi.mock('@/lib/stripe', () => ({
     stripe: hoisted.stripe,
@@ -286,6 +291,24 @@ describe('POST /api/webhooks/stripe', () => {
                 { eventId: sampleEvent.id, eventType: sampleEvent.type },
                 'Unhandled Stripe event type'
             );
+            expect(hoisted.alertsSend).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    severity: 'warning',
+                    context: expect.objectContaining({
+                        source: 'stripe',
+                        eventType: sampleEvent.type,
+                        externalId: sampleEvent.id,
+                    }),
+                })
+            );
+        });
+
+        it('does not alert on handled events', async () => {
+            dispatchWebhookEvent.mockResolvedValue(true);
+
+            await POST(makeRequest(sampleEvent));
+
+            expect(hoisted.alertsSend).not.toHaveBeenCalled();
         });
 
         it('marks event failed with error message on dispatch error', async () => {
@@ -302,6 +325,15 @@ describe('POST /api/webhooks/stripe', () => {
                 status: 'failed',
                 error: 'downstream exploded',
             });
+            expect(hoisted.alertsSend).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    severity: 'error',
+                    context: expect.objectContaining({
+                        externalId: sampleEvent.id,
+                        error: 'downstream exploded',
+                    }),
+                })
+            );
         });
 
         it('stringifies non-Error throws when marking failed', async () => {

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import type Stripe from 'stripe';
 import { createWebhookRepo, type WebhookEvent } from '@nexus/db/repo/webhooks';
+import { alerts } from '@/lib/alerts';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { stripe } from '@/lib/stripe';
@@ -120,6 +121,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             status: isHandled ? 'processed' : 'unhandled',
         });
 
+        if (!isHandled) {
+            await alerts.send({
+                severity: 'warning',
+                title: 'Unhandled Stripe event type',
+                message:
+                    'A Stripe webhook delivered an event type no handler matches; the event row is marked unhandled.',
+                context: {
+                    source: 'stripe',
+                    eventType: event.type,
+                    externalId: event.id,
+                },
+            });
+        }
+
         log.info(
             {
                 eventId: event.id,
@@ -136,9 +151,24 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             'Webhook processing failed'
         );
 
+        const errorMessage =
+            error instanceof Error ? error.message : String(error);
         await webhookRepo.update(webhookEvent.id, {
             status: 'failed',
-            error: error instanceof Error ? error.message : String(error),
+            error: errorMessage,
+        });
+
+        await alerts.send({
+            severity: 'error',
+            title: 'Stripe webhook processing failed',
+            message:
+                'Handler threw while processing a Stripe webhook; the event row is marked failed.',
+            context: {
+                source: 'stripe',
+                eventType: event.type,
+                externalId: event.id,
+                error: errorMessage,
+            },
         });
 
         return NextResponse.json({ received: true });

--- a/apps/web/lib/alerts/discord.test.ts
+++ b/apps/web/lib/alerts/discord.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import type { DeliverableAlert } from './types';
+
+const hoisted = vi.hoisted(() => ({
+    env: { DISCORD_ALERT_WEBHOOK_URL: undefined as string | undefined },
+}));
+
+vi.mock('@/lib/env', () => ({ env: hoisted.env }));
+
+const { DISCORD_LIMITS, buildDiscordPayload, discordTransport, truncate } =
+    await import('./discord');
+
+function makeAlert(
+    overrides: Partial<DeliverableAlert> = {}
+): DeliverableAlert {
+    return {
+        severity: 'error',
+        title: 'stripe webhook failed',
+        message: 'Marking event as failed after handler threw.',
+        environment: 'production',
+        ...overrides,
+    };
+}
+
+describe('buildDiscordPayload', () => {
+    it.each([
+        ['info', 0x3b82f6, 'ℹ️'],
+        ['warning', 0xf59e0b, '⚠️'],
+        ['error', 0xef4444, '🔴'],
+        ['critical', 0x991b1b, '🚨'],
+    ] as const)('maps %s to its color and emoji', (severity, color, emoji) => {
+        const payload = buildDiscordPayload(makeAlert({ severity }));
+
+        expect(payload.embeds[0].color).toBe(color);
+        expect(payload.embeds[0].title).toBe(`${emoji} stripe webhook failed`);
+    });
+
+    it('formats the content line as [env] severity: title', () => {
+        const payload = buildDiscordPayload(makeAlert());
+
+        expect(payload.content).toBe(
+            '[production] error: stripe webhook failed'
+        );
+    });
+
+    it('prepends @here to the content line for critical only', () => {
+        const critical = buildDiscordPayload(
+            makeAlert({ severity: 'critical' })
+        );
+        expect(critical.content).toBe(
+            '@here [production] critical: stripe webhook failed'
+        );
+
+        for (const severity of ['info', 'warning', 'error'] as const) {
+            const payload = buildDiscordPayload(makeAlert({ severity }));
+            expect(payload.content).not.toContain('@here');
+        }
+    });
+
+    it('posts under a consistent username with footer and timestamp', () => {
+        const payload = buildDiscordPayload(makeAlert());
+
+        expect(payload.username).toBe('Nexus Alerts');
+        expect(payload.embeds[0].footer.text).toBe('nexus · lib/alerts');
+        expect(payload.embeds[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('renders environment and short context values as inline fields', () => {
+        const payload = buildDiscordPayload(
+            makeAlert({
+                context: { source: 'stripe', eventType: 'invoice.paid' },
+            })
+        );
+
+        expect(payload.embeds[0].fields).toEqual([
+            { name: 'Environment', value: 'production', inline: true },
+            { name: 'Source', value: 'stripe', inline: true },
+            { name: 'Event type', value: 'invoice.paid', inline: true },
+        ]);
+    });
+
+    it('renders the error context key full-width in a code block', () => {
+        const payload = buildDiscordPayload(
+            makeAlert({ context: { error: 'TRPCError: NOT_FOUND' } })
+        );
+
+        const errorField = payload.embeds[0].fields.find(
+            (field) => field.name === 'Error'
+        );
+        expect(errorField).toEqual({
+            name: 'Error',
+            value: '```\nTRPCError: NOT_FOUND\n```',
+            inline: false,
+        });
+    });
+
+    it('truncates the title to 256 chars with an ellipsis marker', () => {
+        const payload = buildDiscordPayload(
+            makeAlert({ title: 'x'.repeat(300) })
+        );
+
+        expect(payload.embeds[0].title).toHaveLength(DISCORD_LIMITS.title);
+        expect(payload.embeds[0].title.endsWith('…')).toBe(true);
+    });
+
+    it('truncates the description to 4096 chars', () => {
+        const payload = buildDiscordPayload(
+            makeAlert({ message: 'x'.repeat(5000) })
+        );
+
+        expect(payload.embeds[0].description).toHaveLength(
+            DISCORD_LIMITS.description
+        );
+        expect(payload.embeds[0].description.endsWith('…')).toBe(true);
+    });
+
+    it('truncates field values to 1024 chars, including code-block fences', () => {
+        const payload = buildDiscordPayload(
+            makeAlert({
+                context: { source: 'y'.repeat(2000), error: 'x'.repeat(2000) },
+            })
+        );
+
+        for (const field of payload.embeds[0].fields) {
+            expect(field.value.length).toBeLessThanOrEqual(
+                DISCORD_LIMITS.fieldValue
+            );
+        }
+        const errorField = payload.embeds[0].fields.find(
+            (field) => field.name === 'Error'
+        );
+        expect(errorField?.value.startsWith('```\n')).toBe(true);
+        expect(errorField?.value.endsWith('\n```')).toBe(true);
+        expect(errorField?.value).toContain('…');
+    });
+
+    it('truncates the content line to 2000 chars', () => {
+        const payload = buildDiscordPayload(
+            makeAlert({ title: 'x'.repeat(3000) })
+        );
+
+        expect(payload.content).toHaveLength(DISCORD_LIMITS.content);
+        expect(payload.content.endsWith('…')).toBe(true);
+    });
+
+    it('fits the 6000-char embed total by shrinking the description first', () => {
+        const payload = buildDiscordPayload(
+            makeAlert({
+                title: 'x'.repeat(300),
+                message: 'y'.repeat(5000),
+                context: {
+                    source: 'a'.repeat(2000),
+                    eventType: 'b'.repeat(2000),
+                    error: 'c'.repeat(2000),
+                },
+            })
+        );
+
+        const embed = payload.embeds[0];
+        const total =
+            embed.title.length +
+            embed.description.length +
+            embed.footer.text.length +
+            embed.fields.reduce(
+                (sum, field) => sum + field.name.length + field.value.length,
+                0
+            );
+        expect(total).toBeLessThanOrEqual(DISCORD_LIMITS.total);
+        // The identifying fields survive; the prose absorbed the cut.
+        expect(embed.fields.length).toBe(4);
+        expect(embed.description.length).toBeLessThan(5000);
+    });
+});
+
+describe('truncate', () => {
+    it('returns short strings unchanged', () => {
+        expect(truncate('hello', 10)).toBe('hello');
+    });
+
+    it('clips to the limit with a trailing ellipsis', () => {
+        expect(truncate('hello world', 5)).toBe('hell…');
+        expect(truncate('hello world', 5)).toHaveLength(5);
+    });
+});
+
+describe('discordTransport', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal('fetch', fetchMock);
+        hoisted.env.DISCORD_ALERT_WEBHOOK_URL = 'https://discord.test/webhook';
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        hoisted.env.DISCORD_ALERT_WEBHOOK_URL = undefined;
+    });
+
+    it('is unconfigured when the webhook URL env var is unset', () => {
+        hoisted.env.DISCORD_ALERT_WEBHOOK_URL = undefined;
+
+        expect(discordTransport.isConfigured()).toBe(false);
+    });
+
+    it('POSTs the built payload to the configured webhook URL', async () => {
+        fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+        await discordTransport.send(makeAlert());
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://discord.test/webhook',
+            expect.objectContaining({ method: 'POST' })
+        );
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+        expect(body.content).toBe('[production] error: stripe webhook failed');
+    });
+
+    it('throws on a non-ok response so the dispatcher can log it', async () => {
+        fetchMock.mockResolvedValue(
+            new Response('Invalid Webhook Token', { status: 401 })
+        );
+
+        await expect(discordTransport.send(makeAlert())).rejects.toThrow(
+            'Discord webhook responded 401'
+        );
+    });
+});

--- a/apps/web/lib/alerts/discord.ts
+++ b/apps/web/lib/alerts/discord.ts
@@ -1,0 +1,171 @@
+import { env } from '@/lib/env';
+import type { AlertSeverity, AlertTransport, DeliverableAlert } from './types';
+
+/**
+ * Discord hard-rejects oversized payloads with a 400, so the transport clips
+ * every part to these documented limits before sending — a huge error payload
+ * degrades to a truncated message, never a dropped alert.
+ */
+const FETCH_TIMEOUT_MS = 5000;
+
+export const DISCORD_LIMITS = {
+    content: 2000,
+    title: 256,
+    description: 4096,
+    fieldName: 256,
+    fieldValue: 1024,
+    /** Sum of title + description + field names/values + footer text. */
+    total: 6000,
+} as const;
+
+// Emoji in the title because the embed's color bar is easy to miss and
+// invisible in push notifications.
+const SEVERITY_STYLES: Record<AlertSeverity, { color: number; emoji: string }> =
+    {
+        info: { color: 0x3b82f6, emoji: 'ℹ️' },
+        warning: { color: 0xf59e0b, emoji: '⚠️' },
+        error: { color: 0xef4444, emoji: '🔴' },
+        critical: { color: 0x991b1b, emoji: '🚨' },
+    };
+
+interface DiscordEmbedField {
+    name: string;
+    value: string;
+    inline: boolean;
+}
+
+interface DiscordEmbed {
+    title: string;
+    description: string;
+    color: number;
+    fields: DiscordEmbedField[];
+    footer: { text: string };
+    timestamp: string;
+}
+
+export interface DiscordWebhookPayload {
+    username: string;
+    content: string;
+    embeds: [DiscordEmbed];
+}
+
+export function truncate(value: string, max: number): string {
+    if (value.length <= max) return value;
+    return `${value.slice(0, max - 1)}…`;
+}
+
+// `eventType` → `Event type`
+function humanizeKey(key: string): string {
+    const spaced = key.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+// The fence chars count against the field-value limit: ```\n + \n``` = 8.
+function formatCodeBlock(value: string): string {
+    return `\`\`\`\n${truncate(value, DISCORD_LIMITS.fieldValue - 8)}\n\`\`\``;
+}
+
+function getEmbedLength(embed: DiscordEmbed): number {
+    return (
+        embed.title.length +
+        embed.description.length +
+        embed.footer.text.length +
+        embed.fields.reduce(
+            (sum, field) => sum + field.name.length + field.value.length,
+            0
+        )
+    );
+}
+
+export function buildDiscordPayload(
+    alert: DeliverableAlert
+): DiscordWebhookPayload {
+    const style = SEVERITY_STYLES[alert.severity];
+
+    // The plain-text content line is what push notifications and the channel
+    // list show (embeds render poorly there), and the only place mentions
+    // work. @here is reserved for critical — a channel that pings for every
+    // warning gets muted, which recreates the problem alerts exist to fix.
+    const mention = alert.severity === 'critical' ? '@here ' : '';
+    const content = truncate(
+        `${mention}[${alert.environment}] ${alert.severity}: ${alert.title}`,
+        DISCORD_LIMITS.content
+    );
+
+    const fields: DiscordEmbedField[] = [
+        {
+            name: 'Environment',
+            value: truncate(alert.environment, DISCORD_LIMITS.fieldValue),
+            inline: true,
+        },
+    ];
+    for (const [key, value] of Object.entries(alert.context ?? {})) {
+        if (key === 'error') {
+            fields.push({
+                name: 'Error',
+                value: formatCodeBlock(value),
+                inline: false,
+            });
+        } else {
+            fields.push({
+                name: truncate(humanizeKey(key), DISCORD_LIMITS.fieldName),
+                value: truncate(value, DISCORD_LIMITS.fieldValue),
+                inline: true,
+            });
+        }
+    }
+
+    const embed: DiscordEmbed = {
+        title: truncate(`${style.emoji} ${alert.title}`, DISCORD_LIMITS.title),
+        description: truncate(alert.message, DISCORD_LIMITS.description),
+        color: style.color,
+        fields,
+        footer: { text: 'nexus · lib/alerts' },
+        timestamp: new Date().toISOString(),
+    };
+
+    // Fit the 6000-char total: shrink the prose description first (the fields
+    // carry the identifying facts), then drop trailing fields as a last resort.
+    let excess = getEmbedLength(embed) - DISCORD_LIMITS.total;
+    if (excess > 0) {
+        embed.description = truncate(
+            embed.description,
+            Math.max(embed.description.length - excess, 1)
+        );
+        excess = getEmbedLength(embed) - DISCORD_LIMITS.total;
+    }
+    while (excess > 0 && embed.fields.length > 0) {
+        embed.fields.pop();
+        excess = getEmbedLength(embed) - DISCORD_LIMITS.total;
+    }
+
+    return { username: 'Nexus Alerts', content, embeds: [embed] };
+}
+
+export const discordTransport: AlertTransport = {
+    name: 'discord',
+    isConfigured() {
+        return Boolean(env.DISCORD_ALERT_WEBHOOK_URL);
+    },
+    async send(alert: DeliverableAlert): Promise<void> {
+        const url = env.DISCORD_ALERT_WEBHOOK_URL;
+        if (!url) return;
+
+        // Call sites await `alerts.send` inside webhook request paths, so a
+        // stalled Discord endpoint must not hold up the 200 response long
+        // enough for Stripe/SNS to retry the delivery.
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(buildDiscordPayload(alert)),
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+
+        if (!response.ok) {
+            const body = await response.text().catch(() => '');
+            throw new Error(
+                `Discord webhook responded ${response.status}: ${body.slice(0, 200)}`
+            );
+        }
+    },
+};

--- a/apps/web/lib/alerts/index.ts
+++ b/apps/web/lib/alerts/index.ts
@@ -1,0 +1,35 @@
+import { send } from './send';
+
+/**
+ * Operational alerting for failure points, warnings, and checks — importable
+ * from API routes, `server/services/`, and `scripts/`. Delivery follows a
+ * warn-and-swallow contract: `send` never throws (await it freely — failures
+ * and timeouts are logged, not raised), and with zero configured transports
+ * it's a no-op.
+ *
+ * v1 ships a single transport (Discord webhook via
+ * `DISCORD_ALERT_WEBHOOK_URL`); future channels implement `AlertTransport`
+ * with no call-site changes.
+ *
+ * @example
+ * ```typescript
+ * import { alerts } from '@/lib/alerts';
+ *
+ * await alerts.send({
+ *     severity: 'error',
+ *     title: 'Stripe webhook processing failed',
+ *     message: 'Handler threw; the event row is marked failed.',
+ *     context: { source: 'stripe', eventType: 'invoice.paid', error: '…' },
+ * });
+ * ```
+ */
+export const alerts = {
+    send,
+} as const;
+
+export type {
+    Alert,
+    AlertSeverity,
+    AlertTransport,
+    DeliverableAlert,
+} from './types';

--- a/apps/web/lib/alerts/send.test.ts
+++ b/apps/web/lib/alerts/send.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import type { AlertTransport } from './types';
+
+const hoisted = await vi.hoisted(async () => {
+    const { createMockLogger } = await import('@/server/lib/logger/testing');
+    return {
+        logger: createMockLogger(),
+        env: { DISCORD_ALERT_WEBHOOK_URL: undefined as string | undefined },
+    };
+});
+
+vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
+vi.mock('@/lib/env', () => ({ env: hoisted.env }));
+
+const { dispatch, send } = await import('./send');
+
+const alert = {
+    severity: 'error',
+    title: 'something broke',
+    message: 'details',
+} as const;
+
+function makeTransport(
+    overrides: Partial<AlertTransport> = {}
+): AlertTransport {
+    return {
+        name: 'mock',
+        isConfigured: () => true,
+        send: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+describe('dispatch', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('delivers to every configured transport with the environment attached', async () => {
+        vi.stubEnv('VERCEL_ENV', 'production');
+        const first = makeTransport({ name: 'first' });
+        const second = makeTransport({ name: 'second' });
+
+        await dispatch(alert, [first, second]);
+
+        for (const transport of [first, second]) {
+            expect(transport.send).toHaveBeenCalledExactlyOnceWith({
+                ...alert,
+                environment: 'production',
+            });
+        }
+    });
+
+    it('falls back to NODE_ENV when VERCEL_ENV is unset', async () => {
+        const transport = makeTransport();
+
+        await dispatch(alert, [transport]);
+
+        expect(transport.send).toHaveBeenCalledWith(
+            expect.objectContaining({ environment: 'test' })
+        );
+    });
+
+    it('skips unconfigured transports with a debug log', async () => {
+        const unconfigured = makeTransport({
+            name: 'unconfigured',
+            isConfigured: () => false,
+        });
+        const configured = makeTransport({ name: 'configured' });
+
+        await dispatch(alert, [unconfigured, configured]);
+
+        expect(unconfigured.send).not.toHaveBeenCalled();
+        expect(configured.send).toHaveBeenCalledOnce();
+        expect(hoisted.logger.debug).toHaveBeenCalledWith(
+            { transport: 'unconfigured' },
+            'Alert transport not configured, skipping'
+        );
+    });
+
+    it('isolates a failing transport: others still deliver, nothing throws', async () => {
+        const failing = makeTransport({
+            name: 'failing',
+            send: vi.fn().mockRejectedValue(new Error('boom')),
+        });
+        const healthy = makeTransport({ name: 'healthy' });
+
+        await expect(
+            dispatch(alert, [failing, healthy])
+        ).resolves.toBeUndefined();
+
+        expect(healthy.send).toHaveBeenCalledOnce();
+        expect(hoisted.logger.warn).toHaveBeenCalledWith(
+            expect.objectContaining({ transport: 'failing' }),
+            'Failed to deliver alert'
+        );
+    });
+
+    it('is a no-op with zero transports', async () => {
+        await expect(dispatch(alert, [])).resolves.toBeUndefined();
+
+        expect(hoisted.logger.warn).not.toHaveBeenCalled();
+    });
+});
+
+describe('send', () => {
+    it('no-ops (and never throws) when no transport is configured', async () => {
+        // The real transport list holds only discord, whose env var is unset
+        // in this test file's env mock.
+        await expect(send(alert)).resolves.toBeUndefined();
+
+        expect(hoisted.logger.debug).toHaveBeenCalledWith(
+            { transport: 'discord' },
+            'Alert transport not configured, skipping'
+        );
+        expect(hoisted.logger.warn).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/lib/alerts/send.ts
+++ b/apps/web/lib/alerts/send.ts
@@ -1,0 +1,58 @@
+import { logger } from '@/server/lib/logger';
+import { discordTransport } from './discord';
+import type { Alert, AlertTransport, DeliverableAlert } from './types';
+
+const log = logger.child({ service: 'alerts' });
+
+const transports: AlertTransport[] = [discordTransport];
+
+// One shared channel across environments until the multi-env split (#292)
+// settles, so every alert carries where it came from.
+function resolveEnvironment(): string {
+    return process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'unknown';
+}
+
+/**
+ * Dispatches an alert to the given transports. Exported for tests —
+ * production callers go through `alerts.send`, which uses the configured
+ * transport list.
+ */
+export async function dispatch(
+    alert: Alert,
+    targets: AlertTransport[]
+): Promise<void> {
+    // Alerting must never fail the work that triggered it — same
+    // warn-and-swallow contract as server/services/email.ts.
+    try {
+        const deliverable: DeliverableAlert = {
+            ...alert,
+            environment: resolveEnvironment(),
+        };
+
+        await Promise.all(
+            targets.map(async (transport) => {
+                if (!transport.isConfigured()) {
+                    log.debug(
+                        { transport: transport.name },
+                        'Alert transport not configured, skipping'
+                    );
+                    return;
+                }
+                try {
+                    await transport.send(deliverable);
+                } catch (err) {
+                    log.warn(
+                        { transport: transport.name, err, title: alert.title },
+                        'Failed to deliver alert'
+                    );
+                }
+            })
+        );
+    } catch (err) {
+        log.warn({ err, title: alert.title }, 'Alert dispatch failed');
+    }
+}
+
+export async function send(alert: Alert): Promise<void> {
+    await dispatch(alert, transports);
+}

--- a/apps/web/lib/alerts/types.ts
+++ b/apps/web/lib/alerts/types.ts
@@ -1,0 +1,21 @@
+export type AlertSeverity = 'info' | 'warning' | 'error' | 'critical';
+
+export interface Alert {
+    severity: AlertSeverity;
+    title: string;
+    message: string;
+    /** Short identifying facts (source, eventType, externalId, error, …). */
+    context?: Record<string, string>;
+}
+
+/** An alert enriched with the runtime environment, as handed to transports. */
+export interface DeliverableAlert extends Alert {
+    environment: string;
+}
+
+export interface AlertTransport {
+    name: string;
+    /** Unconfigured transports (e.g. missing env var) are skipped, not errors. */
+    isConfigured(): boolean;
+    send(alert: DeliverableAlert): Promise<void>;
+}

--- a/apps/web/lib/env/schema.ts
+++ b/apps/web/lib/env/schema.ts
@@ -19,6 +19,8 @@ export const serverSchema = z.object({
     RESEND_FROM_EMAIL: z.string().min(1),
     BETTER_AUTH_SECRET: z.string().min(32),
     LOG_ERROR_VERBOSITY: logErrorVerbositySchema.optional(),
+    // Unset (local dev, tests, preview) disables the Discord alert transport.
+    DISCORD_ALERT_WEBHOOK_URL: z.string().url().optional(),
 });
 
 // Client-side env vars (NEXT_PUBLIC_ prefix)

--- a/apps/web/scripts/check-s3-event-health.ts
+++ b/apps/web/scripts/check-s3-event-health.ts
@@ -22,6 +22,7 @@
 
 import { and, count, eq, gte, inArray, lt } from 'drizzle-orm';
 
+import { alerts } from '@/lib/alerts';
 import { db } from '@/server/db';
 import { s3RestoreService } from '@/server/services/s3-restore';
 import { retrievals, webhookEvents } from '@nexus/db/schema';
@@ -127,9 +128,31 @@ async function main(): Promise<void> {
     if (hasFailure) {
         console.log('\nCheck failed: S3 event pipeline needs attention.');
         process.exitCode = 1;
+
+        // The exit-1 (and its workflow-failure email) stays as the dead-man
+        // backup for the check itself; this pushes the findings where they
+        // get seen (#288).
+        const runUrl = getWorkflowRunUrl();
+        await alerts.send({
+            severity: 'error',
+            title: 'S3 event pipeline health check failed',
+            message: `${failedWebhooks.length} failed/unhandled SNS webhook event(s) in the last ${FAILED_WEBHOOK_WINDOW_DAYS}d; ${stuckRetrievals.length} retrieval(s) stuck >${STUCK_RETRIEVAL_HOURS}h.`,
+            context: {
+                source: 'check-s3-event-health',
+                ...(runUrl && { workflowRun: runUrl }),
+            },
+        });
     } else {
         console.log('\nAll checks passed.');
     }
+}
+
+function getWorkflowRunUrl(): string | undefined {
+    const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
+    if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) {
+        return undefined;
+    }
+    return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
 }
 
 main()


### PR DESCRIPTION
Closes #288

## What

Adds the `lib/alerts/` alerting primitive and wires its first consumers:

- **`lib/alerts/`** — namespace export `alerts.send({ severity, title, message, context? })` mirroring `lib/email/`. Typed severities (`info | warning | error | critical`), environment name attached to every alert, warn-and-swallow contract (`send` never throws; zero configured transports → no-op).
- **`AlertTransport` interface** — dispatch skips unconfigured transports (debug log) and isolates per-transport failures. v1 ships one implementation, `discordTransport`, POSTing an embed to `env.DISCORD_ALERT_WEBHOOK_URL` (optional in the env schema; unset disables it).
- **Discord format per the issue spec** — plain-text content line `[env] severity: title` (the part push notifications show), severity-mapped color + emoji, context as embed fields (`error` full-width in a code block), `@here` on `critical` only, truncation to all Discord limits (title 256 / description 4096 / field 1024 / total 6000) with ellipsis markers so oversized payloads clip instead of 400-ing. The fetch carries a 5s `AbortSignal.timeout` so a stalled Discord endpoint can't delay a webhook response into Stripe/SNS retry territory.
- **Consumers** — S3/SNS and Stripe webhook routes alert on `unhandled` (warning) and `failed` (error) with `externalId` in context; `check-s3-event-health.ts` posts its findings summary (keeping exit-1 and the workflow-failure email as dead-man backup) with the workflow run URL as a clickable link.
- **Workflow** — `s3-event-health.yml` passes `DISCORD_ALERT_WEBHOOK_URL` and labels the environment via `VERCEL_ENV: ${{ matrix.env }}`.

## Verification

Ran the dev server with `DISCORD_ALERT_WEBHOOK_URL` pointed at a local capture server and drove all three consumers end-to-end:

- POST unhandled S3 event → row marked `unhandled`, Discord payload arrived: `[development] warning: Unhandled S3 event type` with Environment/Source/Event type/External id fields.
- POST unhandled Stripe event → same shape for `stripe`.
- `check:s3-event-health` with the unhandled row present + fake `GITHUB_*` vars → exit 1 and an error alert including the workflow run link.
- Killed the capture server and posted again → route still returned 200, delivery failure logged as `warn` (swallow contract holds live).
- Test rows deleted from the dev DB afterwards; health check back to green.

Unit tests cover severity→color/emoji/mention mapping, every truncation limit plus the combined-overflow case, multi-transport dispatch with one failing, unset-config no-op, and failed-POST swallow. `pnpm check` green.

## Follow-ups (out of scope per issue)

- The `DISCORD_ALERT_WEBHOOK_URL` repo secret still needs to be set (`gh secret set DISCORD_ALERT_WEBHOOK_URL`) once the Discord channel webhook exists — until then the workflow alert path degrades to a no-op.
- Additional transports, severity routing, Lambda worker adoption, DB-backed dedup.