### PR TITLE
chore: extract shared Node/pnpm setup into composite action (#297)

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,14 +1,13 @@
 name: Setup Node and pnpm
 description: >-
-    Checkout, read the Node version from .nvmrc, set up pnpm and Node.js (with
-    pnpm cache), and install dependencies with a frozen lockfile.
+    Read the Node version from .nvmrc, set up pnpm and Node.js (with pnpm
+    cache), and install dependencies with a frozen lockfile. Requires the repo
+    to be checked out first — a local composite action can't run actions/checkout
+    itself, since its own files must already be on disk.
 
 runs:
     using: composite
     steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-
         - name: Read Node version
           id: node-version
           shell: bash

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,28 @@
+name: Setup Node and pnpm
+description: >-
+    Checkout, read the Node version from .nvmrc, set up pnpm and Node.js (with
+    pnpm cache), and install dependencies with a frozen lockfile.
+
+runs:
+    using: composite
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Read Node version
+          id: node-version
+          shell: bash
+          run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+
+        - name: Setup pnpm
+          uses: pnpm/action-setup@v4
+
+        - name: Setup Node.js
+          uses: actions/setup-node@v4
+          with:
+              node-version: ${{ steps.node-version.outputs.version }}
+              cache: 'pnpm'
+
+        - name: Install dependencies
+          shell: bash
+          run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,24 +16,8 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Read Node version
-              id: node-version
-              run: echo "version=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v4
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ steps.node-version.outputs.version }}
-                  cache: 'pnpm'
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup Node and pnpm
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Build trpc-devtools
               run: pnpm -F trpc-devtools build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
             TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
         steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
             - name: Setup Node and pnpm
               uses: ./.github/actions/setup-node-pnpm
 

--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -20,6 +20,9 @@ jobs:
                     - env: prod
                       db-secret: DATABASE_URL_PROD
         steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
             - name: Setup Node and pnpm
               uses: ./.github/actions/setup-node-pnpm
 

--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -20,24 +20,8 @@ jobs:
                     - env: prod
                       db-secret: DATABASE_URL_PROD
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Read Node version
-              id: node-version
-              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v4
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ steps.node-version.outputs.version }}
-                  cache: 'pnpm'
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup Node and pnpm
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Verify database secret is configured
               env:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -15,24 +15,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Read Node version
-              id: node-version
-              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v4
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ steps.node-version.outputs.version }}
-                  cache: 'pnpm'
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup Node and pnpm
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Apply migrations
               run: pnpm -F db db:migrate
@@ -49,24 +33,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Read Node version
-              id: node-version
-              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v4
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ steps.node-version.outputs.version }}
-                  cache: 'pnpm'
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup Node and pnpm
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Verify DATABASE_URL_PROD secret is configured
               env:
@@ -104,24 +72,8 @@ jobs:
             BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
 
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Read Node version
-              id: node-version
-              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v4
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ steps.node-version.outputs.version }}
-                  cache: 'pnpm'
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup Node and pnpm
+              uses: ./.github/actions/setup-node-pnpm
 
             - name: Get Playwright version
               id: playwright-version

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -15,6 +15,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
             - name: Setup Node and pnpm
               uses: ./.github/actions/setup-node-pnpm
 
@@ -33,6 +36,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
             - name: Setup Node and pnpm
               uses: ./.github/actions/setup-node-pnpm
 
@@ -72,6 +78,9 @@ jobs:
             BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
 
         steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
             - name: Setup Node and pnpm
               uses: ./.github/actions/setup-node-pnpm
 

--- a/.github/workflows/s3-event-health.yml
+++ b/.github/workflows/s3-event-health.yml
@@ -58,24 +58,8 @@ jobs:
                       exit 1
                   fi
 
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Read Node version
-              id: node-version
-              run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v4
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ steps.node-version.outputs.version }}
-                  cache: 'pnpm'
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup Node and pnpm
+              uses: ./.github/actions/setup-node-pnpm
 
             # The scripts load env via `tsx --env-file=.env.local`, which
             # errors if the file is missing; real values come from the job

--- a/.github/workflows/s3-event-health.yml
+++ b/.github/workflows/s3-event-health.yml
@@ -58,6 +58,9 @@ jobs:
                       exit 1
                   fi
 
+            - name: Checkout
+              uses: actions/checkout@v4
+
             - name: Setup Node and pnpm
               uses: ./.github/actions/setup-node-pnpm
 


### PR DESCRIPTION
## Summary

Extracts the shared boilerplate (read Node version from `.nvmrc` → setup pnpm → setup Node.js → `pnpm install --frozen-lockfile`) into a reusable composite action at `.github/actions/setup-node-pnpm/action.yml`.

Each job now runs `checkout` then a single `uses:` for the setup action, collapsing five near-identical steps to two across six jobs:
- `ci.yml`
- `post-merge.yml` (migrate, migrate-prod, smoke-tests)
- `migration-drift.yml`
- `s3-event-health.yml`

`actionlint` clean.

## Notes

- Checkout stays in each workflow rather than inside the composite action: a local `./.github/actions/...` reference can't run `actions/checkout` itself, since the action's own files must already be on disk when the runner resolves it.
- `s3-event-health.yml` runs a "verify database secret" step before checkout; that ordering is preserved.
- `publish-trpc-devtools.yml` is a different shape — it hardcodes `node-version: 24` and never reads `.nvmrc` — so it's left untouched to keep this a pure refactor.

Closes #297