### PR TITLE
chore: move prod infra back to us-east-1, defer multi-region

### DIFF
--- a/docs/guides/background-jobs.md
+++ b/docs/guides/background-jobs.md
@@ -19,7 +19,7 @@ ai_summary: 'AWS resource ARNs, CLI provisioning commands, deployment, DLQ inspe
 Operational guide for the SQS + Lambda background job infrastructure. For development patterns and conventions, see [[lambda-development|Lambda Development]].
 
 > [!important] Scope: dev only — prod is Terraform-managed.
-> Prod's queues, Lambda (`nexus-worker-prod`), and IAM live in `sa-east-1` and come from [`infra/terraform/`](../../infra/terraform/README.md) (#53). The code-deploy flow below applies to prod too (use `--function-name nexus-worker-prod --region sa-east-1`), but prod resource changes go through Terraform — including Lambda env vars (`DATABASE_URL`), so don't use `update-function-configuration` against prod.
+> Prod's queues, Lambda (`nexus-worker-prod`), and IAM live in `us-east-1` and come from [`infra/terraform/`](../../infra/terraform/README.md) (#53). The code-deploy flow below applies to prod too (use `--function-name nexus-worker-prod --region us-east-1`), but prod resource changes go through Terraform — including Lambda env vars (`DATABASE_URL`), so don't use `update-function-configuration` against prod.
 
 ## Provisioned Resources
 

--- a/docs/infra/aws-manual-setup.md
+++ b/docs/infra/aws-manual-setup.md
@@ -16,7 +16,7 @@ ai_summary: 'Manual AWS provisioning commands for S3, IAM, and SNS resources in 
 This documents the manual AWS setup for the dev environment. Created 2026-01-23.
 
 > [!important] Scope: dev only — prod is Terraform-managed.
-> The **prod** environment (`sa-east-1`, `-prod` suffixes) is provisioned by Terraform in [`infra/terraform/`](../../infra/terraform/README.md), which is the source of truth for prod (#53). This runbook remains the spec for the hand-built dev resources until #127 recreates dev from the same Terraform config.
+> The **prod** environment (`us-east-1`, `-prod` suffixes) is provisioned by Terraform in [`infra/terraform/`](../../infra/terraform/README.md), which is the source of truth for prod (#53). This runbook remains the spec for the hand-built dev resources until #127 recreates dev from the same Terraform config.
 
 ## Resources Created
 

--- a/docs/infra/supabase-manual-setup.md
+++ b/docs/infra/supabase-manual-setup.md
@@ -32,7 +32,7 @@ Both projects are on the free (pausing) plan, so both are pinged by `.github/wor
 
 1. [Supabase dashboard](https://supabase.com/dashboard) → **New project** in the same organization as the dev project.
 2. Name: `nexus-prod`.
-3. Region: `sa-east-1` (São Paulo) — chosen 2026-07 because the alpha testers are in Brazil. Note this deliberately differs from dev (`us-east-1`) and from the shared AWS resources; cross-region S3 latency is acceptable until prod AWS resources exist (see Follow-Ups).
+3. Region: `us-east-1` — matches dev and the prod AWS resources. A São Paulo (`sa-east-1`) deployment closer to the Brazil alpha testers was trialed 2026-07 but reverted 2026-07-09: the latency win didn't justify the ~3.2× Glacier Deep Archive cost markup in South America. Multi-region is deferred until we validate that tradeoff.
 4. Generate a strong database password and store it in the password manager — it is embedded in the connection string below.
 
 No data migration is needed: prod starts empty and gets its schema from the migration pipeline (see below).
@@ -106,7 +106,7 @@ gh workflow run supabase-keepalive.yml
 ## Follow-Ups
 
 - **Repoint the Vercel production deployment** at the prod project: after setting the Production env vars above, redeploy production so it picks up the prod `DATABASE_URL`. Until then, the production deployment still points at dev.
-- **Prod AWS resources**: provisioned 2026-07-05 via Terraform (`infra/terraform/`, #53) in `sa-east-1`. Remaining: repoint `s3-event-health.yml`'s prod leg and the Vercel Production env vars at the prod resources (#291) — until then the prod leg still runs with dev AWS credentials.
+- **Prod AWS resources**: provisioned via Terraform (`infra/terraform/`, #53) in `us-east-1`. Remaining: repoint `s3-event-health.yml`'s prod leg and the Vercel Production env vars at the prod resources (#291) — until then the prod leg still runs with dev AWS credentials.
 
 ## Related
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -58,7 +58,7 @@ fetching `SubscribeURL`, and Terraform waits for that.
 2. **Worker code** — Terraform ships a stub that throws on every invocation
    (so jobs retry into the DLQ instead of silently succeeding). Deploy the
    real worker per `docs/guides/background-jobs.md`, with
-   `--function-name nexus-worker-prod --region sa-east-1`. Later applies
+   `--function-name nexus-worker-prod --region us-east-1`. Later applies
    won't touch the deployed code (`ignore_changes` on the package), but the
    Lambda's environment (`DATABASE_URL`) **is** Terraform-managed — update it
    here, not with `aws lambda update-function-configuration`.

--- a/infra/terraform/environments/prod.tfvars
+++ b/infra/terraform/environments/prod.tfvars
@@ -1,7 +1,10 @@
-# Prod is sa-east-1: the alpha testers are in Brazil, the prod Supabase project
-# is in sa-east-1, and uploads go browser -> S3 directly (#53, #290).
+# Prod runs in us-east-1 for now: multi-region (sa-east-1, closer to the Brazil
+# alpha testers) is deferred until we validate whether the latency win justifies
+# the ~3.2x Glacier Deep Archive cost markup in South America. Keeping prod in the
+# default US region matches dev and keeps storage economics healthy. Revisit
+# multi-region later; uploads go browser -> S3 directly (#53, #290).
 environment          = "prod"
-region               = "sa-east-1"
+region               = "us-east-1"
 app_domain           = "nexus.thomasar.dev"
 cors_allowed_origins = ["https://nexus.thomasar.dev"]
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -9,7 +9,7 @@ variable "environment" {
 }
 
 variable "region" {
-  description = "AWS region for all resources. Prod is sa-east-1 (uploads go browser -> S3 directly and the alpha testers are in Brazil); dev is us-east-1."
+  description = "AWS region for all resources. Both prod and dev are us-east-1; a sa-east-1 (São Paulo) prod deployment closer to the Brazil alpha testers was reverted 2026-07-09 pending multi-region validation."
   type        = string
 }
 


### PR DESCRIPTION
## What

Reverts the short-lived sa-east-1 (São Paulo) prod deployment back to us-east-1 and updates the IaC + docs to match.

- `prod.tfvars`: `region = "us-east-1"` (+ rationale comment)
- `variables.tf`: region description updated
- Docs (`README`, `aws-manual-setup`, `supabase-manual-setup`, `background-jobs`): stale `sa-east-1` references → `us-east-1`

## Why

S3 Glacier Deep Archive storage costs ~3.2× more in sa-east-1 (~$0.0032/GB-mo vs $0.00099 in us-east-1) while Standard is only ~1.76×. Everything transitions to Deep Archive on day 0, so that markup erodes the flat-plan margins (Starter/Pro/Max) as quotas fill. The latency win for the Brazil alpha testers doesn't justify it yet; multi-region is deferred until that tradeoff is validated.

## Already applied to live infra

These changes were reconciled out-of-band before this PR — the diff just lands the source of truth:

- **AWS**: sa-east-1 prod (S3/SQS/Lambda/SNS/IAM) destroyed, recreated in us-east-1 via Terraform (`terraform plan` clean). sa-east-1 has zero Nexus resources.
- **Supabase**: `nexus-prod` recreated in us-east-1 (`ixtjiqqmecwfqeyxlqjh`), migrated (15 migrations / 12 tables).
- **Vercel**: function region `gru1` → `iad1`; Production `DATABASE_URL` repointed at the new prod DB; redeployed and verified (`/api/auth/get-session` → 200, `x-vercel-id` shows `iad1`).
- **CI**: `DATABASE_URL_PROD` secret repointed.

## Not included (separate work)

- #291 half-cutover is untouched: prod still uses the **dev** S3 bucket + **dev** SQS queue (dev-US, not SA).
- New `nexus-app-prod` IAM access key not yet created.

No-Issue: operational region revert, no product change