### PR TITLE
feat: add assertAllFound helper + fix vmForks pool for Node 24 (#164)

### DIFF
--- a/apps/web/lib/assert.ts
+++ b/apps/web/lib/assert.ts
@@ -1,0 +1,13 @@
+import { NotFoundError } from '@/server/errors';
+
+/**
+ * Asserts that all requested IDs were returned from the database.
+ * Throws NotFoundError listing the missing IDs if any are absent.
+ */
+export function assertAllFound<T extends string>(found: T[], requested: T[]): void {
+    const foundSet = new Set(found);
+    const missing = requested.filter((id) => !foundSet.has(id));
+    if (missing.length > 0) {
+        throw new NotFoundError(`Records not found: ${missing.join(', ')}`);
+    }
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
         setupFiles: ['./vitest.setup.ts'],
         include: ['**/*.test.{ts,tsx}'],
         exclude: [...defaultExclude, '**/*.integration.test.*'],
+        pool: 'vmForks',
+        testTimeout: 60000,
+        hookTimeout: 60000,
         coverage: {
             provider: 'v8',
             reporter: ['text', 'html', 'json-summary'],


### PR DESCRIPTION
## feat: add assertAllFound helper for batch ID validation

Closes #164

---

### What

Adds a typed utility function `assertAllFound` that validates batch database query results against the requested IDs, throwing a descriptive `NotFoundError` when any records are missing.

Also fixes vitest worker pool for Node 24 compatibility (`vmForks`).

### Changes

- **`apps/web/lib/assert.ts`** — new file with exported `assertAllFound<T extends string>` function
- **`apps/web/vitest.config.ts`** — use `vmForks` pool to fix worker timeout on Node 24

### Out of scope

- Integration into existing repositories (follow-up)
- Tests for `assertAllFound` (can be added alongside integration)

### Testing

- `pnpm -F web typecheck` — ✅
- `pnpm -F web lint` — ✅
- `pnpm check` (all workspaces) — ✅ 10/10 tasks