### PR TITLE
fix: enforce one active retrieval per file at the DB level (#266)

### DIFF
--- a/apps/web/server/services/retrieval.integration.test.ts
+++ b/apps/web/server/services/retrieval.integration.test.ts
@@ -13,7 +13,8 @@ import { retrievalService } from './retrieval';
 
 // Exercises the active-retrieval predicate against a real database: `ready`
 // rows past `expiresAt` are expired by query, not by stored status — no S3
-// expiry event ever fires for standard-tier fast-path rows.
+// expiry event ever fires for standard-tier fast-path rows. Also exercises
+// the partial unique index guaranteeing one active retrieval per file (#266).
 
 const db: Connection = createDb(process.env.DATABASE_URL!);
 
@@ -53,6 +54,11 @@ describe('active-retrieval expiry predicate', () => {
         expect(retrieval.id).not.toBe(lapsed.id);
         expect(retrieval.status).toBe('ready');
         expect(retrieval.expiresAt!.getTime()).toBeGreaterThan(Date.now());
+
+        // The insert path flipped the lapsed row to `expired` — it has to,
+        // or the row would still hold the unique-index slot for the file.
+        const rows = await createRetrievalRepo(db).findByUser(userId);
+        expect(rows.find((r) => r.id === lapsed.id)?.status).toBe('expired');
     });
 
     it('getDownloadUrl rejects a lapsed ready retrieval', async () => {
@@ -126,5 +132,46 @@ describe('active-retrieval expiry predicate', () => {
         expect(new Set(activeForTheseFiles.map((r) => r.id))).toEqual(
             new Set([unexpired.id, noExpiry.id, pending.id])
         );
+    });
+});
+
+describe('one active retrieval per file (#266)', () => {
+    it('two concurrent retrieval requests yield exactly one active row', async () => {
+        const file = await insertFile(db, { userId, storageTier: 'standard' });
+
+        const [first, second] = await Promise.all([
+            retrievalService.requestRetrieval(db, userId, file.id),
+            retrievalService.requestRetrieval(db, userId, file.id),
+        ]);
+
+        // Whichever call lost the insert race got the winner's row back.
+        expect(first.id).toBe(second.id);
+
+        const active = await createRetrievalRepo(db).findByFileIds([file.id]);
+        expect(active).toHaveLength(1);
+    });
+
+    it('the unique index skips a duplicate active insert and keeps the existing row', async () => {
+        const repo = createRetrievalRepo(db);
+        const file = await insertFile(db, { userId });
+        const winner = await insertRetrieval(db, {
+            userId,
+            fileId: file.id,
+            status: 'pending',
+        });
+
+        const skipped = await repo.insertMany([
+            {
+                id: crypto.randomUUID(),
+                fileId: file.id,
+                userId,
+                tier: 'standard',
+                status: 'pending',
+            },
+        ]);
+
+        expect(skipped).toEqual([]);
+        const active = await repo.findByFileIds([file.id]);
+        expect(active.map((r) => r.id)).toEqual([winner.id]);
     });
 });

--- a/apps/web/server/services/retrieval.test.ts
+++ b/apps/web/server/services/retrieval.test.ts
@@ -138,6 +138,48 @@ describe('retrieval service', () => {
                 )
             ).rejects.toThrow(InvalidStateError);
         });
