### PR TITLE
chore: environment parity checks — Stripe config, env var keys, prod health (#293)

### DIFF
--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -1,0 +1,111 @@
+name: Environment Parity
+
+# Nightly drift checks for config layers with no shared source of truth
+# (#293): Stripe products/prices/webhook wiring, and Vercel env-var key
+# parity across tiers. A failed run is the alert; alerts.send (Discord) is
+# the faster secondary channel. The prod DB health leg lives in
+# s3-event-health.yml (dev/prod matrix).
+
+on:
+    schedule:
+        - cron: '0 6 * * *'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    stripe-config:
+        name: Stripe config (${{ matrix.mode }} mode)
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - mode: test
+                      stripe-secret: STRIPE_SECRET_KEY
+                    # live mode joins once #213 lands:
+                    # - mode: live
+                    #   stripe-secret: STRIPE_SECRET_KEY_LIVE
+        # The script only talks to Stripe, but importing @/lib/env validates
+        # the full server schema, so the whole (dev-scoped) env block rides
+        # along — same as s3-event-health.yml.
+        env:
+            DATABASE_URL: ${{ secrets.DATABASE_URL }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_REGION: ${{ secrets.AWS_REGION }}
+            S3_BUCKET: ${{ secrets.S3_BUCKET }}
+            SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
+            STRIPE_SECRET_KEY: ${{ secrets[matrix.stripe-secret] }}
+            STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+            RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+            RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
+            BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+            NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+            DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_ALERT_WEBHOOK_URL }}
+            VERCEL_ENV: stripe-${{ matrix.mode }}
+        steps:
+            - name: Verify Stripe secret is configured
+              run: |
+                  if [ -z "$STRIPE_SECRET_KEY" ]; then
+                      echo "::error::secret ${{ matrix.stripe-secret }} is not configured"
+                      exit 1
+                  fi
+
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node and pnpm
+              uses: ./.github/actions/setup-node-pnpm
+
+            # The scripts load env via `tsx --env-file=.env.local`, which
+            # errors if the file is missing; real values come from the job
+            # env above (process env wins over the file).
+            - name: Create empty env file
+              run: touch apps/web/.env.local
+
+            - name: Check Stripe config
+              run: pnpm -F web check:stripe-config
+
+    vercel-env-parity:
+        name: Vercel env-key parity
+        runs-on: ubuntu-latest
+        # The script only talks to the Vercel API, but importing @/lib/alerts
+        # validates the full server env schema, so the whole (dev-scoped)
+        # block rides along here too.
+        env:
+            DATABASE_URL: ${{ secrets.DATABASE_URL }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_REGION: ${{ secrets.AWS_REGION }}
+            S3_BUCKET: ${{ secrets.S3_BUCKET }}
+            SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
+            STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+            STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+            RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+            RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
+            BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+            NEXT_PUBLIC_APP_URL: ${{ secrets.NEXT_PUBLIC_APP_URL }}
+            DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_ALERT_WEBHOOK_URL }}
+            VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+            VERCEL_ENV: ci
+        steps:
+            - name: Verify Vercel token is configured
+              run: |
+                  if [ -z "$VERCEL_TOKEN" ]; then
+                      echo "::error::secret VERCEL_TOKEN is not configured (see docs/guides/environment-setup.md)"
+                      exit 1
+                  fi
+
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node and pnpm
+              uses: ./.github/actions/setup-node-pnpm
+
+            - name: Create empty env file
+              run: touch apps/web/.env.local
+
+            - name: Check Vercel env-key parity
+              run: pnpm -F web check:vercel-env-parity

--- a/apps/web/lib/alerts/index.ts
+++ b/apps/web/lib/alerts/index.ts
@@ -27,6 +27,8 @@ export const alerts = {
     send,
 } as const;
 
+export { getWorkflowRunUrl } from './workflowRun';
+
 export type {
     Alert,
     AlertSeverity,

--- a/apps/web/lib/alerts/workflowRun.ts
+++ b/apps/web/lib/alerts/workflowRun.ts
@@ -1,0 +1,11 @@
+/**
+ * URL of the GitHub Actions run executing the current process, so check
+ * scripts can embed a link in their alert context. Undefined outside CI.
+ */
+export function getWorkflowRunUrl(): string | undefined {
+    const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
+    if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) {
+        return undefined;
+    }
+    return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,9 @@
         "screenshots": "tsx scripts/screenshots.ts",
         "backfill:trial-subscriptions": "tsx --env-file=.env.local scripts/backfill-trial-subscriptions.ts",
         "backfill:storage-tier": "tsx --env-file=.env.local scripts/backfill-storage-tier.ts",
-        "check:s3-event-health": "tsx --env-file=.env.local scripts/check-s3-event-health.ts"
+        "check:s3-event-health": "tsx --env-file=.env.local scripts/check-s3-event-health.ts",
+        "check:stripe-config": "tsx --env-file=.env.local scripts/check-stripe-config.ts",
+        "check:vercel-env-parity": "tsx --env-file=.env.local scripts/check-vercel-env-parity.ts"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.975.0",

--- a/apps/web/scripts/check-s3-event-health.ts
+++ b/apps/web/scripts/check-s3-event-health.ts
@@ -22,7 +22,7 @@
 
 import { and, count, eq, gte, inArray, lt } from 'drizzle-orm';
 
-import { alerts } from '@/lib/alerts';
+import { alerts, getWorkflowRunUrl } from '@/lib/alerts';
 import { db } from '@/server/db';
 import { s3RestoreService } from '@/server/services/s3-restore';
 import { retrievals, webhookEvents } from '@nexus/db/schema';
@@ -145,14 +145,6 @@ async function main(): Promise<void> {
     } else {
         console.log('\nAll checks passed.');
     }
-}
-
-function getWorkflowRunUrl(): string | undefined {
-    const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
-    if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) {
-        return undefined;
-    }
-    return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
 }
 
 main()

--- a/apps/web/scripts/check-stripe-config.ts
+++ b/apps/web/scripts/check-stripe-config.ts
@@ -41,6 +41,13 @@ const EXPECTED_WEBHOOK_EVENTS = [
 
 const WEBHOOK_PATH = '/api/webhooks/stripe';
 
+// Hosts that may legitimately serve the webhook (prod + the dev branch's
+// custom domain). Pinning the host keeps a stale endpoint on a
+// decommissioned deployment from satisfying the check while events go
+// nowhere. Test mode currently points at the prod host (prod is test-mode
+// Stripe until #213), so both hosts are valid in either mode.
+const KNOWN_WEBHOOK_HOSTS = ['nexus.thomasar.dev', 'dev.nexus.thomasar.dev'];
+
 interface ExpectedPrice {
     tier: CheckoutTier;
     interval: BillingInterval;
@@ -116,15 +123,20 @@ function checkPrices(prices: Stripe.Price[]): string[] {
             continue;
         }
         const price = matching[0]!;
+        let isDrifted = false;
         if (price.unit_amount !== expected.unitAmount) {
+            isDrifted = true;
             failures.push(
                 `price ${price.id} (${label}): unit_amount ${price.unit_amount}, expected ${expected.unitAmount}`
             );
-        } else if (price.currency !== 'usd') {
+        }
+        if (price.currency !== 'usd') {
+            isDrifted = true;
             failures.push(
                 `price ${price.id} (${label}): currency '${price.currency}', expected 'usd'`
             );
-        } else {
+        }
+        if (!isDrifted) {
             console.log(
                 `  ✓ price ${label}: ${price.id} (${price.unit_amount} ${price.currency})`
             );
@@ -148,11 +160,14 @@ function checkPrices(prices: Stripe.Price[]): string[] {
 }
 
 function checkWebhookEndpoints(endpoints: Stripe.WebhookEndpoint[]): string[] {
-    const candidates = endpoints.filter(
-        (endpoint) =>
+    const candidates = endpoints.filter((endpoint) => {
+        const url = new URL(endpoint.url);
+        return (
             endpoint.status === 'enabled' &&
-            new URL(endpoint.url).pathname === WEBHOOK_PATH
-    );
+            url.pathname === WEBHOOK_PATH &&
+            KNOWN_WEBHOOK_HOSTS.includes(url.hostname)
+        );
+    });
 
     const covering = candidates.filter((endpoint) => {
         const events = new Set(endpoint.enabled_events);
@@ -186,9 +201,12 @@ function checkWebhookEndpoints(endpoints: Stripe.WebhookEndpoint[]): string[] {
 }
 
 async function main(): Promise<void> {
-    const mode = process.env.STRIPE_SECRET_KEY?.startsWith('sk_live_')
-        ? 'live'
-        : 'test';
+    const secretKey = process.env.STRIPE_SECRET_KEY ?? '';
+    // rk_ prefixes are restricted keys — still mode-carrying.
+    const mode =
+        secretKey.startsWith('sk_live_') || secretKey.startsWith('rk_live_')
+            ? 'live'
+            : 'test';
     console.log(`Checking Stripe config (${mode} mode)\n`);
 
     const [products, prices, webhookEndpoints] = await Promise.all([

--- a/apps/web/scripts/check-stripe-config.ts
+++ b/apps/web/scripts/check-stripe-config.ts
@@ -1,0 +1,244 @@
+/**
+ * Asserts the Stripe account's config matches what the app expects (#293).
+ *
+ * Stripe products, prices, and webhook endpoints are configured by hand once
+ * per mode (test vs live), so they can drift from the code's expectations
+ * silently. Fails (exit 1) when:
+ *   - a checkout tier (starter/pro/max) doesn't map to exactly one active
+ *     product carrying `metadata.tier`
+ *   - the 6 expected prices (3 tiers × month/year, amounts from
+ *     PLAN_DISPLAY) aren't each exactly one active recurring USD price, or a
+ *     tier product carries an active price outside those slots
+ *   - no enabled webhook endpoint at /api/webhooks/stripe subscribes to all
+ *     event types the app handles
+ *
+ * The mode checked is whatever STRIPE_SECRET_KEY selects (sk_test_ vs
+ * sk_live_). CI runs test mode nightly (env-parity.yml); live mode joins
+ * once #213 lands.
+ *
+ * Usage:
+ *   pnpm -F web check:stripe-config
+ *   STRIPE_SECRET_KEY=sk_live_... pnpm -F web check:stripe-config
+ */
+
+import type Stripe from 'stripe';
+
+import { PLAN_DISPLAY } from '@/components/dashboard/subscriptionPlans';
+import { alerts, getWorkflowRunUrl } from '@/lib/alerts';
+import { stripeClient } from '@/lib/stripe/client';
+import type { BillingInterval, CheckoutTier } from '@/lib/stripe/types';
+import { BILLING_INTERVALS } from '@/lib/stripe/types';
+
+// Keep in sync with dispatchWebhookEvent in server/services/subscriptions.ts
+// — the switch there is the ground truth for what the app handles.
+const EXPECTED_WEBHOOK_EVENTS = [
+    'checkout.session.completed',
+    'customer.subscription.created',
+    'customer.subscription.updated',
+    'customer.subscription.deleted',
+    'invoice.payment_failed',
+] as const;
+
+const WEBHOOK_PATH = '/api/webhooks/stripe';
+
+interface ExpectedPrice {
+    tier: CheckoutTier;
+    interval: BillingInterval;
+    unitAmount: number;
+}
+
+// PLAN_DISPLAY amounts are dollars; Stripe unit_amount is cents.
+const expectedPrices: ExpectedPrice[] = PLAN_DISPLAY.flatMap((plan) =>
+    BILLING_INTERVALS.map((interval) => ({
+        tier: plan.tier,
+        interval,
+        unitAmount: plan.prices[interval] * 100,
+    }))
+);
+
+// Stripe list calls auto-paginate when consumed as async iterables.
+async function collectAll<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+    const items: T[] = [];
+    for await (const item of iterable) {
+        items.push(item);
+    }
+    return items;
+}
+
+function checkProducts(products: Stripe.Product[]): string[] {
+    const failures: string[] = [];
+    const tiers = PLAN_DISPLAY.map((plan) => plan.tier);
+
+    for (const tier of tiers) {
+        const matching = products.filter((p) => p.metadata?.tier === tier);
+        if (matching.length === 1) {
+            console.log(`  ✓ product for tier '${tier}': ${matching[0]!.id}`);
+        } else {
+            failures.push(
+                `expected exactly 1 active product with metadata.tier='${tier}', found ${matching.length}` +
+                    (matching.length > 0
+                        ? ` (${matching.map((p) => p.id).join(', ')})`
+                        : '')
+            );
+        }
+    }
+    return failures;
+}
+
+function checkPrices(prices: Stripe.Price[]): string[] {
+    const failures: string[] = [];
+    const checkoutTiers = new Set<string>(PLAN_DISPLAY.map((p) => p.tier));
+
+    // Only prices attached to the checkout-tier products are constrained;
+    // other products (e.g. one-off test products) are none of our business.
+    const tierPrices = prices.filter((price) => {
+        const product = price.product as Stripe.Product;
+        return (
+            typeof product === 'object' &&
+            !('deleted' in product && product.deleted) &&
+            checkoutTiers.has(product.metadata?.tier ?? '')
+        );
+    });
+
+    for (const expected of expectedPrices) {
+        const matching = tierPrices.filter((price) => {
+            const product = price.product as Stripe.Product;
+            return (
+                product.metadata?.tier === expected.tier &&
+                price.recurring?.interval === expected.interval
+            );
+        });
+        const label = `${expected.tier}/${expected.interval}`;
+        if (matching.length !== 1) {
+            failures.push(
+                `expected exactly 1 active price for ${label}, found ${matching.length}`
+            );
+            continue;
+        }
+        const price = matching[0]!;
+        if (price.unit_amount !== expected.unitAmount) {
+            failures.push(
+                `price ${price.id} (${label}): unit_amount ${price.unit_amount}, expected ${expected.unitAmount}`
+            );
+        } else if (price.currency !== 'usd') {
+            failures.push(
+                `price ${price.id} (${label}): currency '${price.currency}', expected 'usd'`
+            );
+        } else {
+            console.log(
+                `  ✓ price ${label}: ${price.id} (${price.unit_amount} ${price.currency})`
+            );
+        }
+    }
+
+    // A price on a tier product outside the 6 expected slots is drift too
+    // (e.g. a stale interval or a one-time price the app can't resolve).
+    const unexpected = tierPrices.filter((price) => {
+        const interval = price.recurring?.interval;
+        return interval !== 'month' && interval !== 'year';
+    });
+    for (const price of unexpected) {
+        const product = price.product as Stripe.Product;
+        failures.push(
+            `unexpected non-recurring/unknown-interval active price ${price.id} on tier product '${product.metadata?.tier}'`
+        );
+    }
+
+    return failures;
+}
+
+function checkWebhookEndpoints(endpoints: Stripe.WebhookEndpoint[]): string[] {
+    const candidates = endpoints.filter(
+        (endpoint) =>
+            endpoint.status === 'enabled' &&
+            new URL(endpoint.url).pathname === WEBHOOK_PATH
+    );
+
+    const covering = candidates.filter((endpoint) => {
+        const events = new Set(endpoint.enabled_events);
+        return (
+            events.has('*') ||
+            EXPECTED_WEBHOOK_EVENTS.every((event) => events.has(event))
+        );
+    });
+
+    if (covering.length > 0) {
+        for (const endpoint of covering) {
+            console.log(
+                `  ✓ webhook endpoint ${endpoint.url} covers all ${EXPECTED_WEBHOOK_EVENTS.length} expected events`
+            );
+        }
+        return [];
+    }
+
+    const inventory =
+        endpoints.length === 0
+            ? '(no webhook endpoints exist in this mode)'
+            : endpoints
+                  .map(
+                      (endpoint) =>
+                          `${endpoint.url} [${endpoint.status}] events: ${endpoint.enabled_events.join(', ')}`
+                  )
+                  .join('; ');
+    return [
+        `no enabled webhook endpoint at ${WEBHOOK_PATH} subscribes to all of: ${EXPECTED_WEBHOOK_EVENTS.join(', ')} — found: ${inventory}`,
+    ];
+}
+
+async function main(): Promise<void> {
+    const mode = process.env.STRIPE_SECRET_KEY?.startsWith('sk_live_')
+        ? 'live'
+        : 'test';
+    console.log(`Checking Stripe config (${mode} mode)\n`);
+
+    const [products, prices, webhookEndpoints] = await Promise.all([
+        collectAll(stripeClient.products.list({ active: true, limit: 100 })),
+        collectAll(
+            stripeClient.prices.list({
+                active: true,
+                limit: 100,
+                expand: ['data.product'],
+            })
+        ),
+        collectAll(stripeClient.webhookEndpoints.list({ limit: 100 })),
+    ]);
+
+    console.log('Products:');
+    const productFailures = checkProducts(products);
+    console.log('Prices:');
+    const priceFailures = checkPrices(prices);
+    console.log('Webhook endpoints:');
+    const webhookFailures = checkWebhookEndpoints(webhookEndpoints);
+
+    const failures = [...productFailures, ...priceFailures, ...webhookFailures];
+    for (const failure of failures) {
+        console.log(`  ✗ ${failure}`);
+    }
+
+    if (failures.length > 0) {
+        console.log(`\nCheck failed: Stripe ${mode}-mode config has drifted.`);
+        process.exitCode = 1;
+
+        // The exit-1 (and its workflow-failure email) stays as the dead-man
+        // backup for the check itself; this pushes the findings where they
+        // get seen (#288).
+        const runUrl = getWorkflowRunUrl();
+        await alerts.send({
+            severity: 'error',
+            title: `Stripe ${mode}-mode config drift detected`,
+            message: failures.join('\n'),
+            context: {
+                source: 'check-stripe-config',
+                mode,
+                ...(runUrl && { workflowRun: runUrl }),
+            },
+        });
+    } else {
+        console.log('\nAll checks passed.');
+    }
+}
+
+main().catch((err) => {
+    console.error('Stripe config check aborted:', err);
+    process.exitCode = 1;
+});

--- a/apps/web/scripts/check-vercel-env-parity.ts
+++ b/apps/web/scripts/check-vercel-env-parity.ts
@@ -1,0 +1,141 @@
+/**
+ * Asserts the three Vercel env tiers hold the same variable *keys* (#293).
+ *
+ * Values legitimately differ per tier (DATABASE_URL, S3_BUCKET, … — see
+ * docs/guides/environment-setup.md), but every key should exist on all of
+ * Production, Preview, and Development: a key present in one tier and
+ * missing in another is exactly the drift that becomes a prod-only bug.
+ * Fails (exit 1) on any key missing from a tier unless it's in
+ * ASYMMETRY_ALLOWLIST.
+ *
+ * Requires VERCEL_TOKEN (a Vercel token with read access to the project).
+ * VERCEL_PROJECT_ID / VERCEL_TEAM_ID default to nexus-web (the values in
+ * .vercel/project.json; they identify, they don't authenticate).
+ *
+ * Usage:
+ *   VERCEL_TOKEN=... pnpm -F web check:vercel-env-parity
+ */
+
+import { alerts, getWorkflowRunUrl } from '@/lib/alerts';
+
+const TIERS = ['production', 'preview', 'development'] as const;
+type Tier = (typeof TIERS)[number];
+
+// Keys allowed to exist in only some tiers, with the reason. Vars whose
+// *values* differ per tier (DATABASE_URL, S3_BUCKET, …) don't belong here —
+// their keys exist everywhere. Add entries when a tier legitimately gains a
+// scoped key (e.g. a Production-only live-mode Stripe credential once #213
+// lands).
+const ASYMMETRY_ALLOWLIST: Record<string, string> = {
+    // lib/env/schema.ts: unset disables the Discord alert transport, which
+    // is the intended state for preview/dev runtimes; CI injects its own.
+    DISCORD_ALERT_WEBHOOK_URL: 'prod-only by design',
+};
+
+const DEFAULT_PROJECT_ID = 'prj_RuKjFko6iKwbyyIy55HYL5S5AabG';
+const DEFAULT_TEAM_ID = 'team_piLBQY2ugwaz6UvqaNNCJebb';
+
+interface VercelEnvVar {
+    key: string;
+    // The API returns an array; older payloads may use a bare string.
+    target: Tier[] | Tier;
+    gitBranch?: string;
+}
+
+async function fetchEnvVars(): Promise<VercelEnvVar[]> {
+    const token = process.env.VERCEL_TOKEN;
+    if (!token) {
+        throw new Error(
+            'VERCEL_TOKEN is not set — create a read-scoped token at vercel.com/account/tokens'
+        );
+    }
+    const projectId = process.env.VERCEL_PROJECT_ID ?? DEFAULT_PROJECT_ID;
+    const teamId = process.env.VERCEL_TEAM_ID ?? DEFAULT_TEAM_ID;
+
+    const response = await fetch(
+        `https://api.vercel.com/v9/projects/${projectId}/env?teamId=${teamId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+    );
+    if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new Error(
+            `Vercel API responded ${response.status}: ${body.slice(0, 300)}`
+        );
+    }
+    const { envs } = (await response.json()) as { envs: VercelEnvVar[] };
+    return envs;
+}
+
+function groupKeysByTier(envs: VercelEnvVar[]): Map<Tier, Set<string>> {
+    const byTier = new Map<Tier, Set<string>>(
+        TIERS.map((tier) => [tier, new Set<string>()])
+    );
+    for (const envVar of envs) {
+        const targets = Array.isArray(envVar.target)
+            ? envVar.target
+            : [envVar.target];
+        for (const target of targets) {
+            byTier.get(target)?.add(envVar.key);
+        }
+    }
+    return byTier;
+}
+
+async function main(): Promise<void> {
+    const envs = await fetchEnvVars();
+    const byTier = groupKeysByTier(envs);
+    const allKeys = [...new Set(envs.map((envVar) => envVar.key))].sort();
+
+    console.log(
+        `Checking ${allKeys.length} distinct env keys across ${TIERS.length} Vercel tiers\n`
+    );
+
+    const failures: string[] = [];
+    for (const key of allKeys) {
+        const missing = TIERS.filter((tier) => !byTier.get(tier)!.has(key));
+        if (missing.length === 0) {
+            console.log(`  ✓ ${key}`);
+        } else if (key in ASYMMETRY_ALLOWLIST) {
+            console.log(
+                `  ~ ${key} missing in ${missing.join(', ')} (allowlisted: ${ASYMMETRY_ALLOWLIST[key]})`
+            );
+        } else {
+            const present = TIERS.filter((tier) => !missing.includes(tier));
+            failures.push(
+                `${key} present in ${present.join(', ')}; missing in ${missing.join(', ')}`
+            );
+        }
+    }
+
+    for (const failure of failures) {
+        console.log(`  ✗ ${failure}`);
+    }
+
+    if (failures.length > 0) {
+        console.log(
+            '\nCheck failed: Vercel env keys have drifted between tiers. If an asymmetry is intentional, add it to ASYMMETRY_ALLOWLIST in this script with the reason.'
+        );
+        process.exitCode = 1;
+
+        // The exit-1 (and its workflow-failure email) stays as the dead-man
+        // backup for the check itself; this pushes the findings where they
+        // get seen (#288).
+        const runUrl = getWorkflowRunUrl();
+        await alerts.send({
+            severity: 'error',
+            title: 'Vercel env-key drift detected between tiers',
+            message: failures.join('\n'),
+            context: {
+                source: 'check-vercel-env-parity',
+                ...(runUrl && { workflowRun: runUrl }),
+            },
+        });
+    } else {
+        console.log('\nAll checks passed.');
+    }
+}
+
+main().catch((err) => {
+    console.error('Vercel env parity check aborted:', err);
+    process.exitCode = 1;
+});

--- a/apps/web/scripts/check-vercel-env-parity.ts
+++ b/apps/web/scripts/check-vercel-env-parity.ts
@@ -8,9 +8,11 @@
  * Fails (exit 1) on any key missing from a tier unless it's in
  * ASYMMETRY_ALLOWLIST.
  *
- * Requires VERCEL_TOKEN (a Vercel token with read access to the project).
- * VERCEL_PROJECT_ID / VERCEL_TEAM_ID default to nexus-web (the values in
- * .vercel/project.json; they identify, they don't authenticate).
+ * Requires VERCEL_TOKEN. Vercel tokens can't be scoped read-only — team-scope
+ * it and give it an expiry (it can also write env vars, so handle it as a
+ * real credential). VERCEL_PROJECT_ID / VERCEL_TEAM_ID default to nexus-web
+ * (the values in .vercel/project.json; they identify, they don't
+ * authenticate).
  *
  * Usage:
  *   VERCEL_TOKEN=... pnpm -F web check:vercel-env-parity
@@ -46,7 +48,7 @@ async function fetchEnvVars(): Promise<VercelEnvVar[]> {
     const token = process.env.VERCEL_TOKEN;
     if (!token) {
         throw new Error(
-            'VERCEL_TOKEN is not set — create a read-scoped token at vercel.com/account/tokens'
+            'VERCEL_TOKEN is not set — create a team-scoped token (with an expiry) at vercel.com/account/tokens'
         );
     }
     const projectId = process.env.VERCEL_PROJECT_ID ?? DEFAULT_PROJECT_ID;
@@ -71,6 +73,10 @@ function groupKeysByTier(envs: VercelEnvVar[]): Map<Tier, Set<string>> {
         TIERS.map((tier) => [tier, new Set<string>()])
     );
     for (const envVar of envs) {
+        // A branch-scoped var only exists on that one branch's deploys, so
+        // it can't make the key "present" for the tier in general — counting
+        // it would mask a key missing from every other preview.
+        if (envVar.gitBranch) continue;
         const targets = Array.isArray(envVar.target)
             ? envVar.target
             : [envVar.target];
@@ -89,6 +95,12 @@ async function main(): Promise<void> {
     console.log(
         `Checking ${allKeys.length} distinct env keys across ${TIERS.length} Vercel tiers\n`
     );
+
+    for (const envVar of envs.filter((e) => e.gitBranch)) {
+        console.log(
+            `  ~ ${envVar.key} (branch-scoped to '${envVar.gitBranch}') ignored for tier parity`
+        );
+    }
 
     const failures: string[] = [];
     for (const key of allKeys) {

--- a/docs/guides/environment-setup.md
+++ b/docs/guides/environment-setup.md
@@ -210,8 +210,10 @@ key manually (`aws iam create-access-key --user-name nexus-app-prod`).
 - `pnpm -F web check:vercel-env-parity` — fails when an env-var **key**
   exists in some tiers but not others (values may differ per tier; keys may
   not). Intentional asymmetries go in the script's `ASYMMETRY_ALLOWLIST`.
-  Needs the `VERCEL_TOKEN` GitHub Actions secret — a read-scoped token from
-  vercel.com/account/tokens.
+  Needs the `VERCEL_TOKEN` GitHub Actions secret — a token from
+  vercel.com/account/tokens, team-scoped and with an expiry. Vercel tokens
+  can't be scoped read-only: this token can also _write_ env vars, so treat
+  it as a real credential.
 
 The prod DB health leg (`check:s3-event-health`) already runs nightly for
 both environments via the dev/prod matrix in `s3-event-health.yml`

--- a/docs/guides/environment-setup.md
+++ b/docs/guides/environment-setup.md
@@ -200,6 +200,23 @@ key manually (`aws iam create-access-key --user-name nexus-app-prod`).
 4. Update `.env.example` for reference
 5. Update this documentation
 
+### Parity Checks (CI)
+
+`env-parity.yml` runs nightly (#293) and backstops the manual processes above:
+
+- `pnpm -F web check:stripe-config` — asserts products/prices/webhook wiring
+  in whichever Stripe mode its `STRIPE_SECRET_KEY` selects (test mode until
+  #213 adds a live leg).
+- `pnpm -F web check:vercel-env-parity` — fails when an env-var **key**
+  exists in some tiers but not others (values may differ per tier; keys may
+  not). Intentional asymmetries go in the script's `ASYMMETRY_ALLOWLIST`.
+  Needs the `VERCEL_TOKEN` GitHub Actions secret — a read-scoped token from
+  vercel.com/account/tokens.
+
+The prod DB health leg (`check:s3-event-health`) already runs nightly for
+both environments via the dev/prod matrix in `s3-event-health.yml`
+(`DATABASE_URL_PROD` secret).
+
 ## Related
 
 - [[getting-started|Getting Started]]


### PR DESCRIPTION
## Summary

Nightly automated checks that surface config drift between dev and prod for the layers with no shared source of truth: Stripe (products/prices/webhook wiring, hand-configured per mode) and Vercel env-var keys (hand-edited per tier). Both scripts follow the `check-s3-event-health.ts` pattern (exit 1 as the dead-man backstop, `alerts.send` as the fast path) and run from a new `env-parity.yml` workflow at 06:00 UTC, after migration-drift (04:00) and s3-event-health (05:00).

Closes #293

## Changes

- `apps/web/scripts/check-stripe-config.ts` — asserts 3 active products with `metadata.tier` (starter/pro/max), 6 active recurring USD prices at the amounts/intervals from `PLAN_DISPLAY` (single source of truth, no hardcoded copies), and an enabled webhook endpoint at `/api/webhooks/stripe` covering the 5 event types `dispatchWebhookEvent` handles. Mode follows whatever `STRIPE_SECRET_KEY` selects; CI runs test mode, with a commented-out live matrix entry ready for #213.
- `apps/web/scripts/check-vercel-env-parity.ts` — diffs env-var **keys** (never values) across Production/Preview/Development via the Vercel REST API; fails on any asymmetry not in `ASYMMETRY_ALLOWLIST` (one entry: `DISCORD_ALERT_WEBHOOK_URL`, prod-only by design per `lib/env/schema.ts`).
- `.github/workflows/env-parity.yml` — nightly cron + `workflow_dispatch`, secret-presence guards, `fail-fast: false` matrix for Stripe modes.
- `apps/web/lib/alerts/workflowRun.ts` — `getWorkflowRunUrl()` extracted from `check-s3-event-health.ts` now that three scripts use it (self-review finding).
- `docs/guides/environment-setup.md` — documents the checks and the `VERCEL_TOKEN` secret.

**AC3 (`check:s3-event-health` against prod) was already satisfied on main**: `s3-event-health.yml` matrices dev/prod via `DATABASE_URL_PROD`. This PR only documents that; the prod-leg AWS-credential gap stays tracked in #318.

## Real drift found during verification

The Vercel parity check was run against the real project and found `DB_ENV` **missing in Preview** (present in Production and Development), contradicting the tier table in `docs/guides/environment-setup.md`. Deliberately not fixed here — it's Vercel dashboard state, and it proves the check works. The nightly run stays red until it's fixed.

## Post-merge ops (needed before the nightly goes green)

1. Add `DB_ENV=development` to the Preview tier: `vercel env add DB_ENV preview` (per-environment, see the per-tier-edits warning in environment-setup.md).
2. Create a read-scoped token at vercel.com/account/tokens and add it as the `VERCEL_TOKEN` GitHub Actions secret.

## Deferred self-review findings

- `EXPECTED_WEBHOOK_EVENTS` stays script-local with a keep-in-sync comment: importing `subscriptions.ts` would drag the DB/email dependency graph into a Stripe-only script. The clean fix is refactoring `dispatchWebhookEvent` to a handler map exporting `handledEventTypes` (the `s3RestoreService` pattern) — follow-up material.
- The ~13-key secrets env block is now copy-pasted across three workflows; GitHub Actions has no clean job-level `env` sharing, so deduping (composite action writing `$GITHUB_ENV`) is deferred.

## Test Plan

- [x] `pnpm check` green
- [x] `pnpm -F web check:stripe-config` run against the real test sandbox — all products/prices/webhook assertions pass
- [x] `pnpm -F web check:vercel-env-parity` run against the real project — allowlist honored, real `DB_ENV` drift detected, exit 1
- [x] After merge + ops steps above: `gh workflow run env-parity.yml` and confirm both jobs green
