### PR TITLE
chore: serve dev SNS webhook from dev.nexus.thomasar.dev, retire bypass token (#317)

### DIFF
--- a/docs/guides/environment-setup.md
+++ b/docs/guides/environment-setup.md
@@ -174,8 +174,9 @@ shared with dev (or is out of scope for the split).
 
 \* Exception: the long-lived `dev` branch (the deployment that receives dev SNS
 webhooks, #127) has a branch-scoped Preview value pointing at its own URL
-(`https://nexus-web-git-dev-…vercel.app`) so dev-triggered emails don't link to
-localhost. It shows as `Preview (dev)` in `vercel env ls`.
+(`https://dev.nexus.thomasar.dev`, the custom domain #317 pinned to the branch)
+so dev-triggered emails don't link to localhost. It shows as `Preview (dev)` in
+`vercel env ls`.
 
 Same on every tier: `AWS_REGION` (`us-east-1`), Resend. **Out of scope:** Stripe
 stays test-mode on Production until live mode ships (#213). The prod AWS resource

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -40,11 +40,6 @@ terraform workspace select prod || terraform workspace new prod   # or dev
 # state bucket.
 set -x TF_VAR_database_url "postgresql://..."   # fish; bash: export TF_VAR_database_url=...
 
-# Dev only: the SNS webhook endpoint is a protected Vercel preview URL, so the
-# subscription carries the Protection Bypass for Automation token (Vercel
-# dashboard: nexus-web > Settings > Deployment Protection). Never commit it.
-set -x TF_VAR_webhook_bypass_query "?x-vercel-protection-bypass=<token>"
-
 terraform plan -var-file=environments/prod.tfvars    # or dev.tfvars
 terraform apply -var-file=environments/prod.tfvars   # or dev.tfvars
 ```
@@ -52,9 +47,14 @@ terraform apply -var-file=environments/prod.tfvars   # or dev.tfvars
 The SNS subscription only confirms if the app is already deployed and serving
 `https://<app_domain>/api/webhooks/s3-restore` — the route auto-confirms by
 fetching `SubscribeURL`, and Terraform waits for that. For dev, `app_domain`
-is the stable branch URL of the long-lived `dev` branch (Preview tier = dev
-Supabase + dev AWS); the post-merge workflow fast-forwards `dev` to `main` on
-every merge so that deployment tracks production code.
+is `dev.nexus.thomasar.dev` (a Cloudflare CNAME → Vercel custom domain pinned
+to the long-lived `dev` branch; Preview tier = dev Supabase + dev AWS). It
+confirms without a bypass token because Vercel Authentication is disabled on the
+nexus-web project — a custom domain on a preview branch is NOT auto-exempt (only
+the production domain is), and the Hobby plan offers no per-domain exception, so
+#317 turned deployment protection off project-wide. The post-merge workflow
+fast-forwards `dev` to `main` on every merge so that deployment tracks
+production code.
 
 ## After apply
 

--- a/infra/terraform/environments/dev.tfvars
+++ b/infra/terraform/environments/dev.tfvars
@@ -1,18 +1,19 @@
 # Dev shares prod's region and module set (#127); only names (-dev suffix),
-# CORS, and the webhook endpoint differ. The app_domain is the stable Vercel
-# branch URL for the long-lived `dev` branch (post-merge keeps it synced with
-# main), which serves the Preview tier — dev Supabase + dev AWS env vars.
-# Vercel deployment protection covers *.vercel.app URLs, so the SNS
-# subscription needs the protection-bypass token: pass it via
-# TF_VAR_webhook_bypass_query="?x-vercel-protection-bypass=<token>".
-# Never commit the token (Vercel dashboard: nexus-web > Settings >
-# Deployment Protection > Protection Bypass for Automation).
+# CORS, and the webhook endpoint differ. app_domain is dev.nexus.thomasar.dev:
+# a Cloudflare CNAME → Vercel custom domain pinned to the long-lived `dev`
+# branch (post-merge keeps it synced with main), which serves the Preview tier
+# — dev Supabase + dev AWS env vars. The SNS subscription reaches this endpoint
+# with no bypass token because Vercel Authentication is OFF on the nexus-web
+# project: pinning a custom domain to a preview branch does NOT exempt it (only
+# the production domain is exempt), and the Hobby plan has no per-domain
+# exception, so #317 disabled deployment protection project-wide and retired the
+# project-wide Protection Bypass token the old *.vercel.app URL depended on.
 environment = "dev"
 region      = "us-east-1"
-app_domain  = "nexus-web-git-dev-thomasreichmanns-projects.vercel.app"
+app_domain  = "dev.nexus.thomasar.dev"
 
 # The dev-branch deployment also carries a branch-scoped NEXT_PUBLIC_APP_URL
-# (Vercel Preview tier, git branch "dev") pointing at this same URL, so links
+# (Vercel Preview tier, git branch "dev") pointing at this same domain, so links
 # in dev-triggered emails (e.g. restore-completed) don't say localhost like
 # ordinary previews do.
 

--- a/infra/terraform/sns.tf
+++ b/infra/terraform/sns.tf
@@ -50,7 +50,7 @@ resource "aws_sqs_queue_policy" "s3_restore_events_dlq" {
 resource "aws_sns_topic_subscription" "s3_restore_webhook" {
   topic_arn              = aws_sns_topic.s3_restore_events.arn
   protocol               = "https"
-  endpoint               = "https://${var.app_domain}/api/webhooks/s3-restore${var.webhook_bypass_query}"
+  endpoint               = "https://${var.app_domain}/api/webhooks/s3-restore"
   endpoint_auto_confirms = true
   raw_message_delivery   = false
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -23,35 +23,6 @@ variable "cors_allowed_origins" {
   type        = list(string)
 }
 
-variable "webhook_bypass_query" {
-  description = "Optional query string (with leading '?') appended to the SNS webhook endpoint. Dev needs it: the dev app runs on a Vercel preview URL behind deployment protection, so the subscription carries the project's Protection Bypass for Automation token (?x-vercel-protection-bypass=...). The token is PROJECT-WIDE — it bypasses protection on every nexus-web deployment (all PR previews), not just this endpoint, and rides the query string into Vercel request logs; treat state/SNS read access as preview access until #317 retires it. Pass via TF_VAR_webhook_bypass_query; never commit."
-  type        = string
-  default     = ""
-  sensitive   = true
-
-  # Guardrails: the var is sensitive, so a bad value would hide inside
-  # "endpoint = (sensitive value)" in the plan instead of being visible.
-  validation {
-    condition     = var.environment != "prod" || var.webhook_bypass_query == ""
-    error_message = "webhook_bypass_query is dev-only; unset TF_VAR_webhook_bypass_query for prod applies."
-  }
-
-  validation {
-    condition     = can(regex("^$|^\\?", var.webhook_bypass_query))
-    error_message = "webhook_bypass_query must be empty or start with '?'."
-  }
-
-  # The inverse footgun: a dev apply from a fresh shell with the var unset
-  # would replace the confirmed subscription with one that can never confirm
-  # (Vercel 302s the confirmation POST) — also masked by the sensitive
-  # redaction. Deployment protection only covers *.vercel.app hosts, so a
-  # custom dev domain (#317) passes this without a token.
-  validation {
-    condition     = !endswith(var.app_domain, ".vercel.app") || var.webhook_bypass_query != ""
-    error_message = "app_domain is a protected *.vercel.app URL; set TF_VAR_webhook_bypass_query or the SNS subscription can never confirm."
-  }
-}
-
 variable "database_url" {
   description = "Supabase transaction-pooler URL (port 6543) injected into the worker Lambda. Pass via TF_VAR_database_url; never commit. Note: persisted in Terraform state."
   type        = string


### PR DESCRIPTION
Closes #317.

Points the dev SNS restore-events subscription at the custom domain `dev.nexus.thomasar.dev` and removes the Vercel Protection Bypass token plumbing.

## Changes
- `dev.tfvars`: `app_domain` → `dev.nexus.thomasar.dev`
- `variables.tf` / `sns.tf`: drop `webhook_bypass_query` variable and its use in the SNS endpoint
- Token references scrubbed from `infra/terraform/README.md` + `docs/guides/environment-setup.md`

## ⚠️ The issue's premise was wrong — read before merging
#317 assumed a custom domain pinned to the `dev` branch bypasses Vercel deployment protection. **It does not.** Only the *production* custom domain is exempt under `all_except_custom_domains`; a domain pinned to a preview branch still serves a preview deployment and stays protected (verified: prod `nexus.thomasar.dev` → 405, new dev domain → 302 to Vercel SSO).

The **Hobby** plan has no per-domain Deployment Protection Exception (that's a Pro feature), so the only lever to make the webhook reachable token-free was **disabling Vercel Authentication project-wide**. Consequences:
- **Every preview — the `dev` branch and all PR previews — is now publicly reachable.** Blast radius is dev-only (dev Supabase / dev AWS; prod was already public).
- The webhook route stays safe regardless — it signature-checks the full SNS envelope.
- The automation bypass token has been **revoked** (`protectionBypass: {}`).
- Dev-branch `NEXT_PUBLIC_APP_URL` repointed to the custom domain (takes effect on next dev deploy).

The clean end-state matching #317's *security* intent would be **Pro → re-enable protection + add `dev.nexus.thomasar.dev` as a Deployment Protection Exception**. Left as a possible follow-up; Hobby-with-protection-off is the current resting state.

## Verification (applied to dev)
- SNS subscription recreated + confirmed against the new endpoint (`PendingConfirmation: false`), no query token.
- `terraform plan` was exactly `1 add / 1 destroy` (subscription only).
- Published a real SNS event → landed in dev `webhook_events` as `event_type=ObjectRestore:Post, status=processed, error=null` (confirmed against `DB_ENV=development`).