+
+        it('expires lapsed ready rows before inserting', async () => {
+            const file = createFileFixture({ storageTier: 'standard' });
+            const retrieval = createRetrievalFixture({ status: 'ready' });
+
+            mocks.files.findMany.mockResolvedValue([file]);
+            mocks.retrievals.findMany.mockResolvedValue([]);
+            mocks.returning.mockResolvedValue([retrieval]);
+
+            await retrievalService.requestRetrieval(
+                db,
+                TEST_USER_ID,
+                TEST_FILE_ID
+            );
+
+            expect(mocks.update).toHaveBeenCalledOnce();
+            expect(mocks.set).toHaveBeenCalledWith({ status: 'expired' });
+        });
+
+        it('returns the surviving row when a concurrent request wins the insert race', async () => {
+            const file = createFileFixture({ storageTier: 'standard' });
+            const survivor = createRetrievalFixture({ status: 'ready' });
+
+            mocks.files.findMany.mockResolvedValue([file]);
+            // First findMany: the pre-insert active check sees nothing; the
+            // competing request inserts between check and insert, so the
+            // conflict-skipped insert returns [] and the reconciliation
+            // lookup finds the winner's row.
+            mocks.retrievals.findMany
+                .mockResolvedValueOnce([])
+                .mockResolvedValueOnce([survivor]);
+            mocks.returning.mockResolvedValue([]);
+
+            const result = await retrievalService.requestRetrieval(
+                db,
+                TEST_USER_ID,
+                TEST_FILE_ID
+            );
+
+            expect(result).toEqual(survivor);
+            expect(mocks.retrievals.findMany).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe('requestBulkRetrieval', () => {

--- a/apps/web/server/services/retrieval.ts
+++ b/apps/web/server/services/retrieval.ts
@@ -40,6 +40,12 @@ async function restoreFiles(
         return existingRetrievals;
     }
 
+    // A lapsed `ready` row is invisible to findByFileIds but still holds the
+    // unique-index slot for its file; expire it or the insert below would
+    // conflict against a row that no longer counts as active.
+    const fileIdsToRestore = filesToRestore.map((f) => f.id);
+    await retrievalRepo.expireLapsedByFileIds(fileIdsToRestore);
+
     // Standard-class objects are downloadable as-is — RestoreObject would
     // fail with InvalidObjectState — so they skip S3 and become ready
     // immediately, entering the same download-window state as completed
@@ -88,6 +94,17 @@ async function restoreFiles(
             expiresAt: readyWindowEnd,
         })),
     ]);
+
+    // A concurrent request may have won the insert for some files (the
+    // unique index skips them via ON CONFLICT DO NOTHING); fetch the
+    // surviving rows so every requested file still maps to a retrieval.
+    if (newRetrievals.length < filesToRestore.length) {
+        const insertedFileIds = new Set(newRetrievals.map((r) => r.fileId));
+        const survivors = await retrievalRepo.findByFileIds(
+            fileIdsToRestore.filter((id) => !insertedFileIds.has(id))
+        );
+        return [...existingRetrievals, ...newRetrievals, ...survivors];
+    }
 
     return [...existingRetrievals, ...newRetrievals];
 }

--- a/packages/db/src/migrations/0015_petite_shockwave.sql
+++ b/packages/db/src/migrations/0015_petite_shockwave.sql
@@ -1,0 +1,19 @@
+-- Existing rows can violate the index this migration creates: lapsed `ready`
+-- rows (expired by read predicate, never by stored status) and duplicates
+-- slipped in by the pre-constraint read-then-insert race (#266). Expire the
+-- lapsed, keep the newest of any remaining active duplicates.
+UPDATE "retrievals" SET "status" = 'expired', "updated_at" = now()
+WHERE "status" = 'ready' AND "expires_at" IS NOT NULL AND "expires_at" <= now();--> statement-breakpoint
+UPDATE "retrievals" SET "status" = 'cancelled', "updated_at" = now()
+WHERE "id" IN (
+    SELECT "id" FROM (
+        SELECT "id", row_number() OVER (
+            PARTITION BY "file_id"
+            ORDER BY "created_at" DESC, "id" DESC
+        ) AS "rn"
+        FROM "retrievals"
+        WHERE "status" IN ('pending', 'in_progress', 'ready')
+    ) "ranked"
+    WHERE "rn" > 1
+);--> statement-breakpoint
+CREATE UNIQUE INDEX "retrievals_active_file_id_idx" ON "retrievals" USING btree ("file_id") WHERE status IN ('pending', 'in_progress', 'ready');

--- a/packages/db/src/migrations/meta/0015_snapshot.json
+++ b/packages/db/src/migrations/meta/0015_snapshot.json
@@ -1,0 +1,1560 @@
+{
+  "id": "6f3d7445-9990-4550-9035-a9ea343c47e6",
+  "prevId": "cdbe7fc3-4100-4351-ac76-3ce63c6595c2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_by_user_id": {
+          "name": "redeemed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_token_idx": {
+          "name": "invites_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_status_idx": {
+          "name": "invites_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invites_redeemed_by_user_id_user_id_fk": {
+          "name": "invites_redeemed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "redeemed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.background_jobs": {
+      "name": "background_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "background_jobs_status_created_at_idx": {
+          "name": "background_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_tier": {
+          "name": "storage_tier",
+          "type": "storage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "status": {
+          "name": "status",
+          "type": "file_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_user_id_idx": {
+          "name": "files_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_status_idx": {
+          "name": "files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_storage_tier_idx": {
+          "name": "files_storage_tier_idx",
+          "columns": [
+            {
+              "expression": "storage_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_batch_id_idx": {
+          "name": "files_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_user_id_created_at_idx": {
+          "name": "files_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_user_id_user_id_fk": {
+          "name": "files_user_id_user_id_fk",
+          "tableFrom": "files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_batch_id_upload_batches_id_fk": {
+          "name": "files_batch_id_upload_batches_id_fk",
+          "tableFrom": "files",
+          "tableTo": "upload_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_s3_key_unique": {
+          "name": "files_s3_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "s3_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.retrievals": {
+      "name": "retrievals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "retrieval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "retrieval_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "initiated_at": {
+          "name": "initiated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "retrievals_file_id_idx": {
+          "name": "retrievals_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_user_id_idx": {
+          "name": "retrievals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_status_idx": {
+          "name": "retrievals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_batch_id_idx": {
+          "name": "retrievals_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_expires_at_idx": {
+          "name": "retrievals_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "retrievals_active_file_id_idx": {
+          "name": "retrievals_active_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'in_progress', 'ready')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "retrievals_file_id_files_id_fk": {
+          "name": "retrievals_file_id_files_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_user_id_user_id_fk": {
+          "name": "retrievals_user_id_user_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "retrievals_batch_id_upload_batches_id_fk": {
+          "name": "retrievals_batch_id_upload_batches_id_fk",
+          "tableFrom": "retrievals",
+          "tableTo": "upload_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_usage": {
+      "name": "storage_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_bytes": {
+          "name": "used_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_usage_user_id_idx": {
+          "name": "storage_usage_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_usage_user_id_user_id_fk": {
+          "name": "storage_usage_user_id_user_id_fk",
+          "tableFrom": "storage_usage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storage_usage_user_id_unique": {
+          "name": "storage_usage_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.upload_batches": {
+      "name": "upload_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "upload_batches_user_id_idx": {
+          "name": "upload_batches_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "upload_batches_user_id_user_id_fk": {
+          "name": "upload_batches_user_id_user_id_fk",
+          "tableFrom": "upload_batches",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_tier": {
+          "name": "plan_tier",
+          "type": "plan_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starter'"
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trialing'"
+        },
+        "storage_limit": {
+          "name": "storage_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_status_idx": {
+          "name": "subscriptions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_user_id_fk": {
+          "name": "subscriptions_user_id_user_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_user_id_unique": {
+          "name": "subscriptions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "subscriptions_stripe_customer_id_unique": {
+          "name": "subscriptions_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        },
+        "subscriptions_stripe_subscription_id_unique": {
+          "name": "subscriptions_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "webhook_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_events_source_external_id_idx": {
+          "name": "webhook_events_source_external_id_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_status_created_at_idx": {
+          "name": "webhook_events_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "redeemed",
+        "revoked"
+      ]
+    },
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.file_status": {
+      "name": "file_status",
+      "schema": "public",
+      "values": [
+        "uploading",
+        "available",
+        "restoring",
+        "deleted"
+      ]
+    },
+    "public.retrieval_status": {
+      "name": "retrieval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "ready",
+        "expired",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.retrieval_tier": {
+      "name": "retrieval_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "bulk",
+        "expedited"
+      ]
+    },
+    "public.storage_tier": {
+      "name": "storage_tier",
+      "schema": "public",
+      "values": [
+        "standard",
+        "glacier",
+        "deep_archive"
+      ]
+    },
+    "public.plan_tier": {
+      "name": "plan_tier",
+      "schema": "public",
+      "values": [
+        "starter",
+        "pro",
+        "max",
+        "enterprise"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "past_due",
+        "canceled",
+        "unpaid",
+        "incomplete",
+        "sponsored"
+      ]
+    },
+    "public.webhook_source": {
+      "name": "webhook_source",
+      "schema": "public",
+      "values": [
+        "stripe",
+        "sns"
+      ]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "processed",
+        "failed",
+        "unhandled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1783269833835,
       "tag": "0014_brainy_kang",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1783872326209,
+      "tag": "0015_petite_shockwave",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repositories/mocks.ts
+++ b/packages/db/src/repositories/mocks.ts
@@ -23,7 +23,12 @@ export function createMockDb() {
     const where: AnyMock = vi.fn(() => ({ returning, groupBy }));
     const set: AnyMock = vi.fn(() => ({ where }));
     const onConflictDoUpdate: AnyMock = vi.fn(() => ({ returning }));
-    const values: AnyMock = vi.fn(() => ({ returning, onConflictDoUpdate }));
+    const onConflictDoNothing: AnyMock = vi.fn(() => ({ returning }));
+    const values: AnyMock = vi.fn(() => ({
+        returning,
+        onConflictDoUpdate,
+        onConflictDoNothing,
+    }));
     // leftJoin has its own `where` so the `.where().orderBy()`/`.where()
     // .groupBy()` terminals here don't collide with the awaitable `where`
     // used by simpler chains. leftJoin returns itself so chains may stack
@@ -82,6 +87,7 @@ export function createMockDb() {
             insert,
             values,
             onConflictDoUpdate,
+            onConflictDoNothing,
             update,
             set,
             delete: deleteFn,

--- a/packages/db/src/repositories/retrievals.test.ts
+++ b/packages/db/src/repositories/retrievals.test.ts
@@ -130,11 +130,43 @@ describe('retrievals repository', () => {
             expect(mocks.insert).toHaveBeenCalledOnce();
         });
 
+        it('skips conflicts instead of throwing', async () => {
+            mocks.returning.mockResolvedValue([]);
+
+            const result = await repo.insertMany([
+                {
+                    id: 'r1',
+                    fileId: 'file1',
+                    userId: TEST_USER_ID,
+                    tier: 'standard',
+                    status: 'pending',
+                },
+            ]);
+
+            expect(result).toEqual([]);
+            expect(mocks.onConflictDoNothing).toHaveBeenCalledOnce();
+        });
+
         it('returns empty array when given empty array', async () => {
             const result = await repo.insertMany([]);
 
             expect(result).toEqual([]);
             expect(mocks.insert).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('expireLapsedByFileIds', () => {
+        it('flips lapsed ready rows to expired', async () => {
+            await repo.expireLapsedByFileIds(['file1', 'file2']);
+
+            expect(mocks.update).toHaveBeenCalledOnce();
+            expect(mocks.set).toHaveBeenCalledWith({ status: 'expired' });
+        });
+
+        it('does nothing when given empty ids', async () => {
+            await repo.expireLapsedByFileIds([]);
+
+            expect(mocks.update).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/db/src/repositories/retrievals.ts
+++ b/packages/db/src/repositories/retrievals.ts
@@ -1,4 +1,14 @@
-import { eq, and, or, inArray, isNull, gt, desc } from 'drizzle-orm';
+import {
+    eq,
+    and,
+    or,
+    not,
+    inArray,
+    isNull,
+    gt,
+    desc,
+    type SQL,
+} from 'drizzle-orm';
 import type { DB } from '../connection';
 import * as schema from '../schema';
 import { createRepository } from './create';
@@ -16,14 +26,20 @@ export type NewRetrieval = typeof schema.retrievals.$inferInsert;
 export function activeRetrievalFilter() {
     return or(
         inArray(schema.retrievals.status, ['pending', 'in_progress']),
-        and(
-            eq(schema.retrievals.status, 'ready'),
-            or(
-                isNull(schema.retrievals.expiresAt),
-                gt(schema.retrievals.expiresAt, new Date())
-            )
-        )
+        and(eq(schema.retrievals.status, 'ready'), readyWindowOpen())
     );
+}
+
+// The download window on a `ready` row is open while `expiresAt` is unset (a
+// malformed restore-completed event: better a stale entry than a download cut
+// off early) or still in the future. Shared with expireLapsedByFileIds so the
+// active predicate and the expiry transition can't drift apart.
+function readyWindowOpen(): SQL {
+    // or() is only `undefined` when called with no arguments
+    return or(
+        isNull(schema.retrievals.expiresAt),
+        gt(schema.retrievals.expiresAt, new Date())
+    )!;
 }
 
 function findByFileId(db: DB, fileId: string): Promise<Retrieval | undefined> {
@@ -112,12 +128,39 @@ async function insert(db: DB, data: NewRetrieval): Promise<Retrieval> {
     return retrieval;
 }
 
+// ON CONFLICT DO NOTHING against the partial unique index on active
+// retrievals (retrievals_active_file_id_idx): when a concurrent request has
+// already inserted an active row for a file, that row is skipped and omitted
+// from the result — callers reconcile missing fileIds against the surviving
+// row via findByFileIds.
 async function insertMany(
     db: DB,
     dataArray: NewRetrieval[]
 ): Promise<Retrieval[]> {
     if (dataArray.length === 0) return [];
-    return db.insert(schema.retrievals).values(dataArray).returning();
+    return db
+        .insert(schema.retrievals)
+        .values(dataArray)
+        .onConflictDoNothing()
+        .returning();
+}
+
+// A lapsed `ready` row is inactive to reads (see activeRetrievalFilter) but
+// still holds the unique-index slot for its file — the index predicate can't
+// see `expiresAt`. Flip such rows to `expired` so a fresh retrieval for the
+// file can insert. Idempotent, safe to race.
+async function expireLapsedByFileIds(db: DB, fileIds: string[]): Promise<void> {
+    if (fileIds.length === 0) return;
+    await db
+        .update(schema.retrievals)
+        .set({ status: 'expired' })
+        .where(
+            and(
+                inArray(schema.retrievals.fileId, fileIds),
+                eq(schema.retrievals.status, 'ready'),
+                not(readyWindowOpen())
+            )
+        );
 }
 
 async function updateStatus(
@@ -144,6 +187,7 @@ export const createRetrievalRepo = createRepository({
     findActiveByUserWithFiles,
     insert,
     insertMany,
+    expireLapsedByFileIds,
     updateStatus,
 });
 

--- a/packages/db/src/schema/storage.ts
+++ b/packages/db/src/schema/storage.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import {
     pgTable,
     pgEnum,
@@ -6,6 +7,7 @@ import {
     bigint,
     integer,
     index,
+    uniqueIndex,
 } from 'drizzle-orm/pg-core';
 import { user } from './auth';
 import { timestamps } from './helpers';
@@ -154,5 +156,12 @@ export const retrievals = pgTable(
         index('retrievals_status_idx').on(table.status),
         index('retrievals_batch_id_idx').on(table.batchId),
         index('retrievals_expires_at_idx').on(table.expiresAt),
+        // At most one active retrieval per file. `expires_at > now()` isn't
+        // indexable (now() is not IMMUTABLE), so a lapsed `ready` row still
+        // occupies the index slot until the insert path flips it to
+        // `expired` — see expireLapsedByFileIds in repositories/retrievals.
+        uniqueIndex('retrievals_active_file_id_idx')
+            .on(table.fileId)
+            .where(sql`status IN ('pending', 'in_progress', 'ready')`),
     ]
 );


### PR DESCRIPTION
## Summary
Nothing at the DB level prevented two active retrieval rows for the same file — `restoreFiles` did a read-then-insert, so concurrent requests (double-click, two tabs, retried mutation) could both pass the active check and insert duplicates. This adds a partial unique index on `retrievals(file_id)` over the non-terminal statuses (`pending`, `in_progress`, `ready`) and makes the insert path race-safe against it.

Since `expires_at > now()` can't appear in an index predicate (`now()` isn't IMMUTABLE), a lapsed `ready` row would otherwise hold the index slot and block a legitimate fresh retrieval — the query-level predicate treats those as inactive, but nothing reliably transitions their stored status (the S3 expiry event never fires for standard-tier fast-path rows). The insert path therefore flips lapsed `ready` rows to `expired` before inserting, per the shape the issue suggested.

Closes #266

## Changes
- Partial unique index `retrievals_active_file_id_idx` on `retrievals(file_id) WHERE status IN ('pending','in_progress','ready')` (`packages/db/src/schema/storage.ts`)
- Migration `0015_petite_shockwave.sql` cleans existing data before creating the index: expires lapsed `ready` rows, cancels all but the newest active duplicate per file (both no-ops on clean data; dev currently has 0 retrieval rows, so a plain non-CONCURRENT index build is fine)
- `insertMany` uses `ON CONFLICT DO NOTHING` — a concurrent duplicate is skipped and omitted from the returned rows
- New `expireLapsedByFileIds` repo function; shares a `readyWindowOpen()` predicate with `activeRetrievalFilter` so the active predicate and the expiry transition can't drift apart
- `restoreFiles` expires lapsed rows before inserting and reconciles conflict-skipped files via a follow-up active lookup, so every requested file maps to the surviving row
- `createMockDb` gains an `onConflictDoNothing` chain mock
- Tests at all three layers: repo unit tests (conflict skip, expiry update), service unit tests (expire-before-insert, surviving-row reconciliation), integration tests against real Postgres (two concurrent requests → exactly one active row + same returned row; duplicate insert skipped; lapsed row flipped to `expired`)
- The #259 defensive guards in `packages/db/src/repositories/files.ts` are untouched, per the issue's out-of-scope note

## Test Plan
- [x] `pnpm check` (lint + build + test) — 10/10
- [x] `pnpm -F web test:integration` — 16/16 against the dev DB (migration applied there); note this tier doesn't run in CI, so the AC3 concurrency test was verified manually
- [x] `pnpm -F db db:drift` + re-run `db:generate` — journal matches, index `.where()` round-trips with no spurious diff