### PR TITLE
feat: provision prod AWS environment via Terraform (#53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ playwright-report/
 # Terraform
 infra/terraform/.terraform/
 infra/terraform/*.tfstate*
+infra/terraform/worker-stub.zip
 
 # Obsidian vault metadata
 docs/.obsidian/workspace.json

--- a/docs/guides/background-jobs.md
+++ b/docs/guides/background-jobs.md
@@ -1,7 +1,7 @@
 ---
 title: Background Jobs Runbook
 created: 2026-02-15
-updated: 2026-02-15
+updated: 2026-07-05
 status: active
 tags:
     - guide
@@ -17,6 +17,9 @@ ai_summary: 'AWS resource ARNs, CLI provisioning commands, deployment, DLQ inspe
 # Background Jobs Runbook
 
 Operational guide for the SQS + Lambda background job infrastructure. For development patterns and conventions, see [[lambda-development|Lambda Development]].
+
+> [!important] Scope: dev only — prod is Terraform-managed.
+> Prod's queues, Lambda (`nexus-worker-prod`), and IAM live in `sa-east-1` and come from [`infra/terraform/`](../../infra/terraform/README.md) (#53). The code-deploy flow below applies to prod too (use `--function-name nexus-worker-prod --region sa-east-1`), but prod resource changes go through Terraform — including Lambda env vars (`DATABASE_URL`), so don't use `update-function-configuration` against prod.
 
 ## Provisioned Resources
 

--- a/docs/infra/aws-manual-setup.md
+++ b/docs/infra/aws-manual-setup.md
@@ -1,7 +1,7 @@
 ---
 title: AWS Manual Setup
 created: 2026-01-23
-updated: 2026-02-15
+updated: 2026-07-05
 status: active
 tags:
     - infra
@@ -14,6 +14,9 @@ ai_summary: 'Manual AWS provisioning commands for S3, IAM, and SNS resources in 
 # AWS Manual Setup (Dev Environment)
 
 This documents the manual AWS setup for the dev environment. Created 2026-01-23.
+
+> [!important] Scope: dev only — prod is Terraform-managed.
+> The **prod** environment (`sa-east-1`, `-prod` suffixes) is provisioned by Terraform in [`infra/terraform/`](../../infra/terraform/README.md), which is the source of truth for prod (#53). This runbook remains the spec for the hand-built dev resources until #127 recreates dev from the same Terraform config.
 
 ## Resources Created
 

--- a/docs/infra/supabase-manual-setup.md
+++ b/docs/infra/supabase-manual-setup.md
@@ -106,7 +106,7 @@ gh workflow run supabase-keepalive.yml
 ## Follow-Ups
 
 - **Repoint the Vercel production deployment** at the prod project: after setting the Production env vars above, redeploy production so it picks up the prod `DATABASE_URL`. Until then, the production deployment still points at dev.
-- **Prod AWS resources**: `s3-event-health.yml` runs its prod leg with dev AWS credentials (no prod S3 bucket exists yet — trivially green while prod is empty). Provision prod AWS resources and secrets when a prod bucket exists; see [[aws-manual-setup|AWS Manual Setup]] for the dev pattern. Put them in `sa-east-1` to match the prod database and the Brazilian user base — uploads go browser → S3 directly, so bucket proximity to users matters more than proximity to dev infrastructure.
+- **Prod AWS resources**: provisioned 2026-07-05 via Terraform (`infra/terraform/`, #53) in `sa-east-1`. Remaining: repoint `s3-event-health.yml`'s prod leg and the Vercel Production env vars at the prod resources (#291) — until then the prod leg still runs with dev AWS credentials.
 
 ## Related
 

--- a/infra/terraform/.terraform.lock.hcl
+++ b/infra/terraform/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.7"
+  hashes = [
+    "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,81 @@
+# Nexus Terraform
+
+Provisions one full Nexus AWS environment (S3 files bucket, SNS restore-events
+topic + webhook subscription, SQS jobs queues, worker Lambda, app IAM user),
+parameterized by `environment` and `region`. **Prod is managed here and is the
+source of truth** (#53). Dev is still the hand-built setup documented in
+`docs/infra/aws-manual-setup.md` and `docs/guides/background-jobs.md` until
+#127 recreates it from these same files.
+
+State lives in S3 (`nexus-terraform-state-391615358272`, us-east-1) with one
+workspace per environment. A guard resource fails the plan if the selected
+workspace doesn't match `var.environment`.
+
+## Prerequisites
+
+- Terraform >= 1.10 (`brew install hashicorp/tap/terraform`)
+- AWS credentials for account `391615358272`
+- One-time state bucket bootstrap (already done; kept for reference):
+
+```bash
+aws s3api create-bucket --bucket nexus-terraform-state-391615358272 --region us-east-1
+aws s3api put-bucket-versioning --bucket nexus-terraform-state-391615358272 \
+    --versioning-configuration Status=Enabled
+aws s3api put-bucket-encryption --bucket nexus-terraform-state-391615358272 \
+    --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+aws s3api put-public-access-block --bucket nexus-terraform-state-391615358272 \
+    --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+```
+
+## Apply (prod)
+
+```bash
+cd infra/terraform
+terraform init
+terraform workspace select prod || terraform workspace new prod
+
+# The worker Lambda's DATABASE_URL — the prod Supabase transaction-pooler URL
+# (port 6543, see docs/infra/supabase-manual-setup.md). Never commit it.
+# It is also stored (encrypted at rest) in the Terraform state bucket.
+set -x TF_VAR_database_url "postgresql://..."   # fish; bash: export TF_VAR_database_url=...
+
+terraform plan -var-file=environments/prod.tfvars
+terraform apply -var-file=environments/prod.tfvars
+```
+
+The SNS subscription only confirms if the app is already deployed and serving
+`https://<app_domain>/api/webhooks/s3-restore` — the route auto-confirms by
+fetching `SubscribeURL`, and Terraform waits for that.
+
+## After apply
+
+1. **App access key** (kept out of Terraform state on purpose):
+
+    ```bash
+    aws iam create-access-key --user-name nexus-app-prod
+    ```
+
+2. **Worker code** — Terraform ships a stub that throws on every invocation
+   (so jobs retry into the DLQ instead of silently succeeding). Deploy the
+   real worker per `docs/guides/background-jobs.md`, with
+   `--function-name nexus-worker-prod --region sa-east-1`. Later applies
+   won't touch the deployed code (`ignore_changes` on the package), but the
+   Lambda's environment (`DATABASE_URL`) **is** Terraform-managed — update it
+   here, not with `aws lambda update-function-configuration`.
+
+3. **Vercel Production env vars** (#291) from `terraform output`:
+
+    | Vercel var                                    | Source                 |
+    | --------------------------------------------- | ---------------------- |
+    | `S3_BUCKET`                                   | `s3_bucket` output     |
+    | `AWS_REGION`                                  | `aws_region` output    |
+    | `SQS_QUEUE_URL`                               | `sqs_queue_url` output |
+    | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | access key from step 1 |
+
+## Dev
+
+Dev is not in state yet (#127). The `environment`/`region` variables and the
+`dev` workspace exist for that migration; don't apply dev until #127 — the
+resource names would collide with the hand-built ones (and the dev Lambda is
+named `nexus-worker`, unsuffixed, so it specifically needs a
+create-before-destroy plan).

--- a/infra/terraform/environments/prod.tfvars
+++ b/infra/terraform/environments/prod.tfvars
@@ -1,0 +1,9 @@
+# Prod is sa-east-1: the alpha testers are in Brazil, the prod Supabase project
+# is in sa-east-1, and uploads go browser -> S3 directly (#53, #290).
+environment          = "prod"
+region               = "sa-east-1"
+app_domain           = "nexus.thomasar.dev"
+cors_allowed_origins = ["https://nexus.thomasar.dev"]
+
+# database_url is intentionally absent: pass via TF_VAR_database_url (the prod
+# Supabase transaction-pooler URL, port 6543). Never commit it.

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -1,0 +1,45 @@
+# Web-app IAM user — spec: docs/infra/aws-manual-setup.md
+#
+# Access keys are created manually (`aws iam create-access-key`) so the secret
+# never lands in Terraform state. See README.md.
+
+resource "aws_iam_user" "app" {
+  name = "nexus-app-${var.environment}"
+}
+
+resource "aws_iam_user_policy" "app_s3" {
+  name = "nexus-s3-access-${var.environment}"
+  user = aws_iam_user.app.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+        "s3:RestoreObject",
+        "s3:GetObjectAttributes",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts",
+      ]
+      Resource = [aws_s3_bucket.files.arn, "${aws_s3_bucket.files.arn}/*"]
+    }]
+  })
+}
+
+resource "aws_iam_user_policy" "app_sqs" {
+  name = "nexus-sqs-access-${var.environment}"
+  user = aws_iam_user.app.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "sqs:SendMessage"
+      Resource = aws_sqs_queue.jobs.arn
+    }]
+  })
+}

--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -1,0 +1,113 @@
+# Worker Lambda + execution role — spec: docs/guides/background-jobs.md
+
+resource "aws_iam_role" "worker" {
+  name = "nexus-worker-role-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "worker_sqs" {
+  name = "nexus-worker-sqs-${var.environment}"
+  role = aws_iam_role.worker.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"]
+      Resource = aws_sqs_queue.jobs.arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "worker_s3" {
+  name = "nexus-worker-s3-${var.environment}"
+  role = aws_iam_role.worker.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:ListBucket",
+        "s3:RestoreObject",
+        "s3:GetObjectAttributes",
+      ]
+      Resource = [aws_s3_bucket.files.arn, "${aws_s3_bucket.files.arn}/*"]
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "worker_logs" {
+  name = "nexus-worker-logs-${var.environment}"
+  role = aws_iam_role.worker.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+      Resource = "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:*"
+    }]
+  })
+}
+
+# Placeholder package so Terraform can create the function. Real worker code
+# deploys via `aws lambda update-function-code` (docs/guides/background-jobs.md);
+# ignore_changes below keeps Terraform from clobbering it on later applies.
+data "archive_file" "worker_stub" {
+  type        = "zip"
+  output_path = "${path.module}/worker-stub.zip"
+
+  source {
+    filename = "handler.js"
+    content  = <<-EOT
+      export const handler = async () => {
+        throw new Error('nexus-worker stub: deploy the real worker code (docs/guides/background-jobs.md)');
+      };
+    EOT
+  }
+
+  source {
+    filename = "package.json"
+    content  = jsonencode({ type = "module" })
+  }
+}
+
+resource "aws_lambda_function" "worker" {
+  function_name = "nexus-worker-${var.environment}"
+  role          = aws_iam_role.worker.arn
+  runtime       = "nodejs22.x"
+  handler       = "handler.handler"
+  timeout       = 30
+  memory_size   = 256
+
+  filename         = data.archive_file.worker_stub.output_path
+  source_code_hash = data.archive_file.worker_stub.output_base64sha256
+
+  environment {
+    variables = {
+      DATABASE_URL = var.database_url
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [filename, source_code_hash]
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "worker_jobs" {
+  function_name    = aws_lambda_function.worker.arn
+  event_source_arn = aws_sqs_queue.jobs.arn
+  batch_size       = 1
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,12 @@
+data "aws_caller_identity" "current" {}
+
+# The selected workspace must match var.environment so prod state can never
+# be mutated with dev tfvars (or vice versa).
+resource "terraform_data" "workspace_environment_guard" {
+  lifecycle {
+    precondition {
+      condition     = terraform.workspace == var.environment
+      error_message = "Workspace '${terraform.workspace}' does not match environment '${var.environment}'. Run: terraform workspace select ${var.environment}"
+    }
+  }
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,45 @@
+# Vercel Production env mapping (#291):
+#   S3_BUCKET     <- s3_bucket
+#   AWS_REGION    <- aws_region
+#   SQS_QUEUE_URL <- sqs_queue_url
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY <- manual access key on app_iam_user
+
+output "s3_bucket" {
+  description = "Files bucket name -> Vercel S3_BUCKET"
+  value       = aws_s3_bucket.files.bucket
+}
+
+output "aws_region" {
+  description = "Region all resources live in -> Vercel AWS_REGION"
+  value       = var.region
+}
+
+output "sqs_queue_url" {
+  description = "Jobs queue URL -> Vercel SQS_QUEUE_URL"
+  value       = aws_sqs_queue.jobs.url
+}
+
+output "app_iam_user" {
+  description = "Web-app IAM user; create its access key manually -> Vercel AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY"
+  value       = aws_iam_user.app.name
+}
+
+output "sns_topic_arn" {
+  description = "S3 restore-events topic"
+  value       = aws_sns_topic.s3_restore_events.arn
+}
+
+output "sns_dlq_url" {
+  description = "DLQ for failed webhook deliveries"
+  value       = aws_sqs_queue.s3_restore_events_dlq.url
+}
+
+output "jobs_dlq_url" {
+  description = "DLQ for failed background jobs"
+  value       = aws_sqs_queue.jobs_dlq.url
+}
+
+output "lambda_function_name" {
+  description = "Worker Lambda (deploy code via `aws lambda update-function-code`)"
+  value       = aws_lambda_function.worker.function_name
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      project     = "nexus"
+      environment = var.environment
+      managed-by  = "terraform"
+    }
+  }
+}

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -1,0 +1,70 @@
+# Files bucket — spec: docs/infra/aws-manual-setup.md
+
+resource "aws_s3_bucket" "files" {
+  bucket = "nexus-storage-files-${var.environment}"
+}
+
+resource "aws_s3_bucket_public_access_block" "files" {
+  bucket = aws_s3_bucket.files.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "files" {
+  bucket = aws_s3_bucket.files.id
+
+  # Every object goes straight to Glacier Deep Archive on day 0.
+  rule {
+    id     = "glacier-deep-archive-immediate"
+    status = "Enabled"
+    filter {}
+
+    transition {
+      days          = 0
+      storage_class = "DEEP_ARCHIVE"
+    }
+  }
+
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "files" {
+  bucket = aws_s3_bucket.files.id
+
+  cors_rule {
+    allowed_origins = var.cors_allowed_origins
+    allowed_methods = ["GET", "PUT", "POST", "DELETE", "HEAD"]
+    allowed_headers = ["*"]
+    # Multipart uploads: the browser must read each part's ETag from the response.
+    expose_headers = ["ETag"]
+  }
+}
+
+# Restore + lifecycle-transition events -> SNS -> /api/webhooks/s3-restore.
+# The topic policy must exist first: S3 validates publish permission on save.
+resource "aws_s3_bucket_notification" "files" {
+  bucket = aws_s3_bucket.files.id
+
+  topic {
+    topic_arn = aws_sns_topic.s3_restore_events.arn
+    events = [
+      "s3:ObjectRestore:Post",
+      "s3:ObjectRestore:Completed",
+      "s3:ObjectRestore:Delete",
+      "s3:LifecycleTransition",
+    ]
+  }
+
+  depends_on = [aws_sns_topic_policy.s3_restore_events]
+}

--- a/infra/terraform/sns.tf
+++ b/infra/terraform/sns.tf
@@ -1,0 +1,60 @@
+# S3 restore-events topic + webhook delivery — spec: docs/infra/aws-manual-setup.md
+
+resource "aws_sns_topic" "s3_restore_events" {
+  name = "nexus-s3-restore-events-${var.environment}"
+}
+
+resource "aws_sns_topic_policy" "s3_restore_events" {
+  arn = aws_sns_topic.s3_restore_events.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "s3.amazonaws.com" }
+      Action    = "SNS:Publish"
+      Resource  = aws_sns_topic.s3_restore_events.arn
+      Condition = {
+        ArnLike = { "aws:SourceArn" = aws_s3_bucket.files.arn }
+      }
+    }]
+  })
+}
+
+# Failed webhook deliveries land here via the subscription's redrive policy.
+resource "aws_sqs_queue" "s3_restore_events_dlq" {
+  name = "nexus-s3-restore-events-dlq-${var.environment}"
+}
+
+resource "aws_sqs_queue_policy" "s3_restore_events_dlq" {
+  queue_url = aws_sqs_queue.s3_restore_events_dlq.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "sns.amazonaws.com" }
+      Action    = "sqs:SendMessage"
+      Resource  = aws_sqs_queue.s3_restore_events_dlq.arn
+      Condition = {
+        ArnEquals = { "aws:SourceArn" = aws_sns_topic.s3_restore_events.arn }
+      }
+    }]
+  })
+}
+
+# Raw message delivery must stay OFF: the webhook parses and signature-checks
+# the full SNS envelope. The route auto-confirms subscriptions (it fetches
+# SubscribeURL), so the app must already be deployed at var.app_domain when
+# this applies — Terraform waits for the confirmation.
+resource "aws_sns_topic_subscription" "s3_restore_webhook" {
+  topic_arn              = aws_sns_topic.s3_restore_events.arn
+  protocol               = "https"
+  endpoint               = "https://${var.app_domain}/api/webhooks/s3-restore"
+  endpoint_auto_confirms = true
+  raw_message_delivery   = false
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.s3_restore_events_dlq.arn
+  })
+}

--- a/infra/terraform/sqs.tf
+++ b/infra/terraform/sqs.tf
@@ -1,0 +1,16 @@
+# Background-jobs queues — spec: docs/guides/background-jobs.md
+
+resource "aws_sqs_queue" "jobs_dlq" {
+  name = "nexus-jobs-dlq-${var.environment}"
+}
+
+resource "aws_sqs_queue" "jobs" {
+  name                       = "nexus-jobs-${var.environment}"
+  visibility_timeout_seconds = 60
+
+  # Jobs retry 3 times before moving to the DLQ.
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.jobs_dlq.arn
+    maxReceiveCount     = 3
+  })
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,30 @@
+variable "environment" {
+  description = "Environment suffix for all resource names (prod, dev)."
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "prod"], var.environment)
+    error_message = "environment must be one of: dev, prod."
+  }
+}
+
+variable "region" {
+  description = "AWS region for all resources. Prod is sa-east-1 (uploads go browser -> S3 directly and the alpha testers are in Brazil); dev is us-east-1."
+  type        = string
+}
+
+variable "app_domain" {
+  description = "Domain of the deployed web app for this environment. Used for the SNS webhook subscription endpoint and S3 CORS."
+  type        = string
+}
+
+variable "cors_allowed_origins" {
+  description = "Origins allowed to make browser requests (presigned uploads/downloads) against the files bucket."
+  type        = list(string)
+}
+
+variable "database_url" {
+  description = "Supabase transaction-pooler URL (port 6543) injected into the worker Lambda. Pass via TF_VAR_database_url; never commit. Note: persisted in Terraform state."
+  type        = string
+  sensitive   = true
+}

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.7"
+    }
+  }
+
+  # One state bucket for all environments; workspaces separate them
+  # (prod state lives at env:/prod/nexus.tfstate). The bucket is bootstrapped
+  # manually once — see README.md. It lives in us-east-1 regardless of
+  # var.region because state is environment-agnostic.
+  backend "s3" {
+    bucket       = "nexus-terraform-state-391615358272"
+    key          = "nexus.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+  }
+}


### PR DESCRIPTION
Closes #53. Part of #289.

## What

`infra/terraform/` — a single root module parameterized by `environment` and `region`, treating the two runbooks (`docs/infra/aws-manual-setup.md`, `docs/guides/background-jobs.md`) as the spec. State lives in a new S3 bucket (`nexus-terraform-state-391615358272`, us-east-1, versioned + encrypted + lockfile locking) with one workspace per environment, and a guard resource fails any plan where the selected workspace doesn't match `var.environment`.

**Already applied for prod** (22 resources, all in `sa-east-1`):

- `nexus-storage-files-prod` — public-access block, day-0 Deep Archive + 7-day multipart-abort lifecycle, CORS for `https://nexus.thomasar.dev`, restore/lifecycle event notifications
- `nexus-s3-restore-events-prod` SNS topic + DLQ + HTTPS subscription to `https://nexus.thomasar.dev/api/webhooks/s3-restore` — **confirmed** (the route auto-confirms; raw message delivery off)
- `nexus-jobs-prod` + DLQ (3 retries, 60s visibility)
- `nexus-worker-prod` Lambda (node22, 30s/256MB, batch size 1) + `nexus-worker-role-prod` with the three runbook policies; `DATABASE_URL` set to the prod Supabase transaction pooler via Terraform-managed function config
- `nexus-app-prod` IAM user with the S3/SQS policies; access key intentionally left manual so the secret never enters TF state

Real worker code is deployed over the initial stub (`pnpm -F worker build` → `update-function-code`); Terraform ignores code changes so the CLI deploy flow keeps working.

## Notes

- Lambda naming: prod is `nexus-worker-prod`; dev's live function stays unsuffixed `nexus-worker` until #127.
- Runbooks now carry a scope banner: prod's source of truth is Terraform, dev remains manual until #127.
- Verified post-apply via CLI: lifecycle rules, notification events, confirmed subscription ARN, Lambda config, CORS — all match the runbook spec.

## Follow-ups (tracked)

- #291 — Vercel Production env vars from `terraform output` + `aws iam create-access-key --user-name nexus-app-prod`; repoint `s3-event-health.yml` prod leg
- #127 — recreate dev from these same files