### PR TITLE
feat: trpc-devtools theme toggle, cURL/JSON export, command palette (epic #91)

### DIFF
--- a/packages/trpc-devtools/.claude/skills/verify/SKILL.md
+++ b/packages/trpc-devtools/.claude/skills/verify/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: verify
+description: Build, run, and drive trpc-devtools in the Nexus app to verify UI changes at runtime
+---
+
+# Verifying trpc-devtools changes
+
+The web app consumes this package's **built dist**, not `src/`. Source edits
+are invisible to the running app until you rebuild — this is the #1 gotcha
+(a stale dist silently verifies old code):
+
+```bash
+pnpm -F trpc-devtools build     # after every src change you want to observe
+```
+
+Launch (from repo root; use the worktree's $PORT, not :3000):
+
+```bash
+env PORT=$PORT pnpm dev         # background; restart after rebuilding dist
+```
+
+Surfaces to drive:
+
+- Embedded component: `http://localhost:$PORT/dev/studio` (SSR — hydration
+  mismatches only reproduce here, not on the standalone route)
+- Standalone route: `http://localhost:$PORT/api/trpc-devtools` (client-only
+  bundle inlined by the route handler; FOUC script, html theme class)
+
+Drive with a Playwright script placed in `apps/web/` and run from there
+(`import { chromium } from '@playwright/test'`, `main().catch(...)`). Useful
+context options: `colorScheme: 'dark'`, `permissions: ['clipboard-read',
+'clipboard-write']` for copy buttons, `context.addCookies` for cookie
+export. `debug.random` is a public procedure (no auth) that always succeeds
+— good for exercising execute/response flows.
+
+Gotchas:
+
+- Watch `console`/`pageerror` events — React hydration warnings on
+  `/dev/studio` are real findings and don't fail the smoke suite when they
+  depend on state (e.g. only appear once request history exists).
+- UI assertions right after a state change race framer-motion exit
+  animations (~150-200ms); use `waitFor({ state: 'hidden' })`, not
+  `isVisible()`.
+- Delete scratch scripts before committing.

--- a/packages/trpc-devtools/src/components/devtools/command-palette.tsx
+++ b/packages/trpc-devtools/src/components/devtools/command-palette.tsx
@@ -3,12 +3,12 @@
 import * as React from 'react';
 import type { LucideIcon } from 'lucide-react';
 import { Search } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { Dialog } from '@/components/ui/dialog';
 import { Kbd } from '@/components/ui/kbd';
 import { fuzzyFilter, type FuzzyMatch } from '@/lib/fuzzy';
 import { cn } from '@/lib/utils';
 import type { ProcedureSchema } from '@/server/types';
+import { ProcedureTypeBadge } from './procedure-type-badge';
 
 export interface PaletteAction {
     id: string;
@@ -155,7 +155,7 @@ export function CommandPalette({
                     {item.kind === 'action' ? (
                         <>
                             <item.action.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                            <span className="flex-1 truncate">
+                            <span className="min-w-0 flex-1 truncate">
                                 <HighlightedText
                                     text={item.action.label}
                                     indices={item.match.indices}
@@ -167,13 +167,11 @@ export function CommandPalette({
                         </>
                     ) : (
                         <>
-                            <Badge
-                                variant={item.procedure.type}
-                                className="px-1.5 py-0 text-[10px]"
-                            >
-                                {item.procedure.type.slice(0, 1).toUpperCase()}
-                            </Badge>
-                            <span className="flex-1 truncate font-mono text-xs">
+                            <ProcedureTypeBadge
+                                type={item.procedure.type}
+                                className="shrink-0"
+                            />
+                            <span className="min-w-0 flex-1 truncate font-mono text-xs">
                                 <HighlightedText
                                     text={item.procedure.path}
                                     indices={item.match.indices}

--- a/packages/trpc-devtools/src/components/devtools/command-palette.tsx
+++ b/packages/trpc-devtools/src/components/devtools/command-palette.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import * as React from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { Search } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Dialog } from '@/components/ui/dialog';
+import { Kbd } from '@/components/ui/kbd';
+import { fuzzyFilter, type FuzzyMatch } from '@/lib/fuzzy';
+import { cn } from '@/lib/utils';
+import type { ProcedureSchema } from '@/server/types';
+
+export interface PaletteAction {
+    id: string;
+    label: string;
+    icon: LucideIcon;
+    /** Preformatted shortcut hint, e.g. "⌘⇧L" */
+    shortcut?: string;
+    run: () => void;
+}
+
+type PaletteItem =
+    | { kind: 'action'; action: PaletteAction; match: FuzzyMatch }
+    | { kind: 'procedure'; procedure: ProcedureSchema; match: FuzzyMatch };
+
+interface CommandPaletteProps {
+    isOpen: boolean;
+    onClose: () => void;
+    procedures: ProcedureSchema[];
+    actions: PaletteAction[];
+    onSelectProcedure: (path: string) => void;
+}
+
+/**
+ * Cmd+K command palette: fuzzy-searches procedures and actions, arrow keys
+ * navigate, Enter selects, Escape closes (via the Dialog focus trap).
+ */
+export function CommandPalette({
+    isOpen,
+    onClose,
+    procedures,
+    actions,
+    onSelectProcedure,
+}: CommandPaletteProps) {
+    const [query, setQuery] = React.useState('');
+    const [activeIndex, setActiveIndex] = React.useState(0);
+    const inputRef = React.useRef<HTMLInputElement>(null);
+
+    // Reset on close (not on open): while closed the input is unmounted, so
+    // this can never race the user's first keystrokes after reopening
+    React.useEffect(() => {
+        if (!isOpen) {
+            setQuery('');
+            setActiveIndex(0);
+        }
+    }, [isOpen]);
+
+    const { actionItems, procedureItems } = React.useMemo(() => {
+        return {
+            actionItems: fuzzyFilter(actions, query, (a) => a.label).map(
+                ({ item, match }): PaletteItem => ({
+                    kind: 'action',
+                    action: item,
+                    match,
+                })
+            ),
+            procedureItems: fuzzyFilter(procedures, query, (p) => p.path).map(
+                ({ item, match }): PaletteItem => ({
+                    kind: 'procedure',
+                    procedure: item,
+                    match,
+                })
+            ),
+        };
+    }, [actions, procedures, query]);
+
+    const items = React.useMemo(
+        () => [...actionItems, ...procedureItems],
+        [actionItems, procedureItems]
+    );
+
+    const selectItem = React.useCallback(
+        (item: PaletteItem) => {
+            onClose();
+            if (item.kind === 'action') {
+                item.action.run();
+            } else {
+                onSelectProcedure(item.procedure.path);
+            }
+        },
+        [onClose, onSelectProcedure]
+    );
+
+    const handleInputKeyDown = (e: React.KeyboardEvent) => {
+        switch (e.key) {
+            case 'ArrowDown': {
+                e.preventDefault();
+                setActiveIndex((prev) =>
+                    items.length === 0 ? 0 : (prev + 1) % items.length
+                );
+                break;
+            }
+            case 'ArrowUp': {
+                e.preventDefault();
+                setActiveIndex((prev) =>
+                    items.length === 0
+                        ? 0
+                        : (prev - 1 + items.length) % items.length
+                );
+                break;
+            }
+            case 'Enter': {
+                e.preventDefault();
+                const item = items[activeIndex];
+                if (item) selectItem(item);
+                break;
+            }
+        }
+    };
+
+    // Keep the active option visible while arrowing through the list
+    React.useEffect(() => {
+        if (!isOpen) return;
+        document
+            .getElementById(`palette-option-${activeIndex}`)
+            ?.scrollIntoView({ block: 'nearest' });
+    }, [activeIndex, isOpen]);
+
+    const renderItem = (item: PaletteItem, index: number) => {
+        const isActive = index === activeIndex;
+
+        return (
+            <li
+                key={
+                    item.kind === 'action'
+                        ? `action-${item.action.id}`
+                        : `proc-${item.procedure.path}`
+                }
+                id={`palette-option-${index}`}
+                role="option"
+                aria-selected={isActive}
+            >
+                <button
+                    type="button"
+                    tabIndex={-1}
+                    onClick={() => selectItem(item)}
+                    onMouseMove={() => setActiveIndex(index)}
+                    className={cn(
+                        'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm transition-colors',
+                        isActive
+                            ? 'bg-accent text-accent-foreground'
+                            : 'text-foreground'
+                    )}
+                >
+                    {item.kind === 'action' ? (
+                        <>
+                            <item.action.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            <span className="flex-1 truncate">
+                                <HighlightedText
+                                    text={item.action.label}
+                                    indices={item.match.indices}
+                                />
+                            </span>
+                            {item.action.shortcut && (
+                                <Kbd>{item.action.shortcut}</Kbd>
+                            )}
+                        </>
+                    ) : (
+                        <>
+                            <Badge
+                                variant={item.procedure.type}
+                                className="px-1.5 py-0 text-[10px]"
+                            >
+                                {item.procedure.type.slice(0, 1).toUpperCase()}
+                            </Badge>
+                            <span className="flex-1 truncate font-mono text-xs">
+                                <HighlightedText
+                                    text={item.procedure.path}
+                                    indices={item.match.indices}
+                                />
+                            </span>
+                        </>
+                    )}
+                </button>
+            </li>
+        );
+    };
+
+    return (
+        <Dialog
+            isOpen={isOpen}
+            onClose={onClose}
+            label="Command palette"
+            initialFocusRef={inputRef}
+        >
+            <div className="flex items-center gap-2 border-b border-border px-3">
+                <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <input
+                    ref={inputRef}
+                    role="combobox"
+                    aria-expanded="true"
+                    aria-controls="palette-listbox"
+                    aria-activedescendant={
+                        items.length > 0
+                            ? `palette-option-${activeIndex}`
+                            : undefined
+                    }
+                    aria-label="Search procedures and actions"
+                    placeholder="Search procedures and actions..."
+                    value={query}
+                    onChange={(e) => {
+                        setQuery(e.target.value);
+                        setActiveIndex(0);
+                    }}
+                    onKeyDown={handleInputKeyDown}
+                    className="h-12 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+                />
+            </div>
+
+            <ul
+                id="palette-listbox"
+                role="listbox"
+                aria-label="Results"
+                className="max-h-80 overflow-y-auto p-1.5"
+            >
+                {items.length === 0 && (
+                    <li className="px-2.5 py-8 text-center text-sm text-muted-foreground">
+                        No results for &ldquo;{query}&rdquo;
+                    </li>
+                )}
+                {actionItems.length > 0 && (
+                    <li
+                        aria-hidden="true"
+                        className="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+                    >
+                        Actions
+                    </li>
+                )}
+                {actionItems.map((item, i) => renderItem(item, i))}
+                {procedureItems.length > 0 && (
+                    <li
+                        aria-hidden="true"
+                        className="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground"
+                    >
+                        Procedures
+                    </li>
+                )}
+                {procedureItems.map((item, i) =>
+                    renderItem(item, actionItems.length + i)
+                )}
+            </ul>
+
+            <div className="flex items-center gap-3 border-t border-border px-3 py-2 text-[10px] text-muted-foreground">
+                <span className="flex items-center gap-1">
+                    <Kbd>↑↓</Kbd> navigate
+                </span>
+                <span className="flex items-center gap-1">
+                    <Kbd>↵</Kbd> select
+                </span>
+                <span className="flex items-center gap-1">
+                    <Kbd>esc</Kbd> close
+                </span>
+            </div>
+        </Dialog>
+    );
+}
+
+function HighlightedText({
+    text,
+    indices,
+}: {
+    text: string;
+    indices: number[];
+}) {
+    if (indices.length === 0) return <>{text}</>;
+
+    const matched = new Set(indices);
+    return (
+        <>
+            {Array.from(text, (char, i) =>
+                matched.has(i) ? (
+                    <span key={i} className="font-semibold text-primary">
+                        {char}
+                    </span>
+                ) : (
+                    char
+                )
+            )}
+        </>
+    );
+}

--- a/packages/trpc-devtools/src/components/devtools/devtools.tsx
+++ b/packages/trpc-devtools/src/components/devtools/devtools.tsx
@@ -199,7 +199,7 @@ export function TRPCDevtools({
                 id: 'clear-response',
                 label: 'Clear response',
                 icon: Eraser,
-                shortcut: formatShortcut('L', { isApple, shift: true }),
+                shortcut: formatShortcut('L', { isApple, isShift: true }),
                 run: () => procedureViewRef.current?.clearResponse(),
             },
             {

--- a/packages/trpc-devtools/src/components/devtools/devtools.tsx
+++ b/packages/trpc-devtools/src/components/devtools/devtools.tsx
@@ -1,17 +1,34 @@
 'use client';
 
 import * as React from 'react';
-import { Menu } from 'lucide-react';
+import {
+    Eraser,
+    FileJson,
+    Keyboard,
+    Menu,
+    SunMoon,
+    Terminal,
+} from 'lucide-react';
 import { Drawer } from '@/components/ui/drawer';
+import { Kbd } from '@/components/ui/kbd';
 import { Skeleton } from '@/components/ui/skeleton';
+import { formatShortcut, useIsApplePlatform } from '@/lib/platform';
 import { useIsMobile } from '@/lib/use-is-mobile';
+import { useTheme, type ThemeMode } from '@/lib/use-theme';
 import { cn } from '@/lib/utils';
 import type { HistoryItem } from '@/lib/storage';
 import type { TRPCResponse } from '@/lib/request';
 import type { ProcedureSchema, RouterSchema } from '@/server/types';
+import { CommandPalette, type PaletteAction } from './command-palette';
 import { ProcedureList, ProcedureListSkeleton } from './procedure-list';
-import { ProcedureView, ProcedureViewSkeleton } from './procedure-view';
+import {
+    ProcedureView,
+    ProcedureViewSkeleton,
+    type ProcedureViewHandle,
+} from './procedure-view';
 import { RequestHistoryPanel } from './request-history';
+import { ShortcutsHelp } from './shortcuts-help';
+import { ThemeToggle } from './theme-toggle';
 
 export interface TRPCDevtoolsProps {
     /** URL to fetch the schema from */
@@ -41,7 +58,22 @@ export function TRPCDevtools({
     const isMobile = useIsMobile();
     const [isDrawerOpen, setIsDrawerOpen] = React.useState(false);
 
+    const { mode, resolvedTheme, cycleMode, isTransitioning } = useTheme();
+    const isApple = useIsApplePlatform();
+
+    const [isPaletteOpen, setIsPaletteOpen] = React.useState(false);
+    const [isHelpOpen, setIsHelpOpen] = React.useState(false);
+    const procedureViewRef = React.useRef<ProcedureViewHandle>(null);
+
     const closeDrawer = React.useCallback(() => setIsDrawerOpen(false), []);
+    const closePalette = React.useCallback(() => setIsPaletteOpen(false), []);
+    const closeHelp = React.useCallback(() => setIsHelpOpen(false), []);
+
+    const openPalette = React.useCallback(() => {
+        setIsHelpOpen(false);
+        setIsDrawerOpen(false);
+        setIsPaletteOpen(true);
+    }, []);
 
     // Reset drawer state when the viewport expands past the mobile breakpoint
     React.useEffect(() => {
@@ -92,17 +124,131 @@ export function TRPCDevtools({
         // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run on mount, not when selectedPath changes
     }, [schemaUrl]);
 
+    // Cycle to the previous/next procedure in schema order (wraps around)
+    const selectByOffset = React.useCallback(
+        (offset: number) => {
+            if (!schema || schema.procedures.length === 0) return;
+
+            const procedures = schema.procedures;
+            const currentIndex = procedures.findIndex(
+                (p) => p.path === selectedPath
+            );
+            const nextIndex =
+                currentIndex === -1
+                    ? 0
+                    : (currentIndex + offset + procedures.length) %
+                      procedures.length;
+            setSelectedPath(procedures[nextIndex].path);
+        },
+        [schema, selectedPath]
+    );
+
+    // Global keyboard shortcuts. Skips events a more specific handler
+    // already claimed (e.defaultPrevented), e.g. Cmd+Enter inside the JSON
+    // editor, so nothing fires twice.
+    React.useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.defaultPrevented) return;
+            if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
+
+            const key = e.key.toLowerCase();
+            const isModalOpen = isPaletteOpen || isHelpOpen;
+
+            if (key === 'k' && !e.shiftKey) {
+                e.preventDefault();
+                if (isPaletteOpen) {
+                    setIsPaletteOpen(false);
+                } else {
+                    openPalette();
+                }
+                return;
+            }
+
+            if (e.key === '?' || (e.shiftKey && e.key === '/')) {
+                e.preventDefault();
+                setIsPaletteOpen(false);
+                setIsHelpOpen((prev) => !prev);
+                return;
+            }
+
+            // The rest act on the studio behind a modal — ignore while one is open
+            if (isModalOpen) return;
+
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                procedureViewRef.current?.execute();
+            } else if (key === 'l' && e.shiftKey) {
+                e.preventDefault();
+                procedureViewRef.current?.clearResponse();
+            } else if (e.key === '[') {
+                e.preventDefault();
+                selectByOffset(-1);
+            } else if (e.key === ']') {
+                e.preventDefault();
+                selectByOffset(1);
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [isPaletteOpen, isHelpOpen, openPalette, selectByOffset]);
+
+    const paletteActions = React.useMemo<PaletteAction[]>(
+        () => [
+            {
+                id: 'clear-response',
+                label: 'Clear response',
+                icon: Eraser,
+                shortcut: formatShortcut('L', { isApple, shift: true }),
+                run: () => procedureViewRef.current?.clearResponse(),
+            },
+            {
+                id: 'toggle-theme',
+                label: 'Toggle theme',
+                icon: SunMoon,
+                run: cycleMode,
+            },
+            {
+                id: 'copy-curl',
+                label: 'Copy as cURL',
+                icon: Terminal,
+                run: () => procedureViewRef.current?.copyCurl(),
+            },
+            {
+                id: 'toggle-raw',
+                label: 'Toggle raw/parsed response',
+                icon: FileJson,
+                run: () => procedureViewRef.current?.toggleRaw(),
+            },
+            {
+                id: 'keyboard-shortcuts',
+                label: 'Keyboard shortcuts',
+                icon: Keyboard,
+                shortcut: formatShortcut('?', { isApple }),
+                run: () => setIsHelpOpen(true),
+            },
+        ],
+        [isApple, cycleMode]
+    );
+
     const selectedProcedure = React.useMemo<ProcedureSchema | null>(() => {
         if (!schema || !selectedPath) return null;
         return schema.procedures.find((p) => p.path === selectedPath) ?? null;
     }, [schema, selectedPath]);
 
+    const rootClassName = cn(
+        'trpc-devtools',
+        resolvedTheme,
+        isTransitioning && 'theme-transition',
+        className
+    );
+
     if (error) {
         return (
             <div
                 className={cn(
-                    'trpc-devtools flex items-center justify-center h-dvh bg-background',
-                    className
+                    rootClassName,
+                    'flex items-center justify-center h-dvh bg-background'
                 )}
             >
                 <div className="text-center space-y-2">
@@ -119,8 +265,8 @@ export function TRPCDevtools({
         return (
             <div
                 className={cn(
-                    'trpc-devtools flex flex-col md:flex-row h-dvh bg-background text-foreground',
-                    className
+                    rootClassName,
+                    'flex flex-col md:flex-row h-dvh bg-background text-foreground'
                 )}
             >
                 {isMobile ? (
@@ -153,14 +299,18 @@ export function TRPCDevtools({
             selectedPath={selectedPath}
             onSelect={handleSelect}
             onReplay={handleHistoryReplay}
+            onOpenPalette={openPalette}
+            paletteShortcut={formatShortcut('K', { isApple })}
+            themeMode={mode}
+            onCycleTheme={cycleMode}
         />
     );
 
     return (
         <div
             className={cn(
-                'trpc-devtools flex flex-col md:flex-row h-dvh bg-background text-foreground',
-                className
+                rootClassName,
+                'flex flex-col md:flex-row h-dvh bg-background text-foreground'
             )}
         >
             {isMobile ? (
@@ -184,6 +334,7 @@ export function TRPCDevtools({
             <div className="flex-1 overflow-hidden">
                 {selectedProcedure ? (
                     <ProcedureView
+                        ref={procedureViewRef}
                         procedure={selectedProcedure}
                         trpcUrl={trpcUrl}
                         headers={headers}
@@ -196,6 +347,15 @@ export function TRPCDevtools({
                     </div>
                 )}
             </div>
+
+            <CommandPalette
+                isOpen={isPaletteOpen}
+                onClose={closePalette}
+                procedures={schema.procedures}
+                actions={paletteActions}
+                onSelectProcedure={handleSelect}
+            />
+            <ShortcutsHelp isOpen={isHelpOpen} onClose={closeHelp} />
         </div>
     );
 }
@@ -230,6 +390,11 @@ interface SidebarContentProps {
     selectedPath: string | null;
     onSelect: (path: string) => void;
     onReplay: (item: HistoryItem) => void;
+    onOpenPalette: () => void;
+    /** Preformatted palette shortcut hint, e.g. "⌘K" */
+    paletteShortcut: string;
+    themeMode: ThemeMode;
+    onCycleTheme: () => void;
 }
 
 function SidebarContent({
@@ -237,14 +402,36 @@ function SidebarContent({
     selectedPath,
     onSelect,
     onReplay,
+    onOpenPalette,
+    paletteShortcut,
+    themeMode,
+    onCycleTheme,
 }: SidebarContentProps) {
     return (
         <>
-            <div className="p-4 border-b border-border">
-                <h1 className="text-lg font-semibold">tRPC Devtools</h1>
-                <p className="text-xs text-muted-foreground">
-                    {schema.procedures.length} procedures
-                </p>
+            <div className="p-4 border-b border-border flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                    <h1 className="text-lg font-semibold">tRPC Devtools</h1>
+                    <p className="text-xs text-muted-foreground">
+                        {schema.procedures.length} procedures
+                    </p>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                    <button
+                        type="button"
+                        onClick={onOpenPalette}
+                        title={`Command palette (${paletteShortcut})`}
+                        aria-label={`Open command palette (${paletteShortcut})`}
+                        className={cn(
+                            'flex h-9 items-center rounded-md px-1.5 transition-colors',
+                            'hover:bg-accent/50',
+                            'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+                        )}
+                    >
+                        <Kbd>{paletteShortcut}</Kbd>
+                    </button>
+                    <ThemeToggle mode={themeMode} onCycle={onCycleTheme} />
+                </div>
             </div>
             <div className="flex-1 overflow-hidden">
                 <ProcedureList

--- a/packages/trpc-devtools/src/components/devtools/index.ts
+++ b/packages/trpc-devtools/src/components/devtools/index.ts
@@ -1,6 +1,9 @@
 export { TRPCDevtools, type TRPCDevtoolsProps } from './devtools';
 export { ProcedureList } from './procedure-list';
-export { ProcedureView } from './procedure-view';
+export { ProcedureView, type ProcedureViewHandle } from './procedure-view';
 export { RequestHistoryPanel } from './request-history';
 export { SchemaForm } from './schema-form';
 export { ResponseViewer } from './response-viewer';
+export { CommandPalette, type PaletteAction } from './command-palette';
+export { ShortcutsHelp } from './shortcuts-help';
+export { ThemeToggle } from './theme-toggle';

--- a/packages/trpc-devtools/src/components/devtools/procedure-list.tsx
+++ b/packages/trpc-devtools/src/components/devtools/procedure-list.tsx
@@ -3,13 +3,13 @@
 import * as React from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ChevronRight } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
 import { loadCollapsedGroups, saveCollapsedGroups } from '@/lib/storage';
 import { cn } from '@/lib/utils';
 import type { ProcedureSchema } from '@/server/types';
+import { ProcedureTypeBadge } from './procedure-type-badge';
 
 interface ProcedureListProps {
     procedures: ProcedureSchema[];
@@ -326,16 +326,9 @@ export function ProcedureList({
                                                                     : 'text-foreground hover:bg-accent/50'
                                                             )}
                                                         >
-                                                            <Badge
-                                                                variant={
-                                                                    proc.type
-                                                                }
-                                                                className="text-[10px] px-1.5 py-0"
-                                                            >
-                                                                {proc.type
-                                                                    .slice(0, 1)
-                                                                    .toUpperCase()}
-                                                            </Badge>
+                                                            <ProcedureTypeBadge
+                                                                type={proc.type}
+                                                            />
                                                             <span className="font-mono text-xs truncate">
                                                                 {displayPath}
                                                             </span>

--- a/packages/trpc-devtools/src/components/devtools/procedure-list.tsx
+++ b/packages/trpc-devtools/src/components/devtools/procedure-list.tsx
@@ -182,9 +182,14 @@ export function ProcedureList({
     // Global "/" shortcut to focus search
     React.useEffect(() => {
         const handleGlobalKeyDown = (e: KeyboardEvent) => {
-            // "/" focuses search (ignore if in text input)
+            // "/" focuses search (ignore if in text input or when held with
+            // modifiers — Cmd+Shift+/ is the shortcuts-help toggle)
             if (
                 e.key === '/' &&
+                !e.metaKey &&
+                !e.ctrlKey &&
+                !e.altKey &&
+                !e.shiftKey &&
                 document.activeElement?.tagName !== 'INPUT' &&
                 document.activeElement?.tagName !== 'TEXTAREA'
             ) {

--- a/packages/trpc-devtools/src/components/devtools/procedure-type-badge.tsx
+++ b/packages/trpc-devtools/src/components/devtools/procedure-type-badge.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { ProcedureSchema } from '@/server/types';
+
+/**
+ * Compact single-letter procedure type indicator (Q/M/S), used wherever
+ * procedures are listed (sidebar, history, command palette).
+ */
+export function ProcedureTypeBadge({
+    type,
+    className,
+}: {
+    type: ProcedureSchema['type'];
+    className?: string;
+}) {
+    return (
+        <Badge
+            variant={type}
+            className={cn('px-1.5 py-0 text-[10px]', className)}
+        >
+            {type.slice(0, 1).toUpperCase()}
+        </Badge>
+    );
+}

--- a/packages/trpc-devtools/src/components/devtools/procedure-view.tsx
+++ b/packages/trpc-devtools/src/components/devtools/procedure-view.tsx
@@ -2,13 +2,17 @@
 
 import * as React from 'react';
 import { motion } from 'framer-motion';
+import { Check, Download, Terminal } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ResizablePanels } from '@/components/ui/resizable-panels';
 import { Skeleton } from '@/components/ui/skeleton';
 import { SchemaForm } from './schema-form';
 import { ResponseViewer } from './response-viewer';
+import { buildCurlCommand } from '@/lib/curl';
 import { executeRequest, type TRPCResponse } from '@/lib/request';
+import { useCopyToClipboard } from '@/lib/use-copy-to-clipboard';
 import { parseZodError } from '@/lib/zod-error';
 import {
     saveToHistory,
@@ -25,17 +29,29 @@ interface ProcedureViewProps {
     onHistoryConsumed?: () => void;
 }
 
-export function ProcedureView({
-    procedure,
-    trpcUrl,
-    headers,
-    historyReplay,
-    onHistoryConsumed,
-}: ProcedureViewProps) {
+/** Imperative surface for global shortcuts and command palette actions */
+export interface ProcedureViewHandle {
+    execute: () => void;
+    clearResponse: () => void;
+    toggleRaw: () => void;
+    copyCurl: () => void;
+}
+
+export const ProcedureView = React.forwardRef<
+    ProcedureViewHandle,
+    ProcedureViewProps
+>(function ProcedureView(
+    { procedure, trpcUrl, headers, historyReplay, onHistoryConsumed },
+    ref
+) {
     const [input, setInput] = React.useState('');
     const [isLoading, setIsLoading] = React.useState(false);
     const [response, setResponse] = React.useState<TRPCResponse | null>(null);
     const [isFromHistory, setIsFromHistory] = React.useState(false);
+    const [showRaw, setShowRaw] = React.useState(false);
+    const [includeCookies, setIncludeCookies] = React.useState(false);
+    const { isCopied: isCurlCopied, copy: copyToClipboard } =
+        useCopyToClipboard();
 
     // Track whether we just consumed a history replay (to skip the reset
     // triggered by onHistoryConsumed setting historyReplay back to null)
@@ -166,6 +182,70 @@ export function ProcedureView({
         }
     };
 
+    // Input parsed for cURL export; ok=false means unparsable (button disabled)
+    const curlInput = React.useMemo(() => {
+        if (!input.trim()) return { ok: true as const, value: undefined };
+        try {
+            return { ok: true as const, value: JSON.parse(input) as unknown };
+        } catch {
+            return { ok: false as const, value: undefined };
+        }
+    }, [input]);
+
+    const canCopyCurl = procedure.type !== 'subscription' && curlInput.ok;
+
+    const handleCopyCurl = () => {
+        if (procedure.type === 'subscription' || !curlInput.ok) return;
+
+        const command = buildCurlCommand(
+            {
+                path: procedure.path,
+                type: procedure.type,
+                input: curlInput.value,
+            },
+            {
+                trpcUrl,
+                origin: window.location.origin,
+                headers,
+                useSuperJSON,
+                cookieHeader: includeCookies ? document.cookie : undefined,
+            }
+        );
+        copyToClipboard(command);
+    };
+
+    const handleDownload = () => {
+        if (!response) return;
+
+        // Mirror what the viewer currently shows: raw wire response, or the
+        // parsed data / error
+        const data = showRaw
+            ? response.rawResponse
+            : response.ok
+              ? response.data
+              : response.error;
+
+        const blob = new Blob([`${JSON.stringify(data, null, 2)}\n`], {
+            type: 'application/json',
+        });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = `${procedure.path}-response.json`;
+        anchor.click();
+        URL.revokeObjectURL(url);
+    };
+
+    React.useImperativeHandle(ref, () => ({
+        execute: () => void handleSubmit(),
+        clearResponse: () => {
+            setResponse(null);
+            setIsFromHistory(false);
+        },
+        toggleRaw: () => setShowRaw((prev) => !prev),
+        copyCurl: handleCopyCurl,
+    }));
+
     return (
         <motion.div
             key={procedure.path}
@@ -219,10 +299,45 @@ export function ProcedureView({
                 className="flex-1"
                 first={
                     <Card className="flex flex-col overflow-hidden h-full">
-                        <CardHeader className="py-3 px-4 border-b border-border">
-                            <CardTitle className="text-sm font-medium">
-                                Request
-                            </CardTitle>
+                        <CardHeader className="py-2 px-4 border-b border-border">
+                            <div className="flex items-center justify-between gap-2 min-h-7">
+                                <CardTitle className="text-sm font-medium">
+                                    Request
+                                </CardTitle>
+                                <div className="flex items-center gap-2">
+                                    <label
+                                        className="flex cursor-pointer select-none items-center gap-1.5 text-xs text-muted-foreground"
+                                        title="Include browser cookies in the cURL command (only cookies readable by JavaScript)"
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            checked={includeCookies}
+                                            onChange={(e) =>
+                                                setIncludeCookies(
+                                                    e.target.checked
+                                                )
+                                            }
+                                            className="h-3.5 w-3.5 accent-primary"
+                                        />
+                                        Cookies
+                                    </label>
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={handleCopyCurl}
+                                        disabled={!canCopyCurl}
+                                        title="Copy request as cURL command"
+                                        className="h-7 gap-1.5 px-2 text-xs"
+                                    >
+                                        {isCurlCopied ? (
+                                            <Check className="h-3.5 w-3.5" />
+                                        ) : (
+                                            <Terminal className="h-3.5 w-3.5" />
+                                        )}
+                                        {isCurlCopied ? 'Copied!' : 'cURL'}
+                                    </Button>
+                                </div>
+                            </div>
                         </CardHeader>
                         <CardContent className="flex-1 p-4 overflow-auto">
                             <SchemaForm
@@ -239,16 +354,31 @@ export function ProcedureView({
                 }
                 second={
                     <Card className="flex flex-col overflow-hidden h-full">
-                        <CardHeader className="py-3 px-4 border-b border-border">
-                            <CardTitle className="text-sm font-medium">
-                                Response
-                            </CardTitle>
+                        <CardHeader className="py-2 px-4 border-b border-border">
+                            <div className="flex items-center justify-between gap-2 min-h-7">
+                                <CardTitle className="text-sm font-medium">
+                                    Response
+                                </CardTitle>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={handleDownload}
+                                    disabled={!response}
+                                    title={`Download response as ${procedure.path}-response.json`}
+                                    className="h-7 gap-1.5 px-2 text-xs"
+                                >
+                                    <Download className="h-3.5 w-3.5" />
+                                    Download
+                                </Button>
+                            </div>
                         </CardHeader>
                         <CardContent className="flex-1 p-0 overflow-hidden">
                             <ResponseViewer
                                 response={response}
                                 zodIssues={validationErrors}
                                 fromHistory={isFromHistory}
+                                showRaw={showRaw}
+                                onToggleRaw={() => setShowRaw((prev) => !prev)}
                             />
                         </CardContent>
                     </Card>
@@ -256,7 +386,7 @@ export function ProcedureView({
             />
         </motion.div>
     );
-}
+});
 
 export function ProcedureViewSkeleton() {
     return (

--- a/packages/trpc-devtools/src/components/devtools/procedure-view.tsx
+++ b/packages/trpc-devtools/src/components/devtools/procedure-view.tsx
@@ -49,7 +49,7 @@ export const ProcedureView = React.forwardRef<
     const [response, setResponse] = React.useState<TRPCResponse | null>(null);
     const [isFromHistory, setIsFromHistory] = React.useState(false);
     const [showRaw, setShowRaw] = React.useState(false);
-    const [includeCookies, setIncludeCookies] = React.useState(false);
+    const [shouldIncludeCookies, setShouldIncludeCookies] = React.useState(false);
     const { isCopied: isCurlCopied, copy: copyToClipboard } =
         useCopyToClipboard();
 
@@ -208,7 +208,7 @@ export const ProcedureView = React.forwardRef<
                 origin: window.location.origin,
                 headers,
                 useSuperJSON,
-                cookieHeader: includeCookies ? document.cookie : undefined,
+                cookieHeader: shouldIncludeCookies ? document.cookie : undefined,
             }
         );
         copyToClipboard(command);
@@ -311,9 +311,9 @@ export const ProcedureView = React.forwardRef<
                                     >
                                         <input
                                             type="checkbox"
-                                            checked={includeCookies}
+                                            checked={shouldIncludeCookies}
                                             onChange={(e) =>
-                                                setIncludeCookies(
+                                                setShouldIncludeCookies(
                                                     e.target.checked
                                                 )
                                             }

--- a/packages/trpc-devtools/src/components/devtools/request-history.tsx
+++ b/packages/trpc-devtools/src/components/devtools/request-history.tsx
@@ -78,39 +78,40 @@ export function RequestHistoryPanel({ onReplay }: RequestHistoryPanelProps) {
 
     return (
         <div className="border-t border-border flex flex-col min-h-0">
-            {/* Header */}
-            <button
-                onClick={() => setIsCollapsed((prev) => !prev)}
-                aria-expanded={!isCollapsed}
-                className={cn(
-                    'w-full flex items-center gap-1 px-4 py-1.5 min-h-11 text-xs font-semibold text-muted-foreground uppercase tracking-wider transition-colors',
-                    'hover:bg-accent/50',
-                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
-                )}
-            >
-                <ChevronRight
+            {/* Header — clear-all is an absolutely-positioned sibling, not a
+                child of the toggle: a <button> inside a <button> is invalid
+                HTML and triggers a React hydration warning */}
+            <div className="relative">
+                <button
+                    onClick={() => setIsCollapsed((prev) => !prev)}
+                    aria-expanded={!isCollapsed}
                     className={cn(
-                        'h-4 w-4 transition-transform duration-150',
-                        !isCollapsed && 'rotate-90'
+                        'w-full flex items-center gap-1 px-4 py-1.5 min-h-11 text-xs font-semibold text-muted-foreground uppercase tracking-wider transition-colors',
+                        'hover:bg-accent/50',
+                        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
                     )}
-                />
-                <span>History</span>
-                {history.length > 0 && (
-                    <Badge
-                        variant="secondary"
-                        className="ml-1 text-[10px] px-1.5 py-0 min-w-0"
-                    >
-                        {history.length}
-                    </Badge>
-                )}
+                >
+                    <ChevronRight
+                        className={cn(
+                            'h-4 w-4 transition-transform duration-150',
+                            !isCollapsed && 'rotate-90'
+                        )}
+                    />
+                    <span>History</span>
+                    {history.length > 0 && (
+                        <Badge
+                            variant="secondary"
+                            className="ml-1 text-[10px] px-1.5 py-0 min-w-0"
+                        >
+                            {history.length}
+                        </Badge>
+                    )}
+                </button>
                 {history.length > 0 && !isCollapsed && (
                     <button
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            handleClearAll();
-                        }}
+                        onClick={handleClearAll}
                         className={cn(
-                            'ml-auto p-1 rounded-sm text-muted-foreground/70 hover:text-destructive transition-colors',
+                            'absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-sm text-muted-foreground/70 hover:text-destructive transition-colors',
                             'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring'
                         )}
                         aria-label="Clear all history"
@@ -118,7 +119,7 @@ export function RequestHistoryPanel({ onReplay }: RequestHistoryPanelProps) {
                         <Trash2 className="h-3.5 w-3.5" />
                     </button>
                 )}
-            </button>
+            </div>
 
             {/* Content */}
             <AnimatePresence initial={false}>

--- a/packages/trpc-devtools/src/components/devtools/request-history.tsx
+++ b/packages/trpc-devtools/src/components/devtools/request-history.tsx
@@ -12,6 +12,7 @@ import {
     type HistoryItem,
 } from '@/lib/storage';
 import { cn } from '@/lib/utils';
+import { ProcedureTypeBadge } from './procedure-type-badge';
 
 interface RequestHistoryPanelProps {
     onReplay: (item: HistoryItem) => void;
@@ -184,12 +185,7 @@ function HistoryItemRow({ item, onReplay }: HistoryItemRowProps) {
             )}
         >
             {/* Type badge */}
-            <Badge
-                variant={item.request.type}
-                className="text-[10px] px-1.5 py-0 shrink-0"
-            >
-                {item.request.type.slice(0, 1).toUpperCase()}
-            </Badge>
+            <ProcedureTypeBadge type={item.request.type} className="shrink-0" />
 
             {/* Procedure path */}
             <span className="flex-1 min-w-0 font-mono text-xs truncate">

--- a/packages/trpc-devtools/src/components/devtools/response-viewer.tsx
+++ b/packages/trpc-devtools/src/components/devtools/response-viewer.tsx
@@ -9,20 +9,27 @@ import type { TRPCResponse } from '@/lib/request';
 import { HighlightedStackTrace } from '@/components/ui/highlighted-stack-trace';
 import { CollapsibleJsonViewer } from '@/components/ui/collapsible-json-viewer';
 import { hasAnsi } from '@/lib/ansi';
+import { useCopyToClipboard } from '@/lib/use-copy-to-clipboard';
 import { formatIssuePath, type ZodIssue } from '@/lib/zod-error';
 
 interface ResponseViewerProps {
     response: TRPCResponse | null;
     zodIssues?: ZodIssue[] | null;
     fromHistory?: boolean;
+    /** Raw/Parsed toggle state — owned by ProcedureView so the command
+     * palette and the Download button can respect it */
+    showRaw: boolean;
+    onToggleRaw: () => void;
 }
 
 export function ResponseViewer({
     response,
     zodIssues,
     fromHistory,
+    showRaw,
+    onToggleRaw,
 }: ResponseViewerProps) {
-    const [showRaw, setShowRaw] = React.useState(false);
+    const { isCopied, copy } = useCopyToClipboard();
 
     if (!response) {
         return (
@@ -69,20 +76,18 @@ export function ResponseViewer({
                     <Button
                         variant={showRaw ? 'secondary' : 'ghost'}
                         size="sm"
-                        onClick={() => setShowRaw(!showRaw)}
+                        onClick={onToggleRaw}
                     >
                         {showRaw ? 'Parsed' : 'Raw'}
                     </Button>
                     <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => {
-                            navigator.clipboard.writeText(
-                                JSON.stringify(displayData, null, 2)
-                            );
-                        }}
+                        onClick={() =>
+                            copy(JSON.stringify(displayData, null, 2))
+                        }
                     >
-                        Copy
+                        {isCopied ? 'Copied!' : 'Copy'}
                     </Button>
                 </div>
             </div>

--- a/packages/trpc-devtools/src/components/devtools/schema-form.tsx
+++ b/packages/trpc-devtools/src/components/devtools/schema-form.tsx
@@ -116,7 +116,7 @@ export function SchemaForm({
                         <ValidationErrorBanner errors={validationErrors} />
                     )}
                     <p className="text-xs text-muted-foreground">
-                        {formatShortcut('F', { isApple, shift: true })} to
+                        {formatShortcut('F', { isApple, isShift: true })} to
                         format
                     </p>
                 </div>

--- a/packages/trpc-devtools/src/components/devtools/schema-form.tsx
+++ b/packages/trpc-devtools/src/components/devtools/schema-form.tsx
@@ -4,7 +4,9 @@ import * as React from 'react';
 import { Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { JsonEditor } from '@/components/ui/json-editor';
+import { Kbd } from '@/components/ui/kbd';
 import { Spinner } from '@/components/ui/spinner';
+import { formatShortcut, useIsApplePlatform } from '@/lib/platform';
 import { generateSample, parseJsonWithPosition } from '@/lib/sample-generator';
 import { formatIssuePath, type ZodIssue } from '@/lib/zod-error';
 import type { JSONSchema } from '@/server/types';
@@ -30,6 +32,7 @@ export function SchemaForm({
 }: SchemaFormProps) {
     const [showSchema, setShowSchema] = React.useState(true);
     const hasInput = schema !== null;
+    const isApple = useIsApplePlatform();
 
     const handleKeyDown = (e: React.KeyboardEvent) => {
         // Cmd/Ctrl + Enter to submit
@@ -113,7 +116,8 @@ export function SchemaForm({
                         <ValidationErrorBanner errors={validationErrors} />
                     )}
                     <p className="text-xs text-muted-foreground">
-                        Cmd+Shift+F to format
+                        {formatShortcut('F', { isApple, shift: true })} to
+                        format
                     </p>
                 </div>
             ) : (
@@ -137,7 +141,7 @@ export function SchemaForm({
                         `Execute ${procedureType === 'query' ? 'Query' : 'Mutation'}`
                     )}
                 </Button>
-                <span className="text-xs text-muted-foreground">⌘ + Enter</span>
+                <Kbd>{formatShortcut('↵', { isApple })}</Kbd>
             </div>
         </div>
     );

--- a/packages/trpc-devtools/src/components/devtools/shortcuts-help.tsx
+++ b/packages/trpc-devtools/src/components/devtools/shortcuts-help.tsx
@@ -26,7 +26,7 @@ export function ShortcutsHelp({ isOpen, onClose }: ShortcutsHelpProps) {
             description: 'Execute request',
         },
         {
-            keys: [formatShortcut('L', { isApple, shift: true })],
+            keys: [formatShortcut('L', { isApple, isShift: true })],
             description: 'Clear response',
         },
         {
@@ -37,7 +37,7 @@ export function ShortcutsHelp({ isOpen, onClose }: ShortcutsHelpProps) {
             description: 'Previous / next procedure',
         },
         {
-            keys: [formatShortcut('F', { isApple, shift: true })],
+            keys: [formatShortcut('F', { isApple, isShift: true })],
             description: 'Format JSON input (in editor)',
         },
         { keys: ['/'], description: 'Focus procedure search' },

--- a/packages/trpc-devtools/src/components/devtools/shortcuts-help.tsx
+++ b/packages/trpc-devtools/src/components/devtools/shortcuts-help.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import * as React from 'react';
+import { Dialog } from '@/components/ui/dialog';
+import { Kbd } from '@/components/ui/kbd';
+import { formatShortcut, useIsApplePlatform } from '@/lib/platform';
+
+interface ShortcutsHelpProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+/**
+ * Keyboard shortcut reference, opened with Cmd+? (Cmd+Shift+/).
+ */
+export function ShortcutsHelp({ isOpen, onClose }: ShortcutsHelpProps) {
+    const isApple = useIsApplePlatform();
+
+    const shortcuts: Array<{ keys: string[]; description: string }> = [
+        {
+            keys: [formatShortcut('K', { isApple })],
+            description: 'Open command palette',
+        },
+        {
+            keys: [formatShortcut('↵', { isApple })],
+            description: 'Execute request',
+        },
+        {
+            keys: [formatShortcut('L', { isApple, shift: true })],
+            description: 'Clear response',
+        },
+        {
+            keys: [
+                formatShortcut('[', { isApple }),
+                formatShortcut(']', { isApple }),
+            ],
+            description: 'Previous / next procedure',
+        },
+        {
+            keys: [formatShortcut('F', { isApple, shift: true })],
+            description: 'Format JSON input (in editor)',
+        },
+        { keys: ['/'], description: 'Focus procedure search' },
+        {
+            keys: [formatShortcut('?', { isApple })],
+            description: 'Keyboard shortcuts',
+        },
+        { keys: ['Esc'], description: 'Close dialog or palette' },
+    ];
+
+    return (
+        <Dialog
+            isOpen={isOpen}
+            onClose={onClose}
+            label="Keyboard shortcuts"
+            className="max-w-md"
+        >
+            <div className="border-b border-border px-4 py-3">
+                <h2 className="text-sm font-semibold">Keyboard shortcuts</h2>
+            </div>
+            <ul className="p-2">
+                {shortcuts.map((shortcut) => (
+                    <li
+                        key={shortcut.description}
+                        className="flex items-center justify-between gap-4 rounded-md px-2 py-1.5"
+                    >
+                        <span className="text-sm text-foreground">
+                            {shortcut.description}
+                        </span>
+                        <span className="flex shrink-0 items-center gap-1">
+                            {shortcut.keys.map((key, i) => (
+                                <React.Fragment key={key}>
+                                    {i > 0 && (
+                                        <span className="text-[10px] text-muted-foreground">
+                                            /
+                                        </span>
+                                    )}
+                                    <Kbd>{key}</Kbd>
+                                </React.Fragment>
+                            ))}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </Dialog>
+    );
+}

--- a/packages/trpc-devtools/src/components/devtools/theme-toggle.tsx
+++ b/packages/trpc-devtools/src/components/devtools/theme-toggle.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import * as React from 'react';
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ThemeMode } from '@/lib/use-theme';
+
+const MODE_LABELS: Record<ThemeMode, string> = {
+    light: 'Light',
+    dark: 'Dark',
+    system: 'System',
+};
+
+const NEXT_MODE: Record<ThemeMode, ThemeMode> = {
+    light: 'dark',
+    dark: 'system',
+    system: 'light',
+};
+
+interface ThemeToggleProps {
+    mode: ThemeMode;
+    onCycle: () => void;
+}
+
+export function ThemeToggle({ mode, onCycle }: ThemeToggleProps) {
+    const Icon = mode === 'light' ? Sun : mode === 'dark' ? Moon : Monitor;
+    const label = `Theme: ${MODE_LABELS[mode]} — switch to ${MODE_LABELS[NEXT_MODE[mode]]}`;
+
+    return (
+        <button
+            type="button"
+            onClick={onCycle}
+            title={label}
+            aria-label={label}
+            className={cn(
+                'flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors',
+                'hover:bg-accent/50 hover:text-foreground',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+            )}
+        >
+            <Icon className="h-4 w-4" />
+        </button>
+    );
+}

--- a/packages/trpc-devtools/src/components/devtools/theme-toggle.tsx
+++ b/packages/trpc-devtools/src/components/devtools/theme-toggle.tsx
@@ -3,18 +3,12 @@
 import * as React from 'react';
 import { Monitor, Moon, Sun } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import type { ThemeMode } from '@/lib/use-theme';
+import { nextThemeMode, type ThemeMode } from '@/lib/use-theme';
 
 const MODE_LABELS: Record<ThemeMode, string> = {
     light: 'Light',
     dark: 'Dark',
     system: 'System',
-};
-
-const NEXT_MODE: Record<ThemeMode, ThemeMode> = {
-    light: 'dark',
-    dark: 'system',
-    system: 'light',
 };
 
 interface ThemeToggleProps {
@@ -24,7 +18,7 @@ interface ThemeToggleProps {
 
 export function ThemeToggle({ mode, onCycle }: ThemeToggleProps) {
     const Icon = mode === 'light' ? Sun : mode === 'dark' ? Moon : Monitor;
-    const label = `Theme: ${MODE_LABELS[mode]} — switch to ${MODE_LABELS[NEXT_MODE[mode]]}`;
+    const label = `Theme: ${MODE_LABELS[mode]} — switch to ${MODE_LABELS[nextThemeMode(mode)]}`;
 
     return (
         <button

--- a/packages/trpc-devtools/src/components/ui/dialog.tsx
+++ b/packages/trpc-devtools/src/components/ui/dialog.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import * as React from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+import { useFocusTrap } from '@/lib/use-focus-trap';
+
+export interface DialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+    /** Accessible name for the dialog */
+    label: string;
+    /** Element to focus when the dialog opens (defaults to the panel) */
+    initialFocusRef?: React.RefObject<HTMLElement | null>;
+    className?: string;
+    children: React.ReactNode;
+}
+
+/**
+ * Top-anchored modal panel with a backdrop overlay (command-palette style).
+ *
+ * While open: Escape closes, Tab focus is trapped inside the panel, and
+ * clicking the backdrop closes. Focus returns to the previously focused
+ * element on close. Rendered in place (no portal) so it stays inside the
+ * `.trpc-devtools` scope for theming.
+ */
+export function Dialog({
+    isOpen,
+    onClose,
+    label,
+    initialFocusRef,
+    className,
+    children,
+}: DialogProps) {
+    const panelRef = React.useRef<HTMLDivElement>(null);
+
+    useFocusTrap(panelRef, { isOpen, onClose, initialFocusRef });
+
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <>
+                    <motion.div
+                        className="fixed inset-0 z-40 bg-black/60 backdrop-blur-[2px]"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.15, ease: 'easeOut' }}
+                        onClick={onClose}
+                        aria-hidden="true"
+                    />
+                    <div className="pointer-events-none fixed inset-x-0 top-[12%] z-50 flex justify-center px-4">
+                        <motion.div
+                            ref={panelRef}
+                            role="dialog"
+                            aria-modal="true"
+                            aria-label={label}
+                            tabIndex={-1}
+                            className={cn(
+                                'pointer-events-auto flex w-full max-w-xl flex-col overflow-hidden rounded-lg border border-border bg-background shadow-2xl focus:outline-none',
+                                className
+                            )}
+                            initial={{ opacity: 0, y: -12, scale: 0.97 }}
+                            animate={{ opacity: 1, y: 0, scale: 1 }}
+                            exit={{ opacity: 0, y: -12, scale: 0.97 }}
+                            transition={{ duration: 0.15, ease: 'easeOut' }}
+                        >
+                            {children}
+                        </motion.div>
+                    </div>
+                </>
+            )}
+        </AnimatePresence>
+    );
+}

--- a/packages/trpc-devtools/src/components/ui/drawer.tsx
+++ b/packages/trpc-devtools/src/components/ui/drawer.tsx
@@ -3,15 +3,7 @@
 import * as React from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { cn } from '@/lib/utils';
-
-const FOCUSABLE_SELECTOR = [
-    'a[href]',
-    'button:not([disabled])',
-    'input:not([disabled])',
-    'textarea:not([disabled])',
-    'select:not([disabled])',
-    '[tabindex]:not([tabindex="-1"])',
-].join(', ');
+import { useFocusTrap } from '@/lib/use-focus-trap';
 
 export interface DrawerProps {
     isOpen: boolean;
@@ -38,56 +30,10 @@ export function Drawer({
 }: DrawerProps) {
     const panelRef = React.useRef<HTMLDivElement>(null);
 
-    React.useEffect(() => {
-        if (!isOpen) return;
-
-        const previouslyFocused = document.activeElement;
-
-        // Focus the panel itself rather than the first focusable element so
-        // opening the drawer doesn't pop the virtual keyboard via the search
-        // input on touch devices.
-        panelRef.current?.focus();
-
-        function handleKeyDown(e: KeyboardEvent) {
-            if (e.key === 'Escape') {
-                onClose();
-                return;
-            }
-
-            if (e.key !== 'Tab' || !panelRef.current) return;
-
-            const focusable = Array.from(
-                panelRef.current.querySelectorAll<HTMLElement>(
-                    FOCUSABLE_SELECTOR
-                )
-            );
-            if (focusable.length === 0) {
-                e.preventDefault();
-                return;
-            }
-
-            const first = focusable[0];
-            const last = focusable[focusable.length - 1];
-            const active = document.activeElement;
-            const isOutside = !panelRef.current.contains(active);
-
-            if (e.shiftKey && (active === first || isOutside)) {
-                e.preventDefault();
-                last.focus();
-            } else if (!e.shiftKey && (active === last || isOutside)) {
-                e.preventDefault();
-                first.focus();
-            }
-        }
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-            if (previouslyFocused instanceof HTMLElement) {
-                previouslyFocused.focus();
-            }
-        };
-    }, [isOpen, onClose]);
+    // The trap focuses the panel itself rather than the first focusable
+    // element so opening the drawer doesn't pop the virtual keyboard via
+    // the search input on touch devices.
+    useFocusTrap(panelRef, { isOpen, onClose });
 
     return (
         <AnimatePresence>

--- a/packages/trpc-devtools/src/components/ui/index.ts
+++ b/packages/trpc-devtools/src/components/ui/index.ts
@@ -11,6 +11,8 @@ export {
 } from './card';
 export { Badge, type BadgeProps } from './badge';
 export { Drawer, type DrawerProps } from './drawer';
+export { Dialog, type DialogProps } from './dialog';
+export { Kbd } from './kbd';
 export { ScrollArea } from './scroll-area';
 export { Skeleton } from './skeleton';
 export { Spinner, type SpinnerProps } from './spinner';

--- a/packages/trpc-devtools/src/components/ui/kbd.tsx
+++ b/packages/trpc-devtools/src/components/ui/kbd.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Inline keyboard shortcut hint, e.g. <Kbd>⌘K</Kbd>
+ */
+export function Kbd({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLElement>) {
+    return (
+        <kbd
+            className={cn(
+                'pointer-events-none inline-flex h-5 select-none items-center rounded border border-border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground',
+                className
+            )}
+            {...props}
+        />
+    );
+}

--- a/packages/trpc-devtools/src/lib/curl.test.ts
+++ b/packages/trpc-devtools/src/lib/curl.test.ts
@@ -28,6 +28,8 @@ describe('buildCurlCommand', () => {
             `curl 'https://app.example.com/api/trpc/files.list?input=%7B%22limit%22%3A10%7D'`
         );
         expect(cmd).not.toContain('-X POST');
+        // executeRequest sends Content-Type on queries too — keep parity
+        expect(cmd).toContain(`-H 'Content-Type: application/json'`);
     });
 
     it('omits the input param for queries without input', () => {
@@ -36,7 +38,10 @@ describe('buildCurlCommand', () => {
             { trpcUrl: '/api/trpc', origin: ORIGIN }
         );
 
-        expect(cmd).toBe(`curl 'https://app.example.com/api/trpc/health.ping'`);
+        expect(cmd).toContain(
+            `curl 'https://app.example.com/api/trpc/health.ping'`
+        );
+        expect(cmd).not.toContain('input=');
     });
 
     it('builds a POST with a JSON body for mutations', () => {

--- a/packages/trpc-devtools/src/lib/curl.test.ts
+++ b/packages/trpc-devtools/src/lib/curl.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { buildCurlCommand, shellQuote } from './curl';
+
+const ORIGIN = 'https://app.example.com';
+
+describe('shellQuote', () => {
+    it('wraps in single quotes', () => {
+        expect(shellQuote('hello')).toBe(`'hello'`);
+    });
+
+    it('escapes embedded single quotes', () => {
+        expect(shellQuote(`it's`)).toBe(`'it'\\''s'`);
+    });
+
+    it('leaves double quotes and dollar signs inert', () => {
+        expect(shellQuote('say "$HOME"')).toBe(`'say "$HOME"'`);
+    });
+});
+
+describe('buildCurlCommand', () => {
+    it('builds a GET with url-encoded input for queries', () => {
+        const cmd = buildCurlCommand(
+            { path: 'files.list', type: 'query', input: { limit: 10 } },
+            { trpcUrl: '/api/trpc', origin: ORIGIN }
+        );
+
+        expect(cmd).toContain(
+            `curl 'https://app.example.com/api/trpc/files.list?input=%7B%22limit%22%3A10%7D'`
+        );
+        expect(cmd).not.toContain('-X POST');
+    });
+
+    it('omits the input param for queries without input', () => {
+        const cmd = buildCurlCommand(
+            { path: 'health.ping', type: 'query' },
+            { trpcUrl: '/api/trpc', origin: ORIGIN }
+        );
+
+        expect(cmd).toBe(`curl 'https://app.example.com/api/trpc/health.ping'`);
+    });
+
+    it('builds a POST with a JSON body for mutations', () => {
+        const cmd = buildCurlCommand(
+            { path: 'files.rename', type: 'mutation', input: { id: 'a' } },
+            { trpcUrl: '/api/trpc', origin: ORIGIN }
+        );
+
+        expect(cmd).toContain(
+            `curl -X POST 'https://app.example.com/api/trpc/files.rename'`
+        );
+        expect(cmd).toContain(`-H 'Content-Type: application/json'`);
+        expect(cmd).toContain(`--data '{"id":"a"}'`);
+    });
+
+    it('sends an empty object body for mutations without input', () => {
+        const cmd = buildCurlCommand(
+            { path: 'files.touch', type: 'mutation' },
+            { trpcUrl: '/api/trpc', origin: ORIGIN }
+        );
+
+        expect(cmd).toContain(`--data '{}'`);
+    });
+
+    it('wraps input in SuperJSON format when enabled', () => {
+        const query = buildCurlCommand(
+            { path: 'files.list', type: 'query', input: { limit: 1 } },
+            { trpcUrl: '/api/trpc', origin: ORIGIN, useSuperJSON: true }
+        );
+        const mutation = buildCurlCommand(
+            { path: 'files.rename', type: 'mutation', input: { id: 'a' } },
+            { trpcUrl: '/api/trpc', origin: ORIGIN, useSuperJSON: true }
+        );
+
+        expect(query).toContain(
+            encodeURIComponent('{"json":{"limit":1}}').replace(/'/g, '')
+        );
+        expect(mutation).toContain(`--data '{"json":{"id":"a"}}'`);
+    });
+
+    it('includes custom headers', () => {
+        const cmd = buildCurlCommand(
+            { path: 'files.list', type: 'query' },
+            {
+                trpcUrl: '/api/trpc',
+                origin: ORIGIN,
+                headers: { 'x-api-key': 'secret', 'x-trace': '1' },
+            }
+        );
+
+        expect(cmd).toContain(`-H 'x-api-key: secret'`);
+        expect(cmd).toContain(`-H 'x-trace: 1'`);
+    });
+
+    it('includes cookies only when a cookie header is provided', () => {
+        const withCookies = buildCurlCommand(
+            { path: 'files.list', type: 'query' },
+            { trpcUrl: '/api/trpc', origin: ORIGIN, cookieHeader: 'a=1; b=2' }
+        );
+        const withoutCookies = buildCurlCommand(
+            { path: 'files.list', type: 'query' },
+            { trpcUrl: '/api/trpc', origin: ORIGIN, cookieHeader: '' }
+        );
+
+        expect(withCookies).toContain(`-b 'a=1; b=2'`);
+        expect(withoutCookies).not.toContain('-b ');
+    });
+
+    it('escapes shell-hostile input safely', () => {
+        const cmd = buildCurlCommand(
+            {
+                path: 'files.rename',
+                type: 'mutation',
+                input: { name: `it's; rm -rf "$HOME"` },
+            },
+            { trpcUrl: '/api/trpc', origin: ORIGIN }
+        );
+
+        expect(cmd).toContain(`'\\''`);
+        expect(cmd).toContain('rm -rf');
+        // The body stays inside a single-quoted string
+        expect(cmd).toMatch(/--data '.*'$/s);
+    });
+
+    it('resolves an absolute trpcUrl without using origin', () => {
+        const cmd = buildCurlCommand(
+            { path: 'files.list', type: 'query' },
+            { trpcUrl: 'https://other.example.com/trpc', origin: ORIGIN }
+        );
+
+        expect(cmd).toContain('https://other.example.com/trpc/files.list');
+    });
+});

--- a/packages/trpc-devtools/src/lib/curl.ts
+++ b/packages/trpc-devtools/src/lib/curl.ts
@@ -1,4 +1,4 @@
-import type { TRPCRequest } from './request';
+import { buildRequestPayload, type TRPCRequest } from './request';
 
 export interface CurlOptions {
     /** tRPC endpoint URL (may be relative) */
@@ -22,38 +22,36 @@ export function shellQuote(value: string): string {
 }
 
 /**
- * Build a cURL command mirroring how executeRequest() issues the call:
- * GET with an `input` query param for queries, POST with a JSON body for
- * mutations, SuperJSON-wrapped when the server uses that transformer.
+ * Build a cURL command mirroring how executeRequest() issues the call
+ * (both delegate the wire format to buildRequestPayload): GET with an
+ * `input` query param for queries, POST with a JSON body for mutations.
  */
 export function buildCurlCommand(
     request: TRPCRequest,
     options: CurlOptions
 ): string {
-    const url = new URL(options.trpcUrl, options.origin);
-    url.pathname = `${url.pathname}/${request.path}`;
+    const { url, body } = buildRequestPayload(request, {
+        trpcUrl: options.trpcUrl,
+        origin: options.origin,
+        useSuperJSON: options.useSuperJSON,
+    });
 
     const parts: string[] = [];
 
-    if (request.type === 'query') {
-        if (request.input !== undefined) {
-            const queryInput = options.useSuperJSON
-                ? { json: request.input }
-                : request.input;
-            url.searchParams.set('input', JSON.stringify(queryInput));
-        }
+    if (body === undefined) {
         parts.push(`curl ${shellQuote(url.toString())}`);
     } else {
-        const body = options.useSuperJSON
-            ? { json: request.input ?? {} }
-            : (request.input ?? {});
         parts.push(`curl -X POST ${shellQuote(url.toString())}`);
-        parts.push(`-H ${shellQuote('Content-Type: application/json')}`);
-        parts.push(`--data ${shellQuote(JSON.stringify(body))}`);
     }
+
+    parts.push(`-H ${shellQuote('Content-Type: application/json')}`);
 
     for (const [name, value] of Object.entries(options.headers ?? {})) {
         parts.push(`-H ${shellQuote(`${name}: ${value}`)}`);
+    }
+
+    if (body !== undefined) {
+        parts.push(`--data ${shellQuote(JSON.stringify(body))}`);
     }
 
     if (options.cookieHeader) {

--- a/packages/trpc-devtools/src/lib/curl.ts
+++ b/packages/trpc-devtools/src/lib/curl.ts
@@ -1,0 +1,64 @@
+import type { TRPCRequest } from './request';
+
+export interface CurlOptions {
+    /** tRPC endpoint URL (may be relative) */
+    trpcUrl: string;
+    /** Origin used to resolve a relative trpcUrl (window.location.origin) */
+    origin: string;
+    /** Custom headers from the auth config */
+    headers?: Record<string, string>;
+    /** Wrap the input in SuperJSON format { json: input } */
+    useSuperJSON?: boolean;
+    /** Cookie header value to include via -b (document.cookie) */
+    cookieHeader?: string;
+}
+
+/**
+ * Quote a string for safe use in a POSIX shell. Wraps in single quotes and
+ * escapes embedded single quotes via the '\'' idiom.
+ */
+export function shellQuote(value: string): string {
+    return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Build a cURL command mirroring how executeRequest() issues the call:
+ * GET with an `input` query param for queries, POST with a JSON body for
+ * mutations, SuperJSON-wrapped when the server uses that transformer.
+ */
+export function buildCurlCommand(
+    request: TRPCRequest,
+    options: CurlOptions
+): string {
+    const url = new URL(options.trpcUrl, options.origin);
+    url.pathname = `${url.pathname}/${request.path}`;
+
+    const parts: string[] = [];
+
+    if (request.type === 'query') {
+        if (request.input !== undefined) {
+            const queryInput = options.useSuperJSON
+                ? { json: request.input }
+                : request.input;
+            url.searchParams.set('input', JSON.stringify(queryInput));
+        }
+        parts.push(`curl ${shellQuote(url.toString())}`);
+    } else {
+        const body = options.useSuperJSON
+            ? { json: request.input ?? {} }
+            : (request.input ?? {});
+        parts.push(`curl -X POST ${shellQuote(url.toString())}`);
+        parts.push(`-H ${shellQuote('Content-Type: application/json')}`);
+        parts.push(`--data ${shellQuote(JSON.stringify(body))}`);
+    }
+
+    for (const [name, value] of Object.entries(options.headers ?? {})) {
+        parts.push(`-H ${shellQuote(`${name}: ${value}`)}`);
+    }
+
+    if (options.cookieHeader) {
+        parts.push(`-b ${shellQuote(options.cookieHeader)}`);
+    }
+
+    return parts.join(' \\\n  ');
+}

--- a/packages/trpc-devtools/src/lib/fuzzy.test.ts
+++ b/packages/trpc-devtools/src/lib/fuzzy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { fuzzyFilter, fuzzyMatch } from './fuzzy';
+
+describe('fuzzyMatch', () => {
+    it('matches an empty query against anything', () => {
+        expect(fuzzyMatch('', 'files.list')).toEqual({
+            score: 0,
+            indices: [],
+        });
+    });
+
+    it('returns null when the query is not a subsequence', () => {
+        expect(fuzzyMatch('xyz', 'files.list')).toBeNull();
+        expect(fuzzyMatch('listx', 'files.list')).toBeNull();
+    });
+
+    it('is case-insensitive', () => {
+        expect(fuzzyMatch('FILES', 'files.list')).not.toBeNull();
+        expect(fuzzyMatch('files', 'FILES.LIST')).not.toBeNull();
+    });
+
+    it('returns the matched character indices', () => {
+        const match = fuzzyMatch('fi', 'files.list');
+        expect(match?.indices).toEqual([0, 1]);
+    });
+
+    it('prefers a contiguous alignment over the first occurrence', () => {
+        // Greedy matching would pick the 'l' in "files"; the best alignment
+        // is the contiguous "list" segment
+        const match = fuzzyMatch('list', 'files.list');
+        expect(match?.indices).toEqual([6, 7, 8, 9]);
+    });
+
+    it('scores consecutive matches above scattered ones', () => {
+        const consecutive = fuzzyMatch('list', 'files.list');
+        const scattered = fuzzyMatch('list', 'labels.instant');
+        expect(consecutive).not.toBeNull();
+        expect(scattered).not.toBeNull();
+        expect(consecutive!.score).toBeGreaterThan(scattered!.score);
+    });
+
+    it('scores segment-start matches above mid-word ones', () => {
+        const boundary = fuzzyMatch('li', 'files.list');
+        const midWord = fuzzyMatch('li', 'fzzzlizzz');
+        expect(boundary!.score).toBeGreaterThan(midWord!.score);
+    });
+});
+
+describe('fuzzyFilter', () => {
+    const items = ['files.list', 'files.delete', 'auth.login', 'user.get'];
+
+    it('keeps only matching items', () => {
+        const results = fuzzyFilter(items, 'files', (s) => s);
+        expect(results.map((r) => r.item)).toEqual([
+            'files.list',
+            'files.delete',
+        ]);
+    });
+
+    it('ranks better matches first', () => {
+        const results = fuzzyFilter(items, 'list', (s) => s);
+        expect(results[0].item).toBe('files.list');
+    });
+
+    it('returns everything for an empty query', () => {
+        expect(fuzzyFilter(items, '', (s) => s)).toHaveLength(items.length);
+    });
+});

--- a/packages/trpc-devtools/src/lib/fuzzy.ts
+++ b/packages/trpc-devtools/src/lib/fuzzy.ts
@@ -1,0 +1,139 @@
+/**
+ * Minimal fuzzy matcher for the command palette. Matches the query as a
+ * character subsequence of the text (case-insensitive) and scores alignments
+ * so tighter, earlier, boundary-aligned hits rank first. No third-party
+ * search library by design — see #97.
+ */
+
+export interface FuzzyMatch {
+    score: number;
+    /** Indices into `text` of the matched characters, for highlighting */
+    indices: number[];
+}
+
+const CONSECUTIVE_BONUS = 8;
+const BOUNDARY_BONUS = 10;
+const START_BONUS = 12;
+const GAP_PENALTY = 1;
+
+/** Whether text[index] starts a new "word" for boundary scoring */
+function isBoundary(text: string, index: number): boolean {
+    if (index === 0) return true;
+
+    const prev = text[index - 1];
+    if (prev === '.' || prev === '-' || prev === '_' || prev === ' ') {
+        return true;
+    }
+
+    // camelCase boundary
+    const current = text[index];
+    return (
+        current === current.toUpperCase() &&
+        current !== current.toLowerCase() &&
+        prev === prev.toLowerCase()
+    );
+}
+
+/**
+ * Match `query` as a subsequence of `text`, picking the highest-scoring
+ * alignment (a greedy first-occurrence match would rank "list" in
+ * "labels.instant" above the contiguous "list" in "files.list").
+ * Returns null when the query doesn't match; an empty query matches
+ * everything with score 0.
+ */
+export function fuzzyMatch(query: string, text: string): FuzzyMatch | null {
+    if (!query) return { score: 0, indices: [] };
+
+    const queryLower = query.toLowerCase();
+    const textLower = text.toLowerCase();
+    const queryLength = query.length;
+    const textLength = text.length;
+    if (queryLength > textLength) return null;
+
+    // scores[i][j]: best score matching query[0..i] with query[i] at text[j]
+    const scores: number[][] = [];
+    const parents: number[][] = [];
+
+    for (let i = 0; i < queryLength; i++) {
+        scores.push(new Array<number>(textLength).fill(-Infinity));
+        parents.push(new Array<number>(textLength).fill(-1));
+
+        for (let j = i; j < textLength; j++) {
+            if (textLower[j] !== queryLower[i]) continue;
+
+            const bonus =
+                j === 0
+                    ? START_BONUS
+                    : isBoundary(text, j)
+                      ? BOUNDARY_BONUS
+                      : 0;
+
+            if (i === 0) {
+                scores[0][j] = bonus - j * GAP_PENALTY;
+                continue;
+            }
+
+            for (let k = i - 1; k < j; k++) {
+                const prevScore = scores[i - 1][k];
+                if (prevScore === -Infinity) continue;
+
+                const candidate =
+                    prevScore +
+                    bonus +
+                    (j === k + 1 ? CONSECUTIVE_BONUS : 0) -
+                    (j - k - 1) * GAP_PENALTY;
+
+                if (candidate > scores[i][j]) {
+                    scores[i][j] = candidate;
+                    parents[i][j] = k;
+                }
+            }
+        }
+    }
+
+    // Best alignment ends wherever the last query char scored highest
+    let bestEnd = -1;
+    let bestScore = -Infinity;
+    for (let j = 0; j < textLength; j++) {
+        if (scores[queryLength - 1][j] > bestScore) {
+            bestScore = scores[queryLength - 1][j];
+            bestEnd = j;
+        }
+    }
+    if (bestEnd === -1) return null;
+
+    const indices = new Array<number>(queryLength);
+    let j = bestEnd;
+    for (let i = queryLength - 1; i >= 0; i--) {
+        indices[i] = j;
+        j = parents[i][j];
+    }
+
+    return { score: bestScore, indices };
+}
+
+export interface FuzzyResult<T> {
+    item: T;
+    match: FuzzyMatch;
+}
+
+/**
+ * Filter and rank items by fuzzy match against `query`. Preserves input
+ * order for equal scores (stable sort).
+ */
+export function fuzzyFilter<T>(
+    items: T[],
+    query: string,
+    getText: (item: T) => string
+): FuzzyResult<T>[] {
+    const results: FuzzyResult<T>[] = [];
+
+    for (const item of items) {
+        const match = fuzzyMatch(query, getText(item));
+        if (match) {
+            results.push({ item, match });
+        }
+    }
+
+    return results.sort((a, b) => b.match.score - a.match.score);
+}

--- a/packages/trpc-devtools/src/lib/platform.ts
+++ b/packages/trpc-devtools/src/lib/platform.ts
@@ -31,10 +31,10 @@ export function useIsApplePlatform(): boolean {
  */
 export function formatShortcut(
     key: string,
-    options: { isApple: boolean; shift?: boolean }
+    options: { isApple: boolean; isShift?: boolean }
 ): string {
     if (options.isApple) {
-        return `⌘${options.shift ? '⇧' : ''}${key}`;
+        return `⌘${options.isShift ? '⇧' : ''}${key}`;
     }
-    return `Ctrl+${options.shift ? 'Shift+' : ''}${key}`;
+    return `Ctrl+${options.isShift ? 'Shift+' : ''}${key}`;
 }

--- a/packages/trpc-devtools/src/lib/platform.ts
+++ b/packages/trpc-devtools/src/lib/platform.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * Whether the user is on an Apple platform (macOS/iOS), so keyboard
+ * shortcut hints show "⌘" instead of "Ctrl".
+ */
+export function isApplePlatform(): boolean {
+    if (typeof navigator === 'undefined') return false;
+    return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+}
+
+/**
+ * Hydration-safe platform detection: returns false until mounted (matching
+ * the server render), then the real value. Same pattern as useIsMobile.
+ */
+export function useIsApplePlatform(): boolean {
+    const [isApple, setIsApple] = React.useState(false);
+
+    React.useEffect(() => {
+        setIsApple(isApplePlatform());
+    }, []);
+
+    return isApple;
+}
+
+/**
+ * Format a shortcut for display, e.g. formatShortcut('K', { isApple: true })
+ * → "⌘K"; with isApple false → "Ctrl+K".
+ */
+export function formatShortcut(
+    key: string,
+    options: { isApple: boolean; shift?: boolean }
+): string {
+    if (options.isApple) {
+        return `⌘${options.shift ? '⇧' : ''}${key}`;
+    }
+    return `Ctrl+${options.shift ? 'Shift+' : ''}${key}`;
+}

--- a/packages/trpc-devtools/src/lib/request.ts
+++ b/packages/trpc-devtools/src/lib/request.ts
@@ -34,6 +34,39 @@ export interface RequestOptions {
 }
 
 /**
+ * Build the request URL (with the input query param for queries) and JSON
+ * body (for mutations), applying SuperJSON wrapping. Single source of truth
+ * for the wire format, shared by executeRequest and buildCurlCommand.
+ */
+export function buildRequestPayload(
+    request: TRPCRequest,
+    options: { trpcUrl: string; origin: string; useSuperJSON?: boolean }
+): { url: URL; body?: unknown } {
+    const url = new URL(options.trpcUrl, options.origin);
+
+    // tRPC uses the procedure path as the URL path
+    url.pathname = `${url.pathname}/${request.path}`;
+
+    if (request.type === 'query') {
+        // Queries use GET with input as query param
+        // Wrap in SuperJSON format if the server uses superjson transformer
+        if (request.input !== undefined) {
+            const queryInput = options.useSuperJSON
+                ? { json: request.input }
+                : request.input;
+            url.searchParams.set('input', JSON.stringify(queryInput));
+        }
+        return { url };
+    }
+
+    // Mutations use POST with input in body
+    const body = options.useSuperJSON
+        ? { json: request.input ?? {} }
+        : (request.input ?? {});
+    return { url, body };
+}
+
+/**
  * Execute a tRPC request directly from the browser
  */
 export async function executeRequest(
@@ -43,48 +76,21 @@ export async function executeRequest(
     const startedAt = Date.now();
 
     try {
-        const url = new URL(options.trpcUrl, window.location.origin);
+        const { url, body } = buildRequestPayload(request, {
+            trpcUrl: options.trpcUrl,
+            origin: window.location.origin,
+            useSuperJSON: options.useSuperJSON,
+        });
 
-        // tRPC uses the procedure path as the URL path
-        url.pathname = `${url.pathname}/${request.path}`;
-
-        let response: Response;
-
-        if (request.type === 'query') {
-            // Queries use GET with input as query param
-            // Wrap in SuperJSON format if the server uses superjson transformer
-            if (request.input !== undefined) {
-                const queryInput = options.useSuperJSON
-                    ? { json: request.input }
-                    : request.input;
-                url.searchParams.set('input', JSON.stringify(queryInput));
-            }
-
-            response = await fetch(url.toString(), {
-                method: 'GET',
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...options.headers,
-                },
-                credentials: 'include',
-            });
-        } else {
-            // Mutations use POST with input in body
-            // Wrap in SuperJSON format if the server uses superjson transformer
-            const bodyInput = options.useSuperJSON
-                ? { json: request.input ?? {} }
-                : (request.input ?? {});
-
-            response = await fetch(url.toString(), {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...options.headers,
-                },
-                credentials: 'include',
-                body: JSON.stringify(bodyInput),
-            });
-        }
+        const response = await fetch(url.toString(), {
+            method: body === undefined ? 'GET' : 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...options.headers,
+            },
+            credentials: 'include',
+            ...(body !== undefined && { body: JSON.stringify(body) }),
+        });
 
         const completedAt = Date.now();
         const rawResponse = await response.json();

--- a/packages/trpc-devtools/src/lib/storage.ts
+++ b/packages/trpc-devtools/src/lib/storage.ts
@@ -4,13 +4,13 @@ const STORAGE_KEY = 'trpc-devtools-history';
 const PANEL_SIZES_KEY = 'trpc-devtools-panel-sizes';
 const SUPERJSON_KEY = 'trpc-devtools-superjson';
 const COLLAPSED_GROUPS_KEY = 'trpc-devtools-collapsed-groups';
-// Also read by the inline FOUC-prevention script in server/handler.ts —
-// keep the key and value format in sync with it.
+// Interpolated into the inline FOUC-prevention script in server/handler.ts —
+// value format ('light' | 'dark' | 'system' literals) must stay in sync.
 export const THEME_KEY = 'trpc-devtools-theme';
 const MAX_HISTORY_ITEMS = 50;
 
-const THEME_MODES = ['light', 'dark', 'system'] as const;
-type StoredThemeMode = (typeof THEME_MODES)[number];
+export const THEME_MODES = ['light', 'dark', 'system'] as const;
+export type ThemeMode = (typeof THEME_MODES)[number];
 
 export interface HistoryItem {
     id: string;
@@ -207,13 +207,13 @@ export function saveSuperJSONPreference(
 /**
  * Load the persisted theme mode, or null if unset/invalid
  */
-export function loadThemePreference(): StoredThemeMode | null {
+export function loadThemePreference(): ThemeMode | null {
     if (typeof window === 'undefined') return null;
 
     try {
         const stored = localStorage.getItem(THEME_KEY);
-        if (stored && THEME_MODES.includes(stored as StoredThemeMode)) {
-            return stored as StoredThemeMode;
+        if (stored && THEME_MODES.includes(stored as ThemeMode)) {
+            return stored as ThemeMode;
         }
         return null;
     } catch {
@@ -224,7 +224,7 @@ export function loadThemePreference(): StoredThemeMode | null {
 /**
  * Persist the theme mode
  */
-export function saveThemePreference(mode: StoredThemeMode): void {
+export function saveThemePreference(mode: ThemeMode): void {
     if (typeof window === 'undefined') return;
 
     try {

--- a/packages/trpc-devtools/src/lib/storage.ts
+++ b/packages/trpc-devtools/src/lib/storage.ts
@@ -4,7 +4,13 @@ const STORAGE_KEY = 'trpc-devtools-history';
 const PANEL_SIZES_KEY = 'trpc-devtools-panel-sizes';
 const SUPERJSON_KEY = 'trpc-devtools-superjson';
 const COLLAPSED_GROUPS_KEY = 'trpc-devtools-collapsed-groups';
+// Also read by the inline FOUC-prevention script in server/handler.ts —
+// keep the key and value format in sync with it.
+export const THEME_KEY = 'trpc-devtools-theme';
 const MAX_HISTORY_ITEMS = 50;
+
+const THEME_MODES = ['light', 'dark', 'system'] as const;
+type StoredThemeMode = (typeof THEME_MODES)[number];
 
 export interface HistoryItem {
     id: string;
@@ -191,6 +197,38 @@ export function saveSuperJSONPreference(
             : {};
         prefs[trpcUrl] = usesSuperJSON;
         localStorage.setItem(SUPERJSON_KEY, JSON.stringify(prefs));
+    } catch {
+        // Storage might be full or disabled
+    }
+}
+
+// Theme preference storage
+
+/**
+ * Load the persisted theme mode, or null if unset/invalid
+ */
+export function loadThemePreference(): StoredThemeMode | null {
+    if (typeof window === 'undefined') return null;
+
+    try {
+        const stored = localStorage.getItem(THEME_KEY);
+        if (stored && THEME_MODES.includes(stored as StoredThemeMode)) {
+            return stored as StoredThemeMode;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Persist the theme mode
+ */
+export function saveThemePreference(mode: StoredThemeMode): void {
+    if (typeof window === 'undefined') return;
+
+    try {
+        localStorage.setItem(THEME_KEY, mode);
     } catch {
         // Storage might be full or disabled
     }

--- a/packages/trpc-devtools/src/lib/use-copy-to-clipboard.ts
+++ b/packages/trpc-devtools/src/lib/use-copy-to-clipboard.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * Copy text to the clipboard with a transient "copied" flag for UI feedback.
+ * The flag resets after `timeoutMs` (re-copying restarts the timer).
+ */
+export function useCopyToClipboard(timeoutMs = 2000): {
+    isCopied: boolean;
+    copy: (text: string) => void;
+} {
+    const [isCopied, setIsCopied] = React.useState(false);
+    const timeoutRef = React.useRef<number | undefined>(undefined);
+
+    React.useEffect(() => {
+        return () => window.clearTimeout(timeoutRef.current);
+    }, []);
+
+    const copy = React.useCallback(
+        (text: string) => {
+            navigator.clipboard.writeText(text);
+            setIsCopied(true);
+            window.clearTimeout(timeoutRef.current);
+            timeoutRef.current = window.setTimeout(
+                () => setIsCopied(false),
+                timeoutMs
+            );
+        },
+        [timeoutMs]
+    );
+
+    return { isCopied, copy };
+}

--- a/packages/trpc-devtools/src/lib/use-focus-trap.ts
+++ b/packages/trpc-devtools/src/lib/use-focus-trap.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import * as React from 'react';
+
+const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'textarea:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+export interface FocusTrapOptions {
+    isOpen: boolean;
+    onClose: () => void;
+    /**
+     * Element to focus when the trap activates. Defaults to the container
+     * itself (which must have tabIndex={-1}).
+     */
+    initialFocusRef?: React.RefObject<HTMLElement | null>;
+}
+
+/**
+ * Modal focus behavior shared by Drawer and Dialog: on open, move focus
+ * inside; while open, Escape closes and Tab cycles within the container;
+ * on close, restore focus to the previously focused element.
+ */
+export function useFocusTrap(
+    containerRef: React.RefObject<HTMLElement | null>,
+    { isOpen, onClose, initialFocusRef }: FocusTrapOptions
+): void {
+    React.useEffect(() => {
+        if (!isOpen) return;
+
+        const previouslyFocused = document.activeElement;
+
+        (initialFocusRef?.current ?? containerRef.current)?.focus();
+
+        function handleKeyDown(e: KeyboardEvent) {
+            if (e.key === 'Escape') {
+                onClose();
+                return;
+            }
+
+            if (e.key !== 'Tab' || !containerRef.current) return;
+
+            const focusable = Array.from(
+                containerRef.current.querySelectorAll<HTMLElement>(
+                    FOCUSABLE_SELECTOR
+                )
+            );
+            if (focusable.length === 0) {
+                e.preventDefault();
+                return;
+            }
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            const active = document.activeElement;
+            const isOutside = !containerRef.current.contains(active);
+
+            if (e.shiftKey && (active === first || isOutside)) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && (active === last || isOutside)) {
+                e.preventDefault();
+                first.focus();
+            }
+        }
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            if (previouslyFocused instanceof HTMLElement) {
+                previouslyFocused.focus();
+            }
+        };
+    }, [isOpen, onClose, containerRef, initialFocusRef]);
+}

--- a/packages/trpc-devtools/src/lib/use-theme.ts
+++ b/packages/trpc-devtools/src/lib/use-theme.ts
@@ -1,12 +1,24 @@
 'use client';
 
 import * as React from 'react';
-import { loadThemePreference, saveThemePreference } from './storage';
+import {
+    loadThemePreference,
+    saveThemePreference,
+    THEME_MODES,
+    type ThemeMode,
+} from './storage';
 
-export type ThemeMode = 'light' | 'dark' | 'system';
+export type { ThemeMode };
 export type ResolvedTheme = 'light' | 'dark';
 
-const MODE_CYCLE: ThemeMode[] = ['light', 'dark', 'system'];
+// Must stay >= the 150ms `.theme-transition` duration in styles/globals.css
+// (a little slack so the class outlives the CSS transition)
+const THEME_TRANSITION_CLEAR_MS = 200;
+
+/** The mode a toggle moves to next: Light → Dark → System → Light */
+export function nextThemeMode(mode: ThemeMode): ThemeMode {
+    return THEME_MODES[(THEME_MODES.indexOf(mode) + 1) % THEME_MODES.length];
+}
 
 export interface UseThemeResult {
     /** The user's selected mode (may be 'system') */
@@ -42,7 +54,7 @@ export function useTheme(): UseThemeResult {
     // hydration mismatch is never patched up by React.
     const [isMounted, setIsMounted] = React.useState(false);
     const [mode, setMode] = React.useState<ThemeMode>('system');
-    const [systemPrefersDark, setSystemPrefersDark] = React.useState(false);
+    const [isSystemDark, setIsSystemDark] = React.useState(false);
     const [isTransitioning, setIsTransitioning] = React.useState(false);
     const transitionTimeoutRef = React.useRef<number | undefined>(undefined);
 
@@ -51,7 +63,7 @@ export function useTheme(): UseThemeResult {
         setMode(loadThemePreference() ?? 'system');
 
         const query = window.matchMedia('(prefers-color-scheme: dark)');
-        const update = () => setSystemPrefersDark(query.matches);
+        const update = () => setIsSystemDark(query.matches);
         update();
         setIsMounted(true);
 
@@ -65,8 +77,7 @@ export function useTheme(): UseThemeResult {
 
     const cycleMode = React.useCallback(() => {
         setMode((prev) => {
-            const next =
-                MODE_CYCLE[(MODE_CYCLE.indexOf(prev) + 1) % MODE_CYCLE.length];
+            const next = nextThemeMode(prev);
             saveThemePreference(next);
             return next;
         });
@@ -75,14 +86,14 @@ export function useTheme(): UseThemeResult {
         window.clearTimeout(transitionTimeoutRef.current);
         transitionTimeoutRef.current = window.setTimeout(
             () => setIsTransitioning(false),
-            200
+            THEME_TRANSITION_CLEAR_MS
         );
     }, []);
 
     const resolvedTheme: ResolvedTheme | null = !isMounted
         ? null
         : mode === 'system'
-          ? systemPrefersDark
+          ? isSystemDark
               ? 'dark'
               : 'light'
           : mode;

--- a/packages/trpc-devtools/src/lib/use-theme.ts
+++ b/packages/trpc-devtools/src/lib/use-theme.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import * as React from 'react';
+import { loadThemePreference, saveThemePreference } from './storage';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+const MODE_CYCLE: ThemeMode[] = ['light', 'dark', 'system'];
+
+export interface UseThemeResult {
+    /** The user's selected mode (may be 'system') */
+    mode: ThemeMode;
+    /**
+     * The concrete theme currently in effect, or null before mount.
+     * Null means "apply no theme class": the wrapper then inherits the host
+     * page's `.dark` class (embedded) or the FOUC script's html class
+     * (standalone), keeping server and client initial renders identical.
+     */
+    resolvedTheme: ResolvedTheme | null;
+    /** Cycle Light → Dark → System */
+    cycleMode: () => void;
+    /**
+     * True for a short window after a user-initiated mode change, so the
+     * caller can apply a CSS transition class only while switching (a
+     * permanent transition on colors would interfere with hover effects).
+     */
+    isTransitioning: boolean;
+}
+
+/**
+ * Theme state for the devtools. Persists the selected mode in localStorage
+ * and tracks the OS preference live while in 'system' mode.
+ *
+ * The caller is responsible for applying `resolvedTheme` as a class on the
+ * `.trpc-devtools` wrapper — theming is wrapper-scoped so an embedded
+ * devtools never fights the host page's theme.
+ */
+export function useTheme(): UseThemeResult {
+    // localStorage and matchMedia are read only after mount (never in initial
+    // state) so the SSR'd and hydrated first renders match — a className
+    // hydration mismatch is never patched up by React.
+    const [isMounted, setIsMounted] = React.useState(false);
+    const [mode, setMode] = React.useState<ThemeMode>('system');
+    const [systemPrefersDark, setSystemPrefersDark] = React.useState(false);
+    const [isTransitioning, setIsTransitioning] = React.useState(false);
+    const transitionTimeoutRef = React.useRef<number | undefined>(undefined);
+
+    // Load the persisted mode and track live OS theme changes
+    React.useEffect(() => {
+        setMode(loadThemePreference() ?? 'system');
+
+        const query = window.matchMedia('(prefers-color-scheme: dark)');
+        const update = () => setSystemPrefersDark(query.matches);
+        update();
+        setIsMounted(true);
+
+        query.addEventListener('change', update);
+        return () => query.removeEventListener('change', update);
+    }, []);
+
+    React.useEffect(() => {
+        return () => window.clearTimeout(transitionTimeoutRef.current);
+    }, []);
+
+    const cycleMode = React.useCallback(() => {
+        setMode((prev) => {
+            const next =
+                MODE_CYCLE[(MODE_CYCLE.indexOf(prev) + 1) % MODE_CYCLE.length];
+            saveThemePreference(next);
+            return next;
+        });
+
+        setIsTransitioning(true);
+        window.clearTimeout(transitionTimeoutRef.current);
+        transitionTimeoutRef.current = window.setTimeout(
+            () => setIsTransitioning(false),
+            200
+        );
+    }, []);
+
+    const resolvedTheme: ResolvedTheme | null = !isMounted
+        ? null
+        : mode === 'system'
+          ? systemPrefersDark
+              ? 'dark'
+              : 'light'
+          : mode;
+
+    return { mode, resolvedTheme, cycleMode, isTransitioning };
+}

--- a/packages/trpc-devtools/src/server/handler.ts
+++ b/packages/trpc-devtools/src/server/handler.ts
@@ -2,6 +2,7 @@ import type { AnyRouter } from '@trpc/server';
 import type { NextRequest } from 'next/server';
 import { introspectRouter } from './introspect';
 import { getStandaloneJs, getStandaloneCss } from './assets';
+import { THEME_KEY } from '../lib/storage';
 import type { TRPCDevtoolsConfig, RouterSchema } from './types';
 
 // Cache the introspected schema to avoid re-processing on every request
@@ -38,14 +39,13 @@ function getDevtoolsHtml(config: {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>tRPC Devtools</title>
     <script>
-        // FOUC prevention: resolve the persisted theme (same key as
-        // lib/storage.ts) before first paint. The React app applies the
-        // theme class to the .trpc-devtools wrapper itself; this only
-        // colors the page shell until hydration.
+        // FOUC prevention: resolve the persisted theme before first paint.
+        // The React app applies the theme class to the .trpc-devtools
+        // wrapper itself; this only colors the page shell until hydration.
         (function () {
             var dark = true;
             try {
-                var mode = localStorage.getItem('trpc-devtools-theme');
+                var mode = localStorage.getItem(${JSON.stringify(THEME_KEY)});
                 dark =
                     mode === 'dark' ||
                     (mode !== 'light' &&

--- a/packages/trpc-devtools/src/server/handler.ts
+++ b/packages/trpc-devtools/src/server/handler.ts
@@ -32,11 +32,32 @@ function getDevtoolsHtml(config: {
     const css = getStandaloneCss();
 
     return `<!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>tRPC Devtools</title>
+    <script>
+        // FOUC prevention: resolve the persisted theme (same key as
+        // lib/storage.ts) before first paint. The React app applies the
+        // theme class to the .trpc-devtools wrapper itself; this only
+        // colors the page shell until hydration.
+        (function () {
+            var dark = true;
+            try {
+                var mode = localStorage.getItem('trpc-devtools-theme');
+                dark =
+                    mode === 'dark' ||
+                    (mode !== 'light' &&
+                        window.matchMedia('(prefers-color-scheme: dark)')
+                            .matches);
+            } catch (e) {
+                // Fall back to dark (previous hardcoded behavior)
+            }
+            document.documentElement.classList.add(dark ? 'dark' : 'light');
+        })();
+    </script>
+    <style>html.dark { background-color: hsl(222 84% 5%); }</style>
     <style>${css}</style>
 </head>
 <body>

--- a/packages/trpc-devtools/src/styles/globals.css
+++ b/packages/trpc-devtools/src/styles/globals.css
@@ -62,6 +62,46 @@
     --color-card-foreground: hsl(210 40% 98%);
 }
 
+/* Explicit light mode — declared after the dark block so an in-app "Light"
+   selection (`.trpc-devtools.light`) wins over a host page's `.dark` class
+   at equal specificity */
+.trpc-devtools.light {
+    --color-background: hsl(0 0% 100%);
+    --color-foreground: hsl(222 84% 5%);
+
+    --color-primary: hsl(220 90% 56%);
+    --color-primary-foreground: hsl(210 40% 98%);
+
+    --color-secondary: hsl(210 40% 96%);
+    --color-secondary-foreground: hsl(222 47% 11%);
+
+    --color-muted: hsl(210 40% 96%);
+    --color-muted-foreground: hsl(215 16% 47%);
+
+    --color-accent: hsl(210 40% 96%);
+    --color-accent-foreground: hsl(222 47% 11%);
+
+    --color-destructive: hsl(0 84% 60%);
+    --color-destructive-foreground: hsl(210 40% 98%);
+
+    --color-border: hsl(214 32% 91%);
+    --color-input: hsl(214 32% 91%);
+    --color-ring: hsl(220 90% 56%);
+
+    --color-card: hsl(0 0% 100%);
+    --color-card-foreground: hsl(222 84% 5%);
+}
+
+/* Applied only for a moment while the theme toggles, so color transitions
+   don't linger on hover effects and other state changes */
+.trpc-devtools.theme-transition,
+.trpc-devtools.theme-transition * {
+    transition:
+        background-color 150ms ease,
+        border-color 150ms ease,
+        color 150ms ease !important;
+}
+
 /* Base studio styles */
 .trpc-devtools {
     @apply bg-background text-foreground;

--- a/packages/trpc-devtools/src/styles/globals.css
+++ b/packages/trpc-devtools/src/styles/globals.css
@@ -93,7 +93,9 @@
 }
 
 /* Applied only for a moment while the theme toggles, so color transitions
-   don't linger on hover effects and other state changes */
+   don't linger on hover effects and other state changes. The class is
+   removed by lib/use-theme.ts (THEME_TRANSITION_CLEAR_MS) — keep that
+   timeout >= the duration here */
 .trpc-devtools.theme-transition,
 .trpc-devtools.theme-transition * {
     transition:


### PR DESCRIPTION
Closes #99, Closes #101, Closes #97

Finishes the remaining sub-issues of epic #91 in one PR (per request). #97 depends on #99 (theme action) and #101 (cURL action), which is why they ship together.

## #99 — Theme toggle

- Sidebar toggle cycling Light → Dark → System (Sun/Moon/Monitor icons, tooltip + aria-label announce current and next mode)
- Persisted under `trpc-devtools-theme` (issue text says `trpc-studio-theme`, but that predates the #109 rename — kept consistent with the other `trpc-devtools-*` keys)
- System mode tracks `prefers-color-scheme` live; 150ms color transition applied only during the switch so it never interferes with hover transitions
- Theme class goes on the `.trpc-devtools` wrapper; a `.trpc-devtools.light` override block lets an explicit Light selection win over a host page's `.dark` class, so embedded devtools never fight the host theme. Resolution is deferred to post-mount (pre-mount the wrapper inherits host/FOUC-script theme) — reading `matchMedia`/`localStorage` in initial state caused a className hydration mismatch that React never patches (caught during live verification)
- Standalone route: inline FOUC script in `<head>` (interpolates `THEME_KEY`) replaces the hardcoded `class="dark"`

## #101 — cURL export + response saving

- `buildCurlCommand` delegates to `buildRequestPayload`, extracted from `executeRequest`, so the copied command and the real request share one wire-format source of truth (GET + `input` param / POST + JSON body, SuperJSON wrapping, `Content-Type` header)
- Shell-safe single-quote escaping (`shellQuote`), unit-tested against quote/`$HOME`/semicolon injection
- Cookies opt-in checkbox (off by default; only JS-readable cookies — httpOnly ones can't be exported, noted in the tooltip)
- Download button in the Response header: `{procedure.path}-response.json`, 2-space indent, respects the Raw/Parsed toggle, disabled with no response; cURL copy works after failed requests
- "Copied!" feedback (2s) added to both the new cURL button and the existing Copy button via a shared `useCopyToClipboard`

## #97 — Command palette + shortcuts

- Cmd+K palette: custom fuzzy matcher (no dependency) using best-alignment DP scoring — greedy first-occurrence matching ranked `list` in `labels.instant` above the contiguous `list` in `files.list`, so the scorer picks the optimal alignment; matched characters are highlighted
- Actions: Clear response, Toggle theme, Copy as cURL, Toggle raw/parsed, Keyboard shortcuts — wired through a `ProcedureViewHandle` imperative ref so state stays where it lives
- Shortcuts: Cmd+Enter (execute from anywhere, `defaultPrevented` guard prevents double-fire with the editor's own handler), Cmd+Shift+L, Cmd+[ / Cmd+] (wrap-around), Cmd+? help modal, Escape everywhere
- Platform-aware hints (⌘ vs Ctrl) deferred to post-mount to stay hydration-safe; ⌘K hint button in the sidebar header, ⌘↵ next to Execute
- Focus trap extracted from Drawer into `useFocusTrap`, shared with the new `Dialog` (focus restoration included)
- Fixed in passing: the sidebar's global `/` shortcut swallowed Cmd+Shift+/ because it didn't check modifier keys

## Verification

- `pnpm check` 10/10, e2e smoke 41/41, 97 package unit tests (22 new for curl/fuzzy)
- Live-driven on `/dev/studio` and the standalone `/api/trpc-devtools` route with Playwright: 26 assertions covering every acceptance criterion (theme cycling + persistence + computed colors, clipboard contents with/without cookies, download filename + content, all shortcuts, palette fuzzy search + actions, FOUC class pre-hydration, zero page errors)
- Self-review (conventions/quality/reuse agents) applied in the second commit; skipped: CSS var indirection inside Tailwind's `@theme` (build-risky for zero behavior change) and a `useMediaQuery` extraction (would tangle `useTheme`'s mount/storage coupling to save ~6 lines)

## Bonus fix: pre-existing hydration warning in request history

Verification surfaced that `request-history.tsx` nested the clear-all `<button>` inside the group-header `<button>` — invalid HTML, so browsers close the outer element while parsing and the SSR'd DOM diverges from the React tree, producing a hydration warning on `/dev/studio` once history entries exist. The clear-all control is now an absolutely-positioned sibling of the toggle. Live-verified: entry created via Cmd+Enter, clear-all + undo + collapse/expand all work, and a reload with history present (the exact path that warned) logs zero console errors.
