### PR TITLE
chore: split Vercel Production tier onto prod infra + harden webhook signature guard (#291)

### DIFF
--- a/apps/web/app/api/webhooks/s3-restore/route.ts
+++ b/apps/web/app/api/webhooks/s3-restore/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { createWebhookRepo } from '@nexus/db/repo/webhooks';
 import { alerts } from '@/lib/alerts';
+import { isLocalDevelopment } from '@/lib/env/runtime';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { verifySnsMessage } from '@/lib/sns/webhooks';
@@ -21,7 +22,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
     }
 
-    if (process.env.NODE_ENV !== 'development') {
+    // Signature verification is bypassed only on a local dev machine — every
+    // deployed environment always verifies (see `isLocalDevelopment`).
+    if (!isLocalDevelopment()) {
         try {
             await verifySnsMessage(body);
         } catch (err) {

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -129,6 +129,22 @@ describe('POST /api/webhooks/stripe', () => {
                 sampleEvent
             );
         });
+
+        // A Vercel deployment must never open the signature bypass, even if
+        // NODE_ENV is misconfigured to 'development' — VERCEL_ENV being set
+        // means we are deployed, so verification still runs.
+        it('still verifies when NODE_ENV=development but running on Vercel', async () => {
+            vi.stubEnv('NODE_ENV', 'development');
+            vi.stubEnv('VERCEL_ENV', 'preview');
+
+            const response = await POST(makeRequest(sampleEvent));
+
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toEqual({
+                error: 'Missing stripe-signature header',
+            });
+            expect(dispatchWebhookEvent).not.toHaveBeenCalled();
+        });
     });
 
     describe('development mode (signature bypass)', () => {

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import type Stripe from 'stripe';
 import { createWebhookRepo, type WebhookEvent } from '@nexus/db/repo/webhooks';
 import { alerts } from '@/lib/alerts';
+import { isLocalDevelopment } from '@/lib/env/runtime';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { stripe } from '@/lib/stripe';
@@ -29,7 +30,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     let event: Stripe.Event;
-    if (process.env.NODE_ENV !== 'development') {
+    // Signature verification is bypassed only on a local dev machine, where
+    // there is no Stripe signing secret to sign against. Every deployed
+    // environment (preview and production) always verifies — see
+    // `isLocalDevelopment`.
+    if (!isLocalDevelopment()) {
         const signature = request.headers.get('stripe-signature');
         if (!signature) {
             return NextResponse.json(

--- a/apps/web/lib/alerts/send.ts
+++ b/apps/web/lib/alerts/send.ts
@@ -1,3 +1,4 @@
+import { resolveRuntimeEnvironment } from '@/lib/env/runtime';
 import { logger } from '@/server/lib/logger';
 import { discordTransport } from './discord';
 import type { Alert, AlertTransport, DeliverableAlert } from './types';
@@ -5,12 +6,6 @@ import type { Alert, AlertTransport, DeliverableAlert } from './types';
 const log = logger.child({ service: 'alerts' });
 
 const transports: AlertTransport[] = [discordTransport];
-
-// One shared channel across environments until the multi-env split (#292)
-// settles, so every alert carries where it came from.
-function resolveEnvironment(): string {
-    return process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'unknown';
-}
 
 /**
  * Dispatches an alert to the given transports. Exported for tests —
@@ -24,9 +19,11 @@ export async function dispatch(
     // Alerting must never fail the work that triggered it — same
     // warn-and-swallow contract as server/services/email.ts.
     try {
+        // One shared channel across environments until the multi-env split
+        // (#292) settles, so every alert carries where it came from.
         const deliverable: DeliverableAlert = {
             ...alert,
-            environment: resolveEnvironment(),
+            environment: resolveRuntimeEnvironment(),
         };
 
         await Promise.all(

--- a/apps/web/lib/env/runtime.test.ts
+++ b/apps/web/lib/env/runtime.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isLocalDevelopment, resolveRuntimeEnvironment } from './runtime';
+
+describe('runtime environment detection', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    describe('isLocalDevelopment', () => {
+        it('is true only for local dev: NODE_ENV=development and no VERCEL_ENV', () => {
+            vi.stubEnv('NODE_ENV', 'development');
+            vi.stubEnv('VERCEL_ENV', undefined);
+            expect(isLocalDevelopment()).toBe(true);
+        });
+
+        it('is false in production', () => {
+            vi.stubEnv('NODE_ENV', 'production');
+            vi.stubEnv('VERCEL_ENV', 'production');
+            expect(isLocalDevelopment()).toBe(false);
+        });
+
+        // The defense-in-depth case: a deployment must never open the bypass
+        // even if NODE_ENV were misconfigured, because VERCEL_ENV is present.
+        it.each(['production', 'preview', 'development'])(
+            'is false on a Vercel %s deployment even when NODE_ENV=development',
+            (vercelEnv) => {
+                vi.stubEnv('NODE_ENV', 'development');
+                vi.stubEnv('VERCEL_ENV', vercelEnv);
+                expect(isLocalDevelopment()).toBe(false);
+            }
+        );
+    });
+
+    describe('resolveRuntimeEnvironment', () => {
+        it('prefers VERCEL_ENV when set', () => {
+            vi.stubEnv('VERCEL_ENV', 'preview');
+            vi.stubEnv('NODE_ENV', 'production');
+            expect(resolveRuntimeEnvironment()).toBe('preview');
+        });
+
+        it('falls back to NODE_ENV off-Vercel', () => {
+            vi.stubEnv('VERCEL_ENV', undefined);
+            vi.stubEnv('NODE_ENV', 'test');
+            expect(resolveRuntimeEnvironment()).toBe('test');
+        });
+    });
+});

--- a/apps/web/lib/env/runtime.ts
+++ b/apps/web/lib/env/runtime.ts
@@ -1,0 +1,36 @@
+/**
+ * Runtime environment detection.
+ *
+ * `VERCEL_ENV` is the canonical signal for *where* the code is running: Vercel
+ * sets it to `'production' | 'preview' | 'development'` on every deployment and
+ * leaves it unset for local `pnpm dev`. `NODE_ENV` only distinguishes a dev
+ * build from a production build, and Next.js forces it to `'production'` for
+ * every deployed build — so it cannot, on its own, tell a preview apart from
+ * prod or a deployment apart from a laptop.
+ */
+
+/**
+ * The environment name to attribute runtime behaviour to. Prefers the platform
+ * signal (`VERCEL_ENV`) and falls back to `NODE_ENV` off-Vercel (local dev, CI,
+ * tests) so the value is always meaningful.
+ */
+export function resolveRuntimeEnvironment(): string {
+    return process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'unknown';
+}
+
+/**
+ * True only on a developer's machine (`pnpm dev`): `NODE_ENV` is `'development'`
+ * AND we are not on any Vercel deployment. Every deployed environment — preview
+ * and production alike — returns `false`, even if `NODE_ENV` were somehow set to
+ * `'development'`, because `VERCEL_ENV` is present.
+ *
+ * Security-sensitive bypasses (e.g. skipping webhook signature verification)
+ * gate on this rather than on `NODE_ENV` alone, so a misconfigured `NODE_ENV`
+ * on a deployment can never open the bypass.
+ */
+export function isLocalDevelopment(): boolean {
+    return (
+        process.env.NODE_ENV === 'development' &&
+        process.env.VERCEL_ENV === undefined
+    );
+}

--- a/docs/guides/environment-setup.md
+++ b/docs/guides/environment-setup.md
@@ -152,13 +152,39 @@ const authSecret = env.BETTER_AUTH_SECRET;
 
 ## Vercel Environment Management
 
-### Initial Setup
+Three Vercel tiers back the two infrastructure environments (#291):
 
-1. Go to Vercel Dashboard → Project Settings → Environment Variables
-2. Add all variables for each environment:
-    - **Production** - Live site values
-    - **Preview** - PR deployment values
-    - **Development** - Local development values
+- **Production** → the isolated **prod** infra (prod Supabase, `-prod` AWS resources).
+- **Preview** and **Development** → the shared **dev** infra. `pnpm env:pull` pulls Development, so local tooling always lands on dev.
+
+### Which values differ per tier
+
+Only the vars below hold prod-specific values on Production; everything else is
+shared with dev (or is out of scope for the split).
+
+| Variable                                      | Production                                                | Preview / Development     |
+| --------------------------------------------- | --------------------------------------------------------- | ------------------------- |
+| `DATABASE_URL`                                | prod Supabase pooler                                      | dev Supabase pooler       |
+| `DB_ENV`                                      | `production`                                              | `development`             |
+| `S3_BUCKET`                                   | `nexus-storage-files-prod`                                | `nexus-storage-files-dev` |
+| `SQS_QUEUE_URL`                               | `…/nexus-jobs-prod`                                       | `…/nexus-jobs-dev`        |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | access key on the `nexus-app-prod` IAM user               | `nexus-app-dev` key       |
+| `BETTER_AUTH_SECRET`                          | prod-only secret (rotating it never touches dev sessions) | dev secret                |
+| `NEXT_PUBLIC_APP_URL`                         | `https://nexus.thomasar.dev`                              | `http://localhost:3000`   |
+
+Same on every tier: `AWS_REGION` (`us-east-1`), Resend. **Out of scope:** Stripe
+stays test-mode on Production until live mode ships (#213). The prod AWS resource
+names come from `infra/terraform/outputs.tf`; create the `nexus-app-prod` access
+key manually (`aws iam create-access-key --user-name nexus-app-prod`).
+
+> [!warning] Per-tier edits via the CLI
+> Some vars are stored as a **single entry attached to all three tiers** (they
+> show one row spanning `Production, Preview, Development` in `vercel env ls`).
+> `vercel env rm NAME production` on such a var removes it from **every** tier,
+> not just Production. To give one tier a distinct value, remove and re-add it
+> **per environment** (`vercel env add NAME development`, `… preview`,
+> `… production`) so the others keep theirs. After any change, `vercel env pull
+--environment=development` and confirm dev is intact.
 
 ### Adding New Variables
 


### PR DESCRIPTION
Closes #291. Part of #289.

Splits the Vercel Production tier onto the isolated prod infra and hardens the webhook signature bypass. The DB migration fan-out already shipped in #290, so this closes the remaining gaps.

## Ops (applied via CLI — not in the diff)

**Vercel Production tier** now points at prod; Preview/Development untouched on dev:

| Var | Production | Preview / Dev |
|---|---|---|
| `DATABASE_URL` | prod Supabase | dev Supabase |
| `DB_ENV` | `production` | `development` |
| `S3_BUCKET` | `nexus-storage-files-prod` | `-dev` |
| `SQS_QUEUE_URL` | `…/nexus-jobs-prod` | `…/nexus-jobs-dev` |
| `AWS_ACCESS_KEY_ID` / `_SECRET` | new key on `nexus-app-prod` | `nexus-app-dev` |
| `BETTER_AUTH_SECRET` | fresh prod-only secret | dev secret (unchanged) |
| `NEXT_PUBLIC_APP_URL` | `https://nexus.thomasar.dev` | `http://localhost:3000` |

- Minted a prod-scoped IAM access key for `nexus-app-prod` (had none) and verified it can reach `nexus-storage-files-prod`.
- Verified after the change: Development env byte-identical to its pre-change baseline, Preview intact, Production on prod values.
- Stripe stays test-mode on Production (out of scope, #213). Legacy `SUPABASE_*` / `AWS_S3_BUCKET` left for env hygiene (#292).

**GitHub secrets:** no change needed — `DATABASE_URL_PROD` (from #290) already targets prod migrations, and drift/keepalive/s3-health matrix read-only over dev+prod (a safe superset of the AC's "dev"). Post-merge smoke tests use `secrets.DATABASE_URL` (dev) + dev AWS — confirmed dev-only.

## Code (AC #5 — the signature-skip guard)

The bypass was gated on `NODE_ENV === 'development'` alone. On Vercel that's always `production`, so there was no live hole, but relying on `NODE_ENV` for a security bypass is fragile. New `isLocalDevelopment()` requires `NODE_ENV=development` **and** no `VERCEL_ENV`, so every deployed environment always verifies — even if `NODE_ENV` were misconfigured.

- `lib/env/runtime.ts`: `isLocalDevelopment()` + `resolveRuntimeEnvironment()`; `alerts/send.ts` reuses the latter (drops a duplicated env-resolution helper).
- Both webhook routes bypass verification only for local dev.
- Tests: helper matrix + a stripe route regression (`NODE_ENV=development` + `VERCEL_ENV=preview` still verifies).

## Verification

- `pnpm check` — 10/10 pass.
- Prod IAM key validated against the prod bucket.

Takes effect on the next Production deploy (which merging this triggers); no real users yet, so the interim mixed state is harmless.