### PR TITLE
refactor: build storage namespace from named imports

### DIFF
--- a/apps/web/lib/storage/index.ts
+++ b/apps/web/lib/storage/index.ts
@@ -1,7 +1,43 @@
-import * as presigned from './presigned';
-import * as glacier from './glacier';
-import * as objects from './objects';
-import * as multipart from './multipart';
+import { put as presignedPut, get as presignedGet } from './presigned';
+import {
+    restore as glacierRestore,
+    restoreMany as glacierRestoreMany,
+    checkStatus as glacierCheckStatus,
+} from './glacier';
+import { remove as objectsRemove, listAll as objectsListAll } from './objects';
+import {
+    create as multipartCreate,
+    signParts as multipartSignParts,
+    signPartsByNumber as multipartSignPartsByNumber,
+    listParts as multipartListParts,
+    complete as multipartComplete,
+    abort as multipartAbort,
+} from './multipart';
+
+const presigned = {
+    put: presignedPut,
+    get: presignedGet,
+} as const;
+
+const glacier = {
+    restore: glacierRestore,
+    restoreMany: glacierRestoreMany,
+    checkStatus: glacierCheckStatus,
+} as const;
+
+const objects = {
+    remove: objectsRemove,
+    listAll: objectsListAll,
+} as const;
+
+const multipart = {
+    create: multipartCreate,
+    signParts: multipartSignParts,
+    signPartsByNumber: multipartSignPartsByNumber,
+    listParts: multipartListParts,
+    complete: multipartComplete,
+    abort: multipartAbort,
+} as const;
 
 /**
  * S3 storage operations for file archival

--- a/docs/ai/conventions.md
+++ b/docs/ai/conventions.md
@@ -87,6 +87,12 @@ Terse reference for AI agents. Detailed examples with code: [[../conventions/nam
 
 See [[../guides/server-architecture|Server Architecture Guide]] for the full layered pattern.
 
+## Namespace Patterns
+
+- **Repository factories**: `@nexus/db` repositories export `create<Entity>Repo(db)` factories that return typed namespace objects with short method names.
+- **Stateless utilities**: barrel files build namespace objects from explicit named imports, not `import * as`. Example: `import { put as presignedPut } from './presigned'`, then `const presigned = { put: presignedPut } as const`.
+- **Public API stability**: keep nested namespaces stable (`s3.presigned.put()`, `s3.glacier.restore()`, `s3.objects.remove()`) even when internal imports change.
+
 ## Auth Enforcement
 
 - `apps/web/proxy.ts` guards `/dashboard/*` with an **optimistic** cookie-presence check (no DB hit) — a UX layer only. It redirects signed-out users to `/sign-in?redirect=<path>` and signed-in users away from the auth pages.


### PR DESCRIPTION
Closes #162

### What
Refactors the storage utility module to follow the consistent namespace pattern established in the codebase conventions. Replaces default exports with named imports to align with the project's module structure.

### Changes
- `apps/web/lib/storage/index.ts` — refactored to use named imports
- `docs/ai/conventions.md` — updated conventions to document the pattern

### Testing
- `pnpm -F web typecheck` — ✅
- `pnpm lint` — ✅ (preexisting Tailwind warnings in `app/dev/*` unrelated to this change)
- `pnpm -F web test:run lib/storage` — ✅