### PR TITLE
feat: add admin invites page for sponsored-access management

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
@@ -18,7 +18,9 @@ import { TablePagination } from '@/components/ui/table-pagination';
 import { cn } from '@/lib/cn';
 import { formatBytes, formatDate, formatRelativeTime } from '@/lib/format';
 import { useTRPC } from '@/lib/trpc/client';
+import { SPONSORED_DEFAULT_STORAGE_LIMIT } from '@/server/services/constants';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { addDays } from 'date-fns';
 import { Ban, Check, Copy, Loader2, RotateCw, Send } from 'lucide-react';
 import { toast } from 'sonner';
 import type { Invite } from '@nexus/db/repo/invites';
@@ -250,7 +252,7 @@ function CreateInviteForm({ onCreated }: CreateInviteFormProps) {
             storageLimit:
                 storageGb && gb > 0 ? Math.round(gb * BYTES_PER_GB) : undefined,
             expiresAt: expiresInDays
-                ? new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
+                ? addDays(new Date(), expiresInDays)
                 : undefined,
         });
     }
@@ -287,7 +289,7 @@ function CreateInviteForm({ onCreated }: CreateInviteFormProps) {
                                 id="invite-storage"
                                 type="number"
                                 min={1}
-                                placeholder="Default (10 TB)"
+                                placeholder={`Default (${formatBytes(SPONSORED_DEFAULT_STORAGE_LIMIT)})`}
                                 value={storageGb}
                                 onChange={(e) => setStorageGb(e.target.value)}
                             />

--- a/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
@@ -28,7 +28,7 @@ import type { Invite } from '@nexus/db/repo/invites';
 type InviteStatus = Invite['status'];
 
 const PAGE_SIZE = 20;
-const BYTES_PER_GB = 1024 ** 3;
+const BYTES_PER_TB = 1024 ** 4;
 
 const STATUS_FILTERS: { label: string; value: InviteStatus | undefined }[] = [
     { label: 'All', value: undefined },
@@ -158,9 +158,16 @@ export default function AdminInvitesPage() {
                                         />
                                     </TableCell>
                                     <TableCell className="text-muted-foreground">
-                                        {invite.storageLimit
-                                            ? formatBytes(invite.storageLimit)
-                                            : 'Default'}
+                                        {formatBytes(
+                                            invite.storageLimit ??
+                                                SPONSORED_DEFAULT_STORAGE_LIMIT
+                                        )}
+                                        {invite.storageLimit === null && (
+                                            <span className="text-muted-foreground/60">
+                                                {' '}
+                                                (default)
+                                            </span>
+                                        )}
                                     </TableCell>
                                     <TableCell className="text-muted-foreground">
                                         {formatRelativeTime(invite.createdAt)}
@@ -224,7 +231,7 @@ interface CreateInviteFormProps {
 function CreateInviteForm({ onCreated }: CreateInviteFormProps) {
     const trpc = useTRPC();
     const [email, setEmail] = useState('');
-    const [storageGb, setStorageGb] = useState('');
+    const [storageTb, setStorageTb] = useState('');
     const [expiresInDays, setExpiresInDays] = useState<number | undefined>();
     const [lastCreated, setLastCreated] = useState<{
         url: string;
@@ -236,7 +243,7 @@ function CreateInviteForm({ onCreated }: CreateInviteFormProps) {
             onSuccess(data) {
                 setLastCreated({ url: data.url, email: data.invite.email });
                 setEmail('');
-                setStorageGb('');
+                setStorageTb('');
                 setExpiresInDays(undefined);
                 toast.success('Invite created');
                 onCreated();
@@ -246,11 +253,11 @@ function CreateInviteForm({ onCreated }: CreateInviteFormProps) {
 
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
-        const gb = Number(storageGb);
+        const tb = Number(storageTb);
         createMutation.mutate({
             email: email.trim() || undefined,
             storageLimit:
-                storageGb && gb > 0 ? Math.round(gb * BYTES_PER_GB) : undefined,
+                storageTb && tb > 0 ? Math.round(tb * BYTES_PER_TB) : undefined,
             expiresAt: expiresInDays
                 ? addDays(new Date(), expiresInDays)
                 : undefined,
@@ -282,16 +289,17 @@ function CreateInviteForm({ onCreated }: CreateInviteFormProps) {
                             <Label htmlFor="invite-storage">
                                 Storage limit{' '}
                                 <span className="font-normal text-muted-foreground">
-                                    (GB)
+                                    (TB)
                                 </span>
                             </Label>
                             <Input
                                 id="invite-storage"
                                 type="number"
-                                min={1}
+                                min={0.1}
+                                step={0.1}
                                 placeholder={`Default (${formatBytes(SPONSORED_DEFAULT_STORAGE_LIMIT)})`}
-                                value={storageGb}
-                                onChange={(e) => setStorageGb(e.target.value)}
+                                value={storageTb}
+                                onChange={(e) => setStorageTb(e.target.value)}
                             />
                         </div>
                     </div>

--- a/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
@@ -1,0 +1,421 @@
+'use client';
+
+import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { TablePagination } from '@/components/ui/table-pagination';
+import { cn } from '@/lib/cn';
+import { formatBytes, formatDate, formatRelativeTime } from '@/lib/format';
+import { useTRPC } from '@/lib/trpc/client';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Ban, Check, Copy, Loader2, RotateCw, Send } from 'lucide-react';
+import { toast } from 'sonner';
+import type { Invite } from '@nexus/db/repo/invites';
+
+type InviteStatus = Invite['status'];
+
+const PAGE_SIZE = 20;
+const BYTES_PER_GB = 1024 ** 3;
+
+const STATUS_FILTERS: { label: string; value: InviteStatus | undefined }[] = [
+    { label: 'All', value: undefined },
+    { label: 'Pending', value: 'pending' },
+    { label: 'Redeemed', value: 'redeemed' },
+    { label: 'Revoked', value: 'revoked' },
+];
+
+const EXPIRY_PRESETS: { label: string; days: number | undefined }[] = [
+    { label: 'Never', days: undefined },
+    { label: '7 days', days: 7 },
+    { label: '30 days', days: 30 },
+    { label: '90 days', days: 90 },
+];
+
+export default function AdminInvitesPage() {
+    const trpc = useTRPC();
+    const queryClient = useQueryClient();
+    const [statusFilter, setStatusFilter] = useState<
+        InviteStatus | undefined
+    >();
+    const [page, setPage] = useState(0);
+
+    const listOptions = trpc.admin.invites.list.queryOptions({
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
+        status: statusFilter,
+    });
+    const { data, isLoading, isFetching } = useQuery(listOptions);
+
+    function invalidateList() {
+        queryClient.invalidateQueries({
+            queryKey: trpc.admin.invites.list.queryKey(),
+        });
+    }
+
+    const revokeMutation = useMutation(
+        trpc.admin.invites.revoke.mutationOptions({
+            onSuccess() {
+                toast.success('Invite revoked');
+                invalidateList();
+            },
+        })
+    );
+
+    return (
+        <div className="mx-auto max-w-6xl space-y-6">
+            <div>
+                <h1 className="text-2xl font-bold">Invites</h1>
+                <p className="text-muted-foreground">
+                    Create and manage sponsored-access invites for alpha testers
+                </p>
+            </div>
+
+            <CreateInviteForm onCreated={invalidateList} />
+
+            <div className="flex items-center gap-2">
+                {STATUS_FILTERS.map((filter) => (
+                    <Button
+                        key={filter.label}
+                        variant={
+                            statusFilter === filter.value
+                                ? 'default'
+                                : 'outline'
+                        }
+                        size="sm"
+                        onClick={() => {
+                            setStatusFilter(filter.value);
+                            setPage(0);
+                        }}
+                    >
+                        {filter.label}
+                    </Button>
+                ))}
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={invalidateList}
+                    disabled={isFetching}
+                    title="Refresh"
+                    className="ml-auto"
+                >
+                    <RotateCw
+                        className={cn('size-4', isFetching && 'animate-spin')}
+                    />
+                </Button>
+            </div>
+
+            <Card>
+                {isLoading ? (
+                    <CardContent className="flex items-center justify-center py-12">
+                        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                    </CardContent>
+                ) : !data?.invites.length ? (
+                    <CardContent className="flex flex-col items-center justify-center py-12">
+                        <p className="text-muted-foreground">
+                            No invites found
+                        </p>
+                    </CardContent>
+                ) : (
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Recipient</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead>Storage</TableHead>
+                                <TableHead>Created</TableHead>
+                                <TableHead>Expires</TableHead>
+                                <TableHead className="w-20" />
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {data.invites.map((invite) => (
+                                <TableRow key={invite.id}>
+                                    <TableCell
+                                        className={cn(
+                                            'font-medium',
+                                            !invite.email &&
+                                                'text-muted-foreground italic'
+                                        )}
+                                    >
+                                        {invite.email ?? 'Link only'}
+                                    </TableCell>
+                                    <TableCell>
+                                        <InviteStatusBadge
+                                            status={invite.status}
+                                        />
+                                    </TableCell>
+                                    <TableCell className="text-muted-foreground">
+                                        {invite.storageLimit
+                                            ? formatBytes(invite.storageLimit)
+                                            : 'Default'}
+                                    </TableCell>
+                                    <TableCell className="text-muted-foreground">
+                                        {formatRelativeTime(invite.createdAt)}
+                                    </TableCell>
+                                    <TableCell className="text-muted-foreground">
+                                        {invite.expiresAt
+                                            ? formatDate(invite.expiresAt)
+                                            : '—'}
+                                    </TableCell>
+                                    <TableCell>
+                                        {invite.status === 'pending' && (
+                                            <div className="flex justify-end gap-1">
+                                                <CopyLinkButton
+                                                    token={invite.token}
+                                                />
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    onClick={() =>
+                                                        revokeMutation.mutate({
+                                                            id: invite.id,
+                                                        })
+                                                    }
+                                                    disabled={
+                                                        revokeMutation.isPending
+                                                    }
+                                                    title="Revoke invite"
+                                                >
+                                                    {revokeMutation.isPending &&
+                                                    revokeMutation.variables
+                                                        ?.id === invite.id ? (
+                                                        <Loader2 className="h-4 w-4 animate-spin" />
+                                                    ) : (
+                                                        <Ban className="h-4 w-4" />
+                                                    )}
+                                                </Button>
+                                            </div>
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                )}
+            </Card>
+
+            <TablePagination
+                page={page}
+                pageSize={PAGE_SIZE}
+                total={data?.total ?? 0}
+                onPageChange={setPage}
+            />
+        </div>
+    );
+}
+
+interface CreateInviteFormProps {
+    onCreated: () => void;
+}
+
+function CreateInviteForm({ onCreated }: CreateInviteFormProps) {
+    const trpc = useTRPC();
+    const [email, setEmail] = useState('');
+    const [storageGb, setStorageGb] = useState('');
+    const [expiresInDays, setExpiresInDays] = useState<number | undefined>();
+    const [lastCreated, setLastCreated] = useState<{
+        url: string;
+        email: string | null;
+    } | null>(null);
+
+    const createMutation = useMutation(
+        trpc.admin.invites.create.mutationOptions({
+            onSuccess(data) {
+                setLastCreated({ url: data.url, email: data.invite.email });
+                setEmail('');
+                setStorageGb('');
+                setExpiresInDays(undefined);
+                toast.success('Invite created');
+                onCreated();
+            },
+        })
+    );
+
+    function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        const gb = Number(storageGb);
+        createMutation.mutate({
+            email: email.trim() || undefined,
+            storageLimit:
+                storageGb && gb > 0 ? Math.round(gb * BYTES_PER_GB) : undefined,
+            expiresAt: expiresInDays
+                ? new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
+                : undefined,
+        });
+    }
+
+    return (
+        <Card>
+            <CardContent className="space-y-4 p-4">
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="grid gap-4 sm:grid-cols-[2fr_1fr]">
+                        <div className="space-y-1.5">
+                            <Label htmlFor="invite-email">
+                                Email{' '}
+                                <span className="font-normal text-muted-foreground">
+                                    (optional — sends the invite; leave empty
+                                    for a shareable link)
+                                </span>
+                            </Label>
+                            <Input
+                                id="invite-email"
+                                type="email"
+                                placeholder="tester@example.com"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label htmlFor="invite-storage">
+                                Storage limit{' '}
+                                <span className="font-normal text-muted-foreground">
+                                    (GB)
+                                </span>
+                            </Label>
+                            <Input
+                                id="invite-storage"
+                                type="number"
+                                min={1}
+                                placeholder="Default (10 TB)"
+                                value={storageGb}
+                                onChange={(e) => setStorageGb(e.target.value)}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="flex flex-wrap items-end gap-4">
+                        <fieldset className="space-y-1.5">
+                            <legend className="text-sm font-medium">
+                                Expires
+                            </legend>
+                            <div className="flex gap-1.5">
+                                {EXPIRY_PRESETS.map((preset) => (
+                                    <Button
+                                        key={preset.label}
+                                        type="button"
+                                        variant={
+                                            expiresInDays === preset.days
+                                                ? 'default'
+                                                : 'outline'
+                                        }
+                                        size="sm"
+                                        onClick={() =>
+                                            setExpiresInDays(preset.days)
+                                        }
+                                    >
+                                        {preset.label}
+                                    </Button>
+                                ))}
+                            </div>
+                        </fieldset>
+                        <Button
+                            type="submit"
+                            disabled={createMutation.isPending}
+                            className="ml-auto"
+                        >
+                            {createMutation.isPending ? (
+                                <Loader2 className="mr-1.5 size-4 animate-spin" />
+                            ) : (
+                                <Send className="mr-1.5 size-4" />
+                            )}
+                            Create invite
+                        </Button>
+                    </div>
+                </form>
+
+                {lastCreated && (
+                    <div
+                        role="status"
+                        className="flex items-center gap-2 rounded-md border border-green-500/20 bg-green-500/5 px-3 py-2"
+                    >
+                        <div className="min-w-0 flex-1">
+                            <p className="text-sm text-green-600">
+                                {lastCreated.email
+                                    ? `Invite emailed to ${lastCreated.email}`
+                                    : 'Invite link created — share it manually'}
+                            </p>
+                            <p className="truncate font-mono text-xs text-muted-foreground">
+                                {lastCreated.url}
+                            </p>
+                        </div>
+                        <CopyUrlButton url={lastCreated.url} />
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function InviteStatusBadge({ status }: { status: InviteStatus }) {
+    switch (status) {
+        case 'pending':
+            return (
+                <Badge
+                    variant="secondary"
+                    className="bg-blue-500/10 text-blue-600"
+                >
+                    Pending
+                </Badge>
+            );
+        case 'redeemed':
+            return (
+                <Badge
+                    variant="secondary"
+                    className="bg-green-500/10 text-green-600"
+                >
+                    Redeemed
+                </Badge>
+            );
+        case 'revoked':
+            return (
+                <Badge
+                    variant="secondary"
+                    className="bg-red-500/10 text-red-600"
+                >
+                    Revoked
+                </Badge>
+            );
+    }
+}
+
+function CopyLinkButton({ token }: { token: string }) {
+    return <CopyUrlButton url={`/invite/${token}`} title="Copy invite link" />;
+}
+
+interface CopyUrlButtonProps {
+    /** Absolute URL, or a path resolved against the current origin on click. */
+    url: string;
+    title?: string;
+}
+
+function CopyUrlButton({ url, title = 'Copy link' }: CopyUrlButtonProps) {
+    const [isCopied, setIsCopied] = useState(false);
+
+    async function handleCopy() {
+        const absolute = new URL(url, window.location.origin).toString();
+        await navigator.clipboard.writeText(absolute);
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), 1500);
+    }
+
+    return (
+        <Button variant="ghost" size="icon" onClick={handleCopy} title={title}>
+            {isCopied ? (
+                <Check className="h-4 w-4 text-green-600" />
+            ) : (
+                <Copy className="h-4 w-4" />
+            )}
+        </Button>
+    );
+}

--- a/apps/web/e2e/admin/files.spec.ts
+++ b/apps/web/e2e/admin/files.spec.ts
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test';
 import { findUserByEmail, type File } from '@nexus/db/test-db';
 import { ADMIN_USER } from '../helpers/auth';
 import { seedFiles, cleanupFiles } from '../helpers/scenarios';
+import { waitForTableLoad } from '../helpers/table';
 
 const PAGE_URL = '/dashboard/files';
 
@@ -27,7 +28,7 @@ test.describe('sequential file deletion', () => {
         { tag: ['@page:/dashboard/files', '@uc:files-delete-single'] },
         async ({ page }) => {
             await page.goto(PAGE_URL);
-            await waitForFileList(page);
+            await waitForTableLoad(page, 'No files yet');
 
             // Verify all 3 seeded files are visible
             for (const file of seededFiles) {
@@ -58,14 +59,6 @@ test.describe('sequential file deletion', () => {
         }
     );
 });
-
-async function waitForFileList(page: Page): Promise<void> {
-    await page
-        .locator('table')
-        .or(page.getByText('No files yet'))
-        .first()
-        .waitFor({ timeout: 10_000 });
-}
 
 async function deleteFileByName(page: Page, name: string): Promise<void> {
     // Find the row containing the file name and click its actions menu

--- a/apps/web/e2e/admin/invites.spec.ts
+++ b/apps/web/e2e/admin/invites.spec.ts
@@ -72,6 +72,13 @@ test.describe('admin invites', () => {
                 .filter({ hasText: SEEDED_EMAIL });
             await expect(row.getByText('Pending')).toBeVisible();
             await expect(row.getByText('2 TB')).toBeVisible();
+
+            // Invites without a per-tester override show the effective
+            // sponsored default, marked as such.
+            const defaultRow = page
+                .locator('tbody tr')
+                .filter({ hasText: REVOKE_EMAIL });
+            await expect(defaultRow.getByText('(default)')).toBeVisible();
         }
     );
 

--- a/apps/web/e2e/admin/invites.spec.ts
+++ b/apps/web/e2e/admin/invites.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '../fixtures';
+import {
+    insertInvite,
+    deleteInvite,
+    deleteInvitesByEmail,
+    deleteInviteByToken,
+    findUserByEmail,
+    type Invite,
+} from '@nexus/db/test-db';
+import { ADMIN_USER } from '../helpers/auth';
+import { waitForTableLoad } from '../helpers/table';
+
+const PAGE_URL = '/dashboard/admin/invites';
+
+// Unique per run so a crashed previous run can't collide; cleaned in afterAll.
+const RUN_ID = `${Date.now()}-${process.pid}`;
+const SEEDED_EMAIL = `invite-seeded-${RUN_ID}@test.local`;
+const REVOKE_EMAIL = `invite-revoke-${RUN_ID}@test.local`;
+const CREATED_EMAIL = `invite-created-${RUN_ID}@test.local`;
+
+// Admin project applies the admin storageState at the project level; align the
+// fixture chain's storageState override to it.
+test.use({ userRole: 'admin' });
+
+// Run serially — tests share seeded rows and mutate the same table.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('admin invites', () => {
+    let seeded: Invite[] = [];
+    // Token of the link-only invite created through the UI, for cleanup.
+    let createdToken: string | undefined;
+
+    test.beforeAll(async ({ db }) => {
+        const admin = await findUserByEmail(db, ADMIN_USER.email);
+        if (!admin) throw new Error('Shared admin e2e user not found');
+
+        seeded = await Promise.all([
+            insertInvite(db, {
+                createdBy: admin.id,
+                email: SEEDED_EMAIL,
+                // 2 TB, to assert the formatted storage cell
+                storageLimit: 2 * 1024 ** 4,
+                expiresAt: new Date(Date.now() + 7 * 86_400_000),
+            }),
+            insertInvite(db, { createdBy: admin.id, status: 'revoked' }),
+            insertInvite(db, { createdBy: admin.id, email: REVOKE_EMAIL }),
+        ]);
+    });
+
+    test.afterAll(async ({ db }) => {
+        await Promise.all(seeded.map((invite) => deleteInvite(db, invite.id)));
+        await deleteInvitesByEmail(db, CREATED_EMAIL);
+        if (createdToken) await deleteInviteByToken(db, createdToken);
+    });
+
+    test(
+        'table renders seeded invites with recipient, status, and details',
+        { tag: ['@page:/dashboard/admin/invites', '@uc:admin-invites-table'] },
+        async ({ page }) => {
+            await page.goto(PAGE_URL);
+            await waitForTableLoad(page, 'No invites found');
+
+            const headers = page.locator('thead th');
+            await expect(headers.nth(0)).toHaveText('Recipient');
+            await expect(headers.nth(1)).toHaveText('Status');
+            await expect(headers.nth(2)).toHaveText('Storage');
+            await expect(headers.nth(3)).toHaveText('Created');
+            await expect(headers.nth(4)).toHaveText('Expires');
+
+            const row = page
+                .locator('tbody tr')
+                .filter({ hasText: SEEDED_EMAIL });
+            await expect(row.getByText('Pending')).toBeVisible();
+            await expect(row.getByText('2 TB')).toBeVisible();
+        }
+    );
+
+    test(
+        'status filters update the table',
+        { tag: ['@page:/dashboard/admin/invites', '@uc:admin-invites-filter'] },
+        async ({ page }) => {
+            await page.goto(PAGE_URL);
+            await waitForTableLoad(page, 'No invites found');
+
+            await page
+                .getByRole('button', { name: 'Revoked', exact: true })
+                .click();
+            await waitForTableLoad(page, 'No invites found');
+
+            const badges = page.locator('tbody td:nth-child(2)');
+            const count = await badges.count();
+            expect(count).toBeGreaterThan(0);
+            for (let i = 0; i < count; i++) {
+                await expect(badges.nth(i)).toHaveText('Revoked');
+            }
+
+            await page
+                .getByRole('button', { name: 'All', exact: true })
+                .click();
+            await waitForTableLoad(page, 'No invites found');
+        }
+    );
+
+    test(
+        'creating a link-only invite shows the shareable URL',
+        { tag: ['@page:/dashboard/admin/invites', '@uc:admin-invites-create'] },
+        async ({ page }) => {
+            await page.goto(PAGE_URL);
+            await waitForTableLoad(page, 'No invites found');
+
+            await page.getByRole('button', { name: 'Create invite' }).click();
+
+            // Locate by message text, not role="status" — Sonner's toast
+            // also carries that role and would trip strict mode.
+            const message = page.getByText(
+                'Invite link created — share it manually'
+            );
+            await expect(message).toBeVisible();
+
+            const url =
+                (await message
+                    .locator('..')
+                    .locator('p')
+                    .nth(1)
+                    .textContent()) ?? '';
+            const token = /\/invite\/([A-Za-z0-9_-]+)/.exec(url)?.[1];
+            expect(token).toBeTruthy();
+            createdToken = token;
+        }
+    );
+
+    test(
+        'creating an email-bound invite confirms the recipient and lists it',
+        { tag: ['@page:/dashboard/admin/invites', '@uc:admin-invites-create'] },
+        async ({ page }) => {
+            await page.goto(PAGE_URL);
+            await waitForTableLoad(page, 'No invites found');
+
+            await page.getByLabel(/email/i).fill(CREATED_EMAIL);
+            await page.getByRole('button', { name: 'Create invite' }).click();
+
+            await expect(
+                page.getByText(`Invite emailed to ${CREATED_EMAIL}`)
+            ).toBeVisible();
+
+            // The list invalidates on creation — the new invite appears.
+            await expect(
+                page.locator('tbody tr').filter({ hasText: CREATED_EMAIL })
+            ).toBeVisible();
+        }
+    );
+
+    test(
+        'revoking a pending invite flips its status badge',
+        { tag: ['@page:/dashboard/admin/invites', '@uc:admin-invites-revoke'] },
+        async ({ page }) => {
+            await page.goto(PAGE_URL);
+            await waitForTableLoad(page, 'No invites found');
+
+            const row = page
+                .locator('tbody tr')
+                .filter({ hasText: REVOKE_EMAIL });
+            await expect(row.getByText('Pending')).toBeVisible();
+
+            await row.getByRole('button', { name: 'Revoke invite' }).click();
+
+            await expect(row.getByText('Revoked')).toBeVisible();
+            // Revoked rows lose their pending-only actions.
+            await expect(
+                row.getByRole('button', { name: 'Revoke invite' })
+            ).toHaveCount(0);
+        }
+    );
+});

--- a/apps/web/e2e/admin/jobs.spec.ts
+++ b/apps/web/e2e/admin/jobs.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '../fixtures';
 import type { Page } from '@playwright/test';
 import { USER_STATE_PATH } from '../helpers/auth';
+import { waitForTableLoad } from '../helpers/table';
 import { waitForTrpcRequest } from '../helpers/trpc';
 import { countJobsByStatus, type Job } from '@nexus/db/test-db';
 import { seedJobs, cleanupJobs } from '../helpers/scenarios';
@@ -76,7 +77,7 @@ test.describe('dashboard with seeded data', () => {
             const dbCounts = await countJobsByStatus(db);
 
             await page.goto(PAGE_URL);
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             await assertStatusCard(page, 'Pending', dbCounts.pending);
             await assertStatusCard(page, 'Processing', dbCounts.processing);
@@ -90,7 +91,7 @@ test.describe('dashboard with seeded data', () => {
         { tag: ['@uc:admin-jobs-table'] },
         async ({ page }) => {
             await page.goto(PAGE_URL);
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             const headers = page.locator('thead th');
             await expect(headers.nth(0)).toHaveText('Type');
@@ -110,12 +111,12 @@ test.describe('dashboard with seeded data', () => {
         { tag: ['@uc:admin-jobs-filter'] },
         async ({ page }) => {
             await page.goto(PAGE_URL);
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             await page
                 .getByRole('button', { name: 'Failed', exact: true })
                 .click();
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             const badges = page.locator('tbody td:nth-child(2)');
             const count = await badges.count();
@@ -127,7 +128,7 @@ test.describe('dashboard with seeded data', () => {
             await page
                 .getByRole('button', { name: 'All', exact: true })
                 .click();
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
         }
     );
 
@@ -136,7 +137,7 @@ test.describe('dashboard with seeded data', () => {
         { tag: ['@uc:admin-jobs-filter'] },
         async ({ page }) => {
             await page.goto(PAGE_URL);
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             // "Processing" was not seeded — filtering to it should show empty state
             await page
@@ -167,12 +168,12 @@ test.describe('pagination', () => {
             const totalPending = dbCounts.pending;
 
             await page.goto(PAGE_URL);
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             await page
                 .getByRole('button', { name: 'Pending', exact: true })
                 .click();
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             const totalPages = Math.ceil(totalPending / 20);
             await expect(
@@ -188,7 +189,7 @@ test.describe('pagination', () => {
             ).toBeVisible();
 
             await page.getByRole('button', { name: 'Next page' }).click();
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             await expect(
                 page.getByText(`Page 2 of ${totalPages}`)
@@ -202,7 +203,7 @@ test.describe('pagination', () => {
             ).toBeVisible();
 
             await page.getByRole('button', { name: 'Previous page' }).click();
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             await expect(
                 page.getByText(`Page 1 of ${totalPages}`)
@@ -217,7 +218,7 @@ test.describe('refresh', () => {
         { tag: ['@uc:admin-jobs-refresh'] },
         async ({ page }) => {
             await page.goto(PAGE_URL);
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             // Refresh must refetch BOTH procedures the page renders from.
             // Waits start before the click so the requests are attributable
@@ -231,7 +232,7 @@ test.describe('refresh', () => {
             await listRefetch;
             await countsRefetch;
             // Refetched data renders (not an error/blank state).
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
         }
     );
 });
@@ -252,13 +253,13 @@ test.describe('retry', () => {
         { tag: ['@uc:admin-jobs-retry'] },
         async ({ page }) => {
             await page.goto(PAGE_URL);
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             // Filter to completed — retry button should NOT appear
             await page
                 .getByRole('button', { name: 'Completed', exact: true })
                 .click();
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
             await expect(
                 page.getByRole('button', { name: 'Retry job' })
             ).toHaveCount(0);
@@ -267,7 +268,7 @@ test.describe('retry', () => {
             await page
                 .getByRole('button', { name: 'Failed', exact: true })
                 .click();
-            await waitForDataLoad(page);
+            await waitForTableLoad(page, 'No jobs found');
 
             const retryButton = page.getByRole('button', { name: 'Retry job' });
             await expect(retryButton.first()).toBeVisible();
@@ -282,14 +283,6 @@ test.describe('retry', () => {
         }
     );
 });
-
-async function waitForDataLoad(page: Page): Promise<void> {
-    await page
-        .locator('table')
-        .or(page.getByText('No jobs found'))
-        .first()
-        .waitFor({ timeout: 10_000 });
-}
 
 async function assertStatusCard(
     page: Page,

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -34,6 +34,7 @@ export type Area =
     | 'upload'
     | 'billing'
     | 'settings'
+    | 'admin-invites'
     | 'admin-jobs'
     | 'admin-dev-tools'
     | 'errors'
@@ -66,6 +67,11 @@ export const PAGES: PageEntry[] = [
     { route: '/dashboard/files', title: 'Files', auth: 'user' },
     { route: '/dashboard/upload', title: 'Upload', auth: 'user' },
     { route: '/dashboard/settings', title: 'Settings', auth: 'user' },
+    {
+        route: '/dashboard/admin/invites',
+        title: 'Admin · Invites',
+        auth: 'admin',
+    },
     { route: '/dashboard/admin/jobs', title: 'Admin · Jobs', auth: 'admin' },
     {
         route: '/dashboard/admin/dev-tools',
@@ -457,6 +463,34 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/settings'],
         excluded:
             'Placeholder UI — no backend wired up yet (button is a no-op)',
+    },
+
+    /* ---------------------------------------------------------------- */
+    /* Admin · Invites                                                   */
+    /* ---------------------------------------------------------------- */
+    {
+        id: 'admin-invites-create',
+        title: 'Create an invite (email-bound or link-only) and get the invite URL',
+        area: 'admin-invites',
+        routes: ['/dashboard/admin/invites'],
+    },
+    {
+        id: 'admin-invites-table',
+        title: 'Invites table renders seeded invites with recipient, status, and details',
+        area: 'admin-invites',
+        routes: ['/dashboard/admin/invites'],
+    },
+    {
+        id: 'admin-invites-filter',
+        title: 'Status filters update the invites table',
+        area: 'admin-invites',
+        routes: ['/dashboard/admin/invites'],
+    },
+    {
+        id: 'admin-invites-revoke',
+        title: 'Revoke a pending invite from the table',
+        area: 'admin-invites',
+        routes: ['/dashboard/admin/invites'],
     },
 
     /* ---------------------------------------------------------------- */

--- a/apps/web/e2e/helpers/table.ts
+++ b/apps/web/e2e/helpers/table.ts
@@ -1,0 +1,16 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Waits for a data-table page to finish loading: either the table itself or
+ * the page's empty-state text, whichever renders first.
+ */
+export async function waitForTableLoad(
+    page: Page,
+    emptyStateText: string
+): Promise<void> {
+    await page
+        .locator('table')
+        .or(page.getByText(emptyStateText))
+        .first()
+        .waitFor({ timeout: 10_000 });
+}

--- a/apps/web/e2e/smoke/authenticated/admin-invites.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/admin-invites.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '../../fixtures/authenticated';
+
+test.use({ userRole: 'admin' });
+
+test.describe('Admin Invites', () => {
+    test(
+        'admin invites page renders without console errors',
+        { tag: ['@page:/dashboard/admin/invites'] },
+        async ({ page, consoleErrors }) => {
+            await page.goto('/dashboard/admin/invites');
+
+            await expect(
+                page.getByRole('heading', { name: /invites/i })
+            ).toBeVisible();
+
+            expect(consoleErrors).toEqual([]);
+        }
+    );
+});

--- a/apps/web/lib/dashboard/navigation.ts
+++ b/apps/web/lib/dashboard/navigation.ts
@@ -5,6 +5,7 @@ import {
     ListChecks,
     Settings,
     Upload,
+    UserPlus,
     Wrench,
 } from 'lucide-react';
 
@@ -20,6 +21,12 @@ export const dashboardNavigation: NavItem[] = [
     { name: 'Files', href: '/dashboard/files', icon: FolderOpen },
     { name: 'Upload', href: '/dashboard/upload', icon: Upload },
     { name: 'Settings', href: '/dashboard/settings', icon: Settings },
+    {
+        name: 'Invites',
+        href: '/dashboard/admin/invites',
+        icon: UserPlus,
+        isAdminOnly: true,
+    },
     {
         name: 'Jobs',
         href: '/dashboard/admin/jobs',

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -56,15 +56,25 @@ export default defineConfig({
             dependencies: ['admin-files'],
             testMatch: /admin\/jobs\.spec\.ts/,
         },
+        {
+            name: 'admin-invites',
+            use: adminChrome,
+            dependencies: ['admin-jobs'],
+            testMatch: /admin\/invites\.spec\.ts/,
+        },
         // Catch-all tail of the chain: new admin specs land here
         // automatically. If this project ever holds more than one spec file,
         // give the new file its own chain link above.
         {
             name: 'admin',
             use: adminChrome,
-            dependencies: ['admin-jobs'],
+            dependencies: ['admin-invites'],
             testMatch: /admin\/.*/,
-            testIgnore: [/admin\/files\.spec\.ts/, /admin\/jobs\.spec\.ts/],
+            testIgnore: [
+                /admin\/files\.spec\.ts/,
+                /admin\/jobs\.spec\.ts/,
+                /admin\/invites\.spec\.ts/,
+            ],
         },
         // Interactive user flows with dedicated per-spec users (created in
         // each spec's beforeAll via provisionDedicatedUser) — isolated from

--- a/apps/web/server/trpc/routers/admin.ts
+++ b/apps/web/server/trpc/routers/admin.ts
@@ -5,6 +5,7 @@ import {
     type JobType,
     type SqsMessageBody,
 } from '@nexus/db/repo/jobs';
+import { createInviteRepo } from '@nexus/db/repo/invites';
 import { sendToQueue } from '@/lib/jobs/publish';
 import { inviteService } from '@/server/services/invites';
 import { adminProcedure, router } from '../init';
@@ -17,9 +18,38 @@ const jobStatusSchema = z.enum([
     'failed',
 ]);
 
+const inviteStatusSchema = z.enum(['pending', 'redeemed', 'revoked']);
+
 export const adminRouter = router({
     devTools: devToolsRouter,
     invites: router({
+        list: adminProcedure
+            .input(
+                z
+                    .object({
+                        limit: z.number().min(1).max(100).default(20),
+                        offset: z.number().min(0).default(0),
+                        status: inviteStatusSchema.optional(),
+                    })
+                    .optional()
+            )
+            .query(async ({ ctx, input }) => {
+                const inviteRepo = createInviteRepo(ctx.db);
+                const limit = input?.limit ?? 20;
+                const offset = input?.offset ?? 0;
+
+                const result = await inviteRepo.findMany({
+                    limit,
+                    offset,
+                    status: input?.status,
+                });
+
+                return {
+                    invites: result.invites,
+                    total: result.total,
+                };
+            }),
+
         create: adminProcedure
             .input(
                 z

--- a/packages/db/src/repositories/invites.test.ts
+++ b/packages/db/src/repositories/invites.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createMockDb, type MockDbMocks } from './mocks';
+import { createInviteFixture } from './fixtures';
+import { createInviteRepo, type InviteRepo } from './invites';
+
+describe('invites repository', () => {
+    let mocks: MockDbMocks;
+    let repo: InviteRepo;
+
+    beforeEach(() => {
+        const mockDb = createMockDb();
+        mocks = mockDb.mocks;
+        repo = createInviteRepo(mockDb.db);
+    });
+
+    describe('findMany', () => {
+        it('returns invites and total count', async () => {
+            const invites = [
+                createInviteFixture({ id: 'invite1' }),
+                createInviteFixture({ id: 'invite2' }),
+            ];
+            mocks.invites.findMany.mockResolvedValue(invites);
+            mocks.where.mockResolvedValue([{ count: 2 }]);
+
+            const result = await repo.findMany();
+
+            expect(result.invites).toEqual(invites);
+            expect(result.total).toBe(2);
+        });
+
+        it('uses default pagination (limit: 50, offset: 0)', async () => {
+            mocks.invites.findMany.mockResolvedValue([]);
+            mocks.where.mockResolvedValue([{ count: 0 }]);
+
+            await repo.findMany();
+
+            expect(mocks.invites.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({ limit: 50, offset: 0 })
+            );
+        });
+
+        it('respects custom pagination options', async () => {
+            mocks.invites.findMany.mockResolvedValue([]);
+            mocks.where.mockResolvedValue([{ count: 0 }]);
+
+            await repo.findMany({ limit: 10, offset: 20 });
+
+            expect(mocks.invites.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({ limit: 10, offset: 20 })
+            );
+        });
+
+        it('filters by status when provided', async () => {
+            mocks.invites.findMany.mockResolvedValue([]);
+            mocks.where.mockResolvedValue([{ count: 0 }]);
+
+            await repo.findMany({ limit: 50, offset: 0, status: 'pending' });
+
+            expect(mocks.invites.findMany).toHaveBeenCalledWith(
+                expect.objectContaining({ where: expect.anything() })
+            );
+        });
+
+        it('returns empty result when no invites exist', async () => {
+            mocks.invites.findMany.mockResolvedValue([]);
+            mocks.where.mockResolvedValue([{ count: 0 }]);
+
+            const result = await repo.findMany();
+
+            expect(result.invites).toEqual([]);
+            expect(result.total).toBe(0);
+        });
+    });
+});

--- a/packages/db/src/repositories/invites.ts
+++ b/packages/db/src/repositories/invites.ts
@@ -1,10 +1,21 @@
-import { and, eq, gt, isNull, or } from 'drizzle-orm';
+import { and, desc, eq, gt, isNull, or, sql } from 'drizzle-orm';
 import type { DB } from '../connection';
 import * as schema from '../schema';
 import { createRepository } from './create';
 
 export type Invite = typeof schema.invites.$inferSelect;
 export type NewInvite = typeof schema.invites.$inferInsert;
+
+interface FindManyOptions {
+    limit: number;
+    offset: number;
+    status?: Invite['status'];
+}
+
+interface FindManyResult {
+    invites: Invite[];
+    total: number;
+}
 
 function findById(db: DB, id: string): Promise<Invite | undefined> {
     return db.query.invites.findFirst({
@@ -16,6 +27,30 @@ function findByToken(db: DB, token: string): Promise<Invite | undefined> {
     return db.query.invites.findFirst({
         where: eq(schema.invites.token, token),
     });
+}
+
+async function findMany(
+    db: DB,
+    opts: FindManyOptions = { limit: 50, offset: 0 }
+): Promise<FindManyResult> {
+    const whereClause = opts.status
+        ? eq(schema.invites.status, opts.status)
+        : undefined;
+
+    const [invites, [countResult]] = await Promise.all([
+        db.query.invites.findMany({
+            where: whereClause,
+            orderBy: desc(schema.invites.createdAt),
+            limit: opts.limit,
+            offset: opts.offset,
+        }),
+        db
+            .select({ count: sql<number>`count(*)::int` })
+            .from(schema.invites)
+            .where(whereClause),
+    ]);
+
+    return { invites, total: countResult?.count ?? 0 };
 }
 
 async function insert(db: DB, data: NewInvite): Promise<Invite> {
@@ -67,6 +102,7 @@ async function revoke(db: DB, id: string): Promise<Invite | undefined> {
 export const createInviteRepo = createRepository({
     findById,
     findByToken,
+    findMany,
     insert,
     claim,
     revoke,

--- a/packages/db/src/test-db/queries.ts
+++ b/packages/db/src/test-db/queries.ts
@@ -84,6 +84,24 @@ export async function deleteInvite(db: DB, id: string): Promise<void> {
     await db.delete(schema.invites).where(eq(schema.invites.id, id));
 }
 
+// Cleanup for invites created through the UI, where the test never sees the
+// row id: email-bound ones are found by their unique test email, link-only
+// ones by the token extracted from the displayed invite URL.
+
+export async function deleteInvitesByEmail(
+    db: DB,
+    email: string
+): Promise<void> {
+    await db.delete(schema.invites).where(eq(schema.invites.email, email));
+}
+
+export async function deleteInviteByToken(
+    db: DB,
+    token: string
+): Promise<void> {
+    await db.delete(schema.invites).where(eq(schema.invites.token, token));
+}
+
 /**
  * Upserts the user's subscription to a fresh trial. Used by global setup (the
  * shared e2e users are reused across runs and may pre-date the signup trial


### PR DESCRIPTION
## Summary

Adds the missing last mile of the sponsored-access epic (#239/#247/#246/#252): an admin-facing surface to actually create and manage invites. The backend procedures existed but had zero callers.

- **`/dashboard/admin/invites` page** — create form (optional email, optional storage limit in GB, expiry presets) plus a table of all invites with status filters, pagination, copy-link and revoke actions on pending rows. Created invites surface their URL with a copy button; email-bound ones are sent automatically by the existing service path.
- **`admin.invites.list` tRPC procedure** + `findMany` on the invite repo (limit/offset required, mirroring the jobs repo).
- **Sidebar nav** — admin-only "Invites" item.
- **Tests** — repo unit tests, authenticated smoke spec, and a 5-test admin e2e spec driving the real flows (UI-driven create of both invite types, revoke, filters) with DB cleanup helpers added to test-db. New `admin-invites` Playwright chain link so admin specs stay serialized. Extracted the thrice-duplicated `waitForTableLoad` e2e helper.

## Test plan

- `pnpm check` — 10/10
- `pnpm -F web test:e2e:smoke` — 39/39
- `pnpm -F web test:e2e:admin` — 20/20
- `pnpm -F web e2e:coverage --check` — 15/15 pages, 67/67 use-cases

## Notes

- Deploying this is not enough to use it in prod: the admin account needs `role = 'admin'` set manually in nexus-prod (nothing promotes a user outside the seed scenario).

No-Issue: solo-dev free-form work by explicit owner decision; scope discussed in-session