### PR TITLE
ci: run build + e2e coverage gate on PRs, stabilize required-check name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,12 @@ concurrency:
 
 jobs:
     ci:
-        name: Lint, Typecheck, Test
+        # Required status check in branch protection. The name is deliberately
+        # generic and task-independent: this job's step list evolves (lint,
+        # typecheck, build, test, e2e coverage today), and coupling the
+        # required-check name to that list turns every step addition into a
+        # branch-protection migration. Keep this name stable; change steps freely.
+        name: Checks
         runs-on: ubuntu-latest
         env:
             TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -22,8 +27,29 @@ jobs:
             - name: Setup Node and pnpm
               uses: ./.github/actions/setup-node-pnpm
 
+            # trpc-devtools ships built types from dist/ (its package `exports`
+            # resolve to dist/*.d.ts) and web imports it in real source, so
+            # lint/typecheck/build all need its dist on disk first. Only the
+            # `build` task declares `^build`; `typecheck` does not, so it can
+            # race an in-graph build — build it explicitly up front instead.
             - name: Build trpc-devtools
               run: pnpm -F trpc-devtools build
 
-            - name: Lint, Typecheck, Test
-              run: pnpm exec turbo lint typecheck test --continue
+            # Pre-merge gate. Same tasks as `pnpm check` (lint + build + test)
+            # plus typecheck — typecheck uniquely covers the Playwright specs
+            # (`tsc -p e2e`), which `next build` never type-checks. Adding
+            # `build` here is what catches broken config / build regressions
+            # that lint+typecheck alone miss. --continue so one failing task
+            # doesn't hide the others.
+            - name: Lint, typecheck, build, test
+              run: pnpm exec turbo lint typecheck build test --continue
+
+            # Static coverage gate: `playwright test --list` cross-referenced
+            # against e2e/coverage/manifest.ts. No browser, no server, no build
+            # — runs in seconds. Fails a PR that tags a test with a @page/@uc
+            # id missing from the manifest (or leaves a page/use-case
+            # untested). `!cancelled()` so this still reports when the checks
+            # above fail, surfacing both signals on one red PR.
+            - name: E2E coverage gate
+              if: ${{ !cancelled() }}
+              run: pnpm -F web e2e:coverage --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,30 @@ jobs:
             # `build` here is what catches broken config / build regressions
             # that lint+typecheck alone miss. --continue so one failing task
             # doesn't hide the others.
+            #
+            # `next build` collects page data by evaluating route modules, and
+            # some read server env at module scope, so the build needs the full
+            # env schema satisfied — not just NEXT_PUBLIC_*. These are
+            # NON-SECRET placeholders that only have to pass zod validation: the
+            # build constructs DB/AWS/Stripe clients lazily and never connects.
+            # Literals (not `secrets.*`) on purpose — fork PRs run without repo
+            # secrets, so a real dev-env wiring would leave every outside
+            # contributor's build red. Nothing here runs the app; the tiers
+            # that do (smoke e2e) live in post-merge with real dev secrets.
             - name: Lint, typecheck, build, test
+              env:
+                  NEXT_PUBLIC_APP_URL: https://ci.example.com
+                  DATABASE_URL: postgres://user:pass@localhost:5432/ci
+                  AWS_ACCESS_KEY_ID: ci
+                  AWS_SECRET_ACCESS_KEY: ci
+                  AWS_REGION: us-east-1
+                  S3_BUCKET: ci-bucket
+                  SQS_QUEUE_URL: https://sqs.us-east-1.amazonaws.com/000000000000/ci
+                  STRIPE_SECRET_KEY: sk_test_ci
+                  STRIPE_WEBHOOK_SECRET: whsec_ci
+                  RESEND_API_KEY: re_ci
+                  RESEND_FROM_EMAIL: ci@example.com
+                  BETTER_AUTH_SECRET: ci_dummy_secret_least_thirty_two_chars_long_000
               run: pnpm exec turbo lint typecheck build test --continue
 
             # Static coverage gate: `playwright test --list` cross-referenced


### PR DESCRIPTION
No-Issue: ci config

## Why

PR CI ran only `lint + typecheck + test` (no build) and no coverage gate, so a test tagged with a `@page`/`@uc` id that isn't in `apps/web/e2e/coverage/manifest.ts` merged clean. That's how the orphaned `@uc:i18n-locale` tag in #306 slipped through. Smoke e2e still runs only post-merge; this adds the cheap, fast checks that catch this class on PRs.

## What

Fold two things into the existing required CI job (no new job, no duplication):

- **`build`** added to the turbo run — catches broken `next.config` / build regressions that lint+typecheck alone miss.
- **`pnpm -F web e2e:coverage --check`** — static `playwright test --list` cross-referenced against the manifest. ~1.5s, no browser, no server, no secrets. Fails a PR that tags an unknown `@page`/`@uc` id or leaves a page/use-case untested.
- **`typecheck` kept** — it uniquely covers the Playwright specs (`tsc -p e2e`), which `next build` never type-checks. Dropping it (e.g. collapsing to `pnpm check`) would silently lose e2e-spec typechecking.

## Required-check rename

Job renamed `Lint, Typecheck, Test` → **`Checks`**, and branch protection updated to require `Checks`. The name is now decoupled from the step list, so future step additions don't require a branch-protection migration. Branch protection was updated **before** this lands, so this PR itself reports `Checks` and can merge; other open PRs (e.g. #306) will report `Checks` once rebased onto this.