### PR TITLE
docs: replace boilerplate web app README with workspace overview (#114)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,36 +1,74 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Nexus Web App
 
-## Getting Started
+The Next.js application behind [Nexus](../../README.md) — archival file storage on AWS S3 Glacier. This workspace holds the entire user-facing product: the App Router UI, the tRPC API, the S3/Glacier storage layer, and the Stripe billing integration.
 
-First, run the development server:
+For monorepo setup, prerequisites, and environment variables, see the [root README](../../README.md). Detailed architecture docs live in [`docs/`](../../docs/index.md).
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+## Routes
+
+Production pages:
+
+| Route                                     | What it is                                                      |
+| ----------------------------------------- | --------------------------------------------------------------- |
+| `/`                                       | Landing page                                                    |
+| `/sign-in`, `/sign-up`, `/invite/[token]` | Auth (BetterAuth) and invite redemption                         |
+| `/dashboard`                              | Storage overview: usage, file-type breakdown, active retrievals |
+| `/dashboard/files`                        | File browser grouped by upload batch, with restore + download   |
+| `/dashboard/upload`                       | Presigned single/multipart uploads straight to S3               |
+| `/dashboard/settings`                     | Account, subscription, and billing management                   |
+| `/dashboard/admin/*`                      | Admin tooling: jobs, invites, dev-tools                         |
+
+Dev-only tooling (APIs behind these are gated to `NODE_ENV=development`):
+
+| Route           | What it is                                                                     |
+| --------------- | ------------------------------------------------------------------------------ |
+| `/design`       | Component showcase for the UI kit (Tailwind + shadcn/ui)                       |
+| `/dev/studio`   | tRPC devtools panel ([`packages/trpc-devtools`](../../packages/trpc-devtools)) |
+| `/dev/coverage` | Live E2E coverage dashboard                                                    |
+| `/dev/report`   | E2E coverage report viewer                                                     |
+
+## Directory structure
+
+```
+apps/web/
+├── app/          # App Router routes, layouts, API routes (tRPC handler, webhooks)
+├── server/       # tRPC routers + services (restore state machine, billing, jobs)
+├── lib/          # Client/server utilities: storage (S3/Glacier), auth, stripe, env, trpc
+├── components/   # React components (shadcn/ui primitives under components/ui/)
+├── e2e/          # Playwright suites (smoke/flows/admin/validate/repro) + fixtures
+├── scripts/      # Workspace scripts (e2e coverage gate, ops checks, backfills)
+└── types/        # Shared TypeScript types
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The database schema and migrations are not here — they live in [`packages/db`](../../packages/db) (`@nexus/db`), which this app consumes for queries, repositories, and typed test seeding.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Stack
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Next.js 16 (App Router, React 19) · tRPC v11 for the API · Drizzle ORM against Postgres via `@nexus/db` · BetterAuth for sessions · AWS S3 for storage (every file goes to Glacier) with SNS webhooks driving restore status · Stripe for subscriptions.
 
-## Learn More
+## Development workflow
 
-To learn more about Next.js, take a look at the following resources:
+From the repo root (see the root README for first-time setup):
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+pnpm dev                       # start the app on http://localhost:3000
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+After changing the database schema (in `packages/db`):
 
-## Deploy on Vercel
+```bash
+pnpm -F db db:generate         # generate a migration
+pnpm -F db db:migrate          # apply it
+pnpm -F db db:studio           # inspect data in Drizzle Studio
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Testing this workspace:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+pnpm -F web test               # unit + integration (Vitest)
+pnpm -F web test:e2e:smoke     # fastest E2E tier — run after any UI change
+pnpm -F web test:e2e           # full Playwright suite
+pnpm -F web e2e:coverage --check  # coverage gate — run after adding a page or test
+```
+
+E2E tests run against a production build on an ephemeral port, so they coexist with `pnpm dev`. Tier selection and test-data conventions: [`docs/guides/e2e-testing-guidelines.md`](../../docs/guides/e2e-testing-guidelines.md).


### PR DESCRIPTION
Closes #114

Replaces the default `create-next-app` README at `apps/web/README.md` with a project-specific workspace overview:

- What the app is, with links to the root README (setup/env) and `docs/` (architecture)
- Production routes and dev-only tooling routes (`/design`, `/dev/studio`, `/dev/coverage`, `/dev/report`)
- App-specific directory structure (`app/`, `server/`, `lib/`, `components/`, `e2e/`, `scripts/`, `types/`)
- High-level stack (Next.js 16, tRPC v11, Drizzle via `@nexus/db`, BetterAuth, S3/Glacier, Stripe)
- Local dev workflow commands (db migration flow, test tiers, coverage gate)

Note: the issue listed `/dev/preview` as a dev route; it no longer exists, so the README documents the actual current dev routes instead.

74 lines, within the ~50–100 target. Docs-only change; `pnpm check` green.