### PR TITLE
feat: Sentry error tracking — client, server, tRPC, upload failures (#327)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -29,3 +29,13 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # Logging (optional)
 # LOG_ERROR_VERBOSITY=full  # minimal | standard | full (defaults: full in dev, standard in prod)
+
+# Sentry error tracking (deployed Vercel envs only — leave unset locally!)
+# The DSN's presence is what turns Sentry on: setting it here would make
+# local/e2e production builds send events and break the zero-console-error
+# smoke assertions. Configured in Vercel env (production + preview tiers).
+# NEXT_PUBLIC_SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
+# Build-time source-map upload (Vercel builds only):
+# SENTRY_ORG=xxx
+# SENTRY_PROJECT=xxx
+# SENTRY_AUTH_TOKEN=sntrys_xxx

--- a/apps/web/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/app/api/trpc/[trpc]/route.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { createTRPCContext } from '@/server/trpc/init';
 import { appRouter } from '@/server/trpc/router';
@@ -8,6 +9,17 @@ function handler(req: Request) {
         req,
         router: appRouter,
         createContext: createTRPCContext,
+        // Procedure errors are reported by the logging middleware. A missing
+        // ctx means createTRPCContext itself threw (session store or DB
+        // outage) — the one class of error no middleware ever runs for, and
+        // the adapter swallows it before Next's onRequestError can see it.
+        onError({ error, ctx }) {
+            if (ctx === undefined) {
+                Sentry.captureException(error.cause ?? error, {
+                    tags: { source: 'createTRPCContext' },
+                });
+            }
+        },
     });
 }
 

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import Link from 'next/link';
+import * as Sentry from '@sentry/nextjs';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -33,6 +34,9 @@ export default function Error({
             { err: error, digest: error.digest },
             error.message || 'route error boundary'
         );
+        // React catches render errors before window.onerror fires, so the
+        // boundary is the only capture point for them.
+        Sentry.captureException(error);
     }, [error]);
 
     return (

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import * as Sentry from '@sentry/nextjs';
 
 import { log } from '@/lib/logger/client';
 
@@ -24,6 +25,9 @@ export default function GlobalError({
             { err: error, digest: error.digest },
             error.message || 'global error boundary'
         );
+        // React catches render errors before window.onerror fires, so the
+        // boundary is the only capture point for them.
+        Sentry.captureException(error);
     }, [error]);
 
     return (

--- a/apps/web/components/ClientErrorReporter.tsx
+++ b/apps/web/components/ClientErrorReporter.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
+import * as Sentry from '@sentry/nextjs';
 
 import { useSession } from '@/lib/auth/client';
 import { log, setClientLogContext } from '@/lib/logger/client';
@@ -17,8 +18,14 @@ export function ClientErrorReporter(): null {
     // Node process.
     if (typeof window !== 'undefined') {
         setClientLogContext({ userId, page: pathname });
+        // Attach the signed-in user to client-side Sentry events (the URL is
+        // already on every event). `null` clears it on sign-out.
+        Sentry.setUser(userId ? { id: userId } : null);
     }
 
+    // These listeners feed the pino dev-log transmit only. Sentry installs
+    // its own window error/unhandledrejection instrumentation at init —
+    // capturing here as well would double-report every uncaught error.
     useEffect(() => {
         function handleError(event: ErrorEvent): void {
             log.error(

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
+import * as Sentry from '@sentry/nextjs';
 import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/client';
 import { useInvalidateFileList } from '@/lib/hooks/useInvalidateFileList';
@@ -90,6 +91,31 @@ interface InternalUploadFile extends UploadFile {
 
 function randomId(): string {
     return Math.random().toString(36).substring(7);
+}
+
+/**
+ * Terminal upload failures never reach the server — the failing legs are
+ * browser→S3 presigned PUTs — so this client-side capture is their only
+ * observer. Called after the abort/pause early-returns: only failures the
+ * user actually sees as an error row get reported.
+ */
+function reportUploadFailure(
+    error: unknown,
+    engine: 'single' | 'multipart',
+    uploadFile: InternalUploadFile,
+    fileId?: string
+): void {
+    Sentry.captureException(error, {
+        tags: { feature: 'upload', engine },
+        contexts: {
+            upload: {
+                fileId: fileId ?? uploadFile.fileId,
+                fileName: uploadFile.name,
+                sizeBytes: uploadFile.size,
+                batchId: uploadFile.batchId,
+            },
+        },
+    });
 }
 
 export function useUpload() {
@@ -181,6 +207,7 @@ export function useUpload() {
                 if (isAbortError(error)) {
                     return;
                 }
+                reportUploadFailure(error, 'single', uploadFile);
                 updateFile(uploadFile.id, {
                     status: 'error',
                     error:
@@ -421,6 +448,7 @@ export function useUpload() {
                     updateFile(uploadFile.id, { status: 'paused' });
                     return;
                 }
+                reportUploadFailure(error, 'multipart', uploadFile, fileId);
                 updateFile(uploadFile.id, {
                     status: 'error',
                     error:

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -106,14 +106,20 @@ export function useUpload() {
     const createBatchMutation = useMutation(
         trpc.files.createBatch.mutationOptions()
     );
+    // Confirm/complete are retried in-mutation (default backoff matches
+    // retryAsync's 1s/2s/4s) because the file data is already in S3. An
+    // external retryAsync loop would fire the MutationCache Sentry capture
+    // (lib/trpc/query-client.ts) once per attempt instead of once per failure.
     const confirmMutation = useMutation(
-        trpc.files.confirmUpload.mutationOptions()
+        trpc.files.confirmUpload.mutationOptions({ retry: CONFIRM_RETRIES })
     );
     const multipartInitMutation = useMutation(
         trpc.files.multipart.init.mutationOptions()
     );
     const multipartCompleteMutation = useMutation(
-        trpc.files.multipart.complete.mutationOptions()
+        trpc.files.multipart.complete.mutationOptions({
+            retry: CONFIRM_RETRIES,
+        })
     );
     const multipartAbortMutation = useMutation(
         trpc.files.multipart.abort.mutationOptions()
@@ -148,17 +154,22 @@ export function useUpload() {
                 abortController,
             });
 
+            // Carried outside the try so the failure report can include the
+            // id once init has assigned it — the uploadFile closure predates
+            // init (mirrors the multipart engine).
+            let fileId = uploadFile.fileId;
             try {
-                const { fileId, uploadUrl } = await uploadMutation.mutateAsync({
+                const init = await uploadMutation.mutateAsync({
                     name: file.name,
                     sizeBytes: file.size,
                     mimeType: file.type || undefined,
                     batchId: sessionBatchId,
                 });
+                fileId = init.fileId;
 
                 updateFile(uploadFile.id, { fileId });
 
-                await xhrPut(uploadUrl, file, {
+                await xhrPut(init.uploadUrl, file, {
                     onProgress: (loaded, total) => {
                         updateFile(uploadFile.id, {
                             progress: Math.round((loaded / total) * 100),
@@ -167,11 +178,7 @@ export function useUpload() {
                     signal: abortController.signal,
                 });
 
-                // Retry confirmUpload since the file data is already in S3
-                await retryAsync(
-                    () => confirmMutation.mutateAsync({ fileId }),
-                    CONFIRM_RETRIES
-                );
+                await confirmMutation.mutateAsync({ fileId: init.fileId });
 
                 updateFile(uploadFile.id, {
                     status: 'complete',
@@ -182,7 +189,18 @@ export function useUpload() {
                 if (isAbortError(error)) {
                     return;
                 }
-                reportUploadFailure(error, 'single', uploadFile);
+                // A network drop pauses for reconnect rather than failing the
+                // upload — same policy as the multipart engine; the online
+                // handler restarts it.
+                if (isNetworkError(error) && !navigatorIsOnline()) {
+                    updateFile(uploadFile.id, { status: 'paused' });
+                    return;
+                }
+                reportUploadFailure(error, 'single', {
+                    ...uploadFile,
+                    fileId,
+                    batchId: sessionBatchId,
+                });
                 updateFile(uploadFile.id, {
                     status: 'error',
                     error:
@@ -392,16 +410,11 @@ export function useUpload() {
                 );
                 if (firstError) throw firstError;
 
-                // Retry complete since the parts are already in S3.
-                await retryAsync(
-                    () =>
-                        multipartCompleteMutation.mutateAsync({
-                            fileId: fileId!,
-                            uploadId: uploadId!,
-                            parts: mergeParts(completed),
-                        }),
-                    CONFIRM_RETRIES
-                );
+                await multipartCompleteMutation.mutateAsync({
+                    fileId: fileId!,
+                    uploadId: uploadId!,
+                    parts: mergeParts(completed),
+                });
 
                 await deleteUpload(fileId!);
                 updateFile(uploadFile.id, {
@@ -423,11 +436,13 @@ export function useUpload() {
                     updateFile(uploadFile.id, { status: 'paused' });
                     return;
                 }
-                // Spread picks up the local fileId assigned after init —
-                // fresher than the stale uploadFile closure's.
+                // Spread picks up the local fileId assigned after init and
+                // the threaded session batch — both fresher than the stale
+                // uploadFile closure.
                 reportUploadFailure(error, 'multipart', {
                     ...uploadFile,
                     fileId,
+                    batchId: sessionBatchId,
                 });
                 updateFile(uploadFile.id, {
                     status: 'error',
@@ -570,7 +585,10 @@ export function useUpload() {
                 for (const f of paused) {
                     const current = filesRef.current.find((x) => x.id === f.id);
                     if (current?.status === 'paused' && current.file) {
-                        await uploadMultipartFile(current);
+                        // runUpload, not uploadMultipartFile: a single-engine
+                        // upload paused by a network drop restarts through
+                        // its own engine.
+                        await runUpload(current);
                     }
                 }
                 setIsUploading(false);
@@ -582,7 +600,7 @@ export function useUpload() {
             window.removeEventListener('offline', onOffline);
             window.removeEventListener('online', onOnline);
         };
-    }, [uploadMultipartFile]);
+    }, [runUpload]);
 
     const addFiles = useCallback(async (picked: PickedFile[]) => {
         if (picked.length === 0) return;

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import * as Sentry from '@sentry/nextjs';
 import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/client';
 import { useInvalidateFileList } from '@/lib/hooks/useInvalidateFileList';
@@ -33,6 +32,7 @@ import {
     isAbortError,
     isExpiredUrlError,
     isNetworkError,
+    reportUploadFailure,
 } from '@/lib/upload/errors';
 
 const MULTIPART_THRESHOLD = 100 * 1024 * 1024; // 100MB
@@ -91,31 +91,6 @@ interface InternalUploadFile extends UploadFile {
 
 function randomId(): string {
     return Math.random().toString(36).substring(7);
-}
-
-/**
- * Terminal upload failures never reach the server — the failing legs are
- * browser→S3 presigned PUTs — so this client-side capture is their only
- * observer. Called after the abort/pause early-returns: only failures the
- * user actually sees as an error row get reported.
- */
-function reportUploadFailure(
-    error: unknown,
-    engine: 'single' | 'multipart',
-    uploadFile: InternalUploadFile,
-    fileId?: string
-): void {
-    Sentry.captureException(error, {
-        tags: { feature: 'upload', engine },
-        contexts: {
-            upload: {
-                fileId: fileId ?? uploadFile.fileId,
-                fileName: uploadFile.name,
-                sizeBytes: uploadFile.size,
-                batchId: uploadFile.batchId,
-            },
-        },
-    });
 }
 
 export function useUpload() {
@@ -448,7 +423,12 @@ export function useUpload() {
                     updateFile(uploadFile.id, { status: 'paused' });
                     return;
                 }
-                reportUploadFailure(error, 'multipart', uploadFile, fileId);
+                // Spread picks up the local fileId assigned after init —
+                // fresher than the stale uploadFile closure's.
+                reportUploadFailure(error, 'multipart', {
+                    ...uploadFile,
+                    fileId,
+                });
                 updateFile(uploadFile.id, {
                     status: 'error',
                     error:

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,12 +1,17 @@
 import * as Sentry from '@sentry/nextjs';
 
-// DSN presence is the deployment gate on the client: the DSN exists only in
-// Vercel's production/preview env tiers (see ASYMMETRY_ALLOWLIST in
-// scripts/check-vercel-env-parity.ts), so local dev, CI, and the e2e
-// production builds — which assert zero console errors — never initialize
-// Sentry. `process.env.VERCEL` can't gate here: it isn't NEXT_PUBLIC_-
-// prefixed, so it is never inlined into the client bundle.
-if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+// Same double gate as sentry.server.config.ts, client-flavored: the DSN
+// exists only in Vercel's production/preview env tiers (see
+// ASYMMETRY_ALLOWLIST in scripts/check-vercel-env-parity.ts), and
+// NEXT_PUBLIC_VERCEL_ENV — inlined on every deployment because the project
+// auto-exposes system env vars; `process.env.VERCEL` isn't NEXT_PUBLIC_-
+// prefixed so it can't gate here — keeps a stray .env.local DSN from turning
+// Sentry on in local dev, CI, and the e2e production builds, which assert
+// zero console errors. Raw process.env (not `@/lib/env`) is deliberate too:
+// the env proxy reads process.env[key] dynamically, which the bundler can't
+// inline into browser code — only literal process.env.NEXT_PUBLIC_*
+// expressions survive client bundling.
+if (process.env.NEXT_PUBLIC_VERCEL_ENV && process.env.NEXT_PUBLIC_SENTRY_DSN) {
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
         // Mirrors resolveRuntimeEnvironment(), which reads server-only vars

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -16,7 +16,16 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
         // Tracing is out of scope for #327 — errors and replay only.
         tracesSampleRate: 0,
         // Replay on-error only: the free plan has 50 replays/mo.
-        integrations: [Sentry.replayIntegration()],
+        // Masking/blocking off: replays exist to debug alpha testers'
+        // sessions, so visibility beats redaction — it's our own known
+        // testers, and the SDK keeps masking password inputs regardless.
+        integrations: [
+            Sentry.replayIntegration({
+                maskAllText: false,
+                maskAllInputs: false,
+                blockAllMedia: false,
+            }),
+        ],
         replaysSessionSampleRate: 0,
         replaysOnErrorSampleRate: 1.0,
     });

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,0 +1,27 @@
+import * as Sentry from '@sentry/nextjs';
+
+// DSN presence is the deployment gate on the client: the DSN exists only in
+// Vercel's production/preview env tiers (see ASYMMETRY_ALLOWLIST in
+// scripts/check-vercel-env-parity.ts), so local dev, CI, and the e2e
+// production builds — which assert zero console errors — never initialize
+// Sentry. `process.env.VERCEL` can't gate here: it isn't NEXT_PUBLIC_-
+// prefixed, so it is never inlined into the client bundle.
+if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+    Sentry.init({
+        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+        // Mirrors resolveRuntimeEnvironment(), which reads server-only vars
+        // and can't run in the browser: the Vercel tier when system env vars
+        // are exposed, else the build type.
+        environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV,
+        // Tracing is out of scope for #327 — errors and replay only.
+        tracesSampleRate: 0,
+        // Replay on-error only: the free plan has 50 replays/mo.
+        integrations: [Sentry.replayIntegration()],
+        replaysSessionSampleRate: 0,
+        replaysOnErrorSampleRate: 1.0,
+    });
+}
+
+// Inert while tracing is off; wired now so navigation instrumentation works
+// the day a sample rate is set.
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,15 @@
+import * as Sentry from '@sentry/nextjs';
+
+export async function register(): Promise<void> {
+    if (process.env.NEXT_RUNTIME === 'nodejs') {
+        await import('./sentry.server.config');
+    }
+    if (process.env.NEXT_RUNTIME === 'edge') {
+        await import('./sentry.edge.config');
+    }
+}
+
+// Captures errors from React Server Components and route handlers. tRPC
+// procedure errors never surface here — the fetch adapter catches them —
+// so those are reported from the logging middleware instead.
+export const onRequestError = Sentry.captureRequestError;

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -10,6 +10,7 @@ export async function register(): Promise<void> {
 }
 
 // Captures errors from React Server Components and route handlers. tRPC
-// procedure errors never surface here — the fetch adapter catches them —
-// so those are reported from the logging middleware instead.
+// errors never surface here — the fetch adapter catches them — so those are
+// reported from the logging middleware (procedure errors) and the adapter's
+// onError in app/api/trpc/[trpc]/route.ts (context-creation failures).
 export const onRequestError = Sentry.captureRequestError;

--- a/apps/web/lib/env/schema.ts
+++ b/apps/web/lib/env/schema.ts
@@ -26,4 +26,8 @@ export const serverSchema = z.object({
 // Client-side env vars (NEXT_PUBLIC_ prefix)
 export const clientSchema = z.object({
     NEXT_PUBLIC_APP_URL: z.string().url(),
+    // Deployed Vercel envs only (production/preview tiers) — presence is the
+    // gate that turns Sentry on, so local dev, CI, and e2e builds leave it
+    // unset. See instrumentation-client.ts.
+    NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
 });

--- a/apps/web/lib/env/schema.ts
+++ b/apps/web/lib/env/schema.ts
@@ -26,8 +26,9 @@ export const serverSchema = z.object({
 // Client-side env vars (NEXT_PUBLIC_ prefix)
 export const clientSchema = z.object({
     NEXT_PUBLIC_APP_URL: z.string().url(),
-    // Deployed Vercel envs only (production/preview tiers) — presence is the
-    // gate that turns Sentry on, so local dev, CI, and e2e builds leave it
-    // unset. See instrumentation-client.ts.
+    // Deployed Vercel envs only (production/preview tiers). Presence is half
+    // the gate that turns Sentry on — the other half is a deployment signal
+    // (VERCEL server-side, NEXT_PUBLIC_VERCEL_ENV client-side) — so local
+    // dev, CI, and e2e builds leave it unset. See instrumentation-client.ts.
     NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
 });

--- a/apps/web/lib/sentry/init.ts
+++ b/apps/web/lib/sentry/init.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/nextjs';
+
+import { env } from '@/lib/env';
+import { resolveRuntimeEnvironment } from '@/lib/env/runtime';
+
+/**
+ * Shared by the node and edge Sentry entry files — Next.js requires them to
+ * be separate modules, but the init itself is runtime-agnostic.
+ *
+ * Same deployment gate as Vercel Analytics (app/layout.tsx): off-Vercel
+ * production builds (CI, e2e) must never send events. The DSN check alone
+ * would do today — the DSN only exists in Vercel env tiers (see
+ * ASYMMETRY_ALLOWLIST in scripts/check-vercel-env-parity.ts) — but the
+ * VERCEL check keeps a stray .env.local DSN from turning Sentry on locally.
+ */
+export function initServerSentry(): void {
+    if (process.env.VERCEL && env.NEXT_PUBLIC_SENTRY_DSN) {
+        Sentry.init({
+            dsn: env.NEXT_PUBLIC_SENTRY_DSN,
+            environment: resolveRuntimeEnvironment(),
+            // Tracing is out of scope for #327 — errors only.
+            tracesSampleRate: 0,
+        });
+    }
+}

--- a/apps/web/lib/sentry/testing.ts
+++ b/apps/web/lib/sentry/testing.ts
@@ -1,0 +1,24 @@
+import { vi, type Mock } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMock = Mock<any>;
+
+export interface MockSentry {
+    captureException: AnyMock;
+}
+
+/**
+ * Vitest stub for `@sentry/nextjs`. Wire it through `vi.hoisted` with a
+ * dynamic import (same pattern as `@/server/lib/logger/testing`):
+ *
+ * ```ts
+ * const hoisted = await vi.hoisted(async () => {
+ *     const { createMockSentry } = await import('@/lib/sentry/testing');
+ *     return { sentry: createMockSentry() };
+ * });
+ * vi.mock('@sentry/nextjs', () => hoisted.sentry);
+ * ```
+ */
+export function createMockSentry(): MockSentry {
+    return { captureException: vi.fn() };
+}

--- a/apps/web/lib/trpc/error-reporting.test.ts
+++ b/apps/web/lib/trpc/error-reporting.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { TRPCClientError } from '@trpc/client';
 
-const hoisted = vi.hoisted(() => ({ captureException: vi.fn() }));
+const hoisted = await vi.hoisted(async () => {
+    const { createMockSentry } = await import('@/lib/sentry/testing');
+    return { sentry: createMockSentry() };
+});
 
-vi.mock('@sentry/nextjs', () => ({
-    captureException: hoisted.captureException,
-}));
+vi.mock('@sentry/nextjs', () => hoisted.sentry);
 
 import {
     isUnexpectedClientError,
@@ -50,15 +51,15 @@ describe('isUnexpectedClientError', () => {
 
 describe('reportUnexpectedClientError', () => {
     beforeEach(() => {
-        hoisted.captureException.mockClear();
+        hoisted.sentry.captureException.mockClear();
     });
 
     it('captures unexpected errors with the cache context', () => {
         const error = makeClientError({ code: 'INTERNAL_SERVER_ERROR' });
         reportUnexpectedClientError(error, { queryKey: ['files', 'list'] });
 
-        expect(hoisted.captureException).toHaveBeenCalledOnce();
-        const [captured, options] = hoisted.captureException.mock.calls[0]!;
+        expect(hoisted.sentry.captureException).toHaveBeenCalledOnce();
+        const [captured, options] = hoisted.sentry.captureException.mock.calls[0]!;
         expect(captured).toBe(error);
         expect(options.contexts.trpc).toEqual({
             queryKey: ['files', 'list'],
@@ -72,6 +73,6 @@ describe('reportUnexpectedClientError', () => {
         });
         reportUnexpectedClientError(error, { mutationKey: ['upload'] });
 
-        expect(hoisted.captureException).not.toHaveBeenCalled();
+        expect(hoisted.sentry.captureException).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/lib/trpc/error-reporting.test.ts
+++ b/apps/web/lib/trpc/error-reporting.test.ts
@@ -15,27 +15,34 @@ import {
 import { makeClientError } from './test-fixtures';
 
 describe('isUnexpectedClientError', () => {
-    it('returns false for domain errors', () => {
+    it('returns false for errors the server marked expected', () => {
         const error = makeClientError({
             code: 'PRECONDITION_FAILED',
             domainCode: 'QUOTA_EXCEEDED',
         });
         expect(isUnexpectedClientError(error)).toBe(false);
+
+        const authGate = makeClientError({
+            code: 'UNAUTHORIZED',
+            expected: true,
+        });
+        expect(isUnexpectedClientError(authGate)).toBe(false);
     });
 
-    it('returns false for input validation and auth-gate rejections', () => {
-        for (const code of ['BAD_REQUEST', 'UNAUTHORIZED', 'FORBIDDEN']) {
-            expect(isUnexpectedClientError(makeClientError({ code }))).toBe(
-                false
-            );
-        }
-    });
-
-    it('returns true for server 500s', () => {
+    it('returns true for server defects', () => {
         const error = makeClientError({
             code: 'INTERNAL_SERVER_ERROR',
             httpStatus: 500,
+            expected: false,
         });
+        expect(isUnexpectedClientError(error)).toBe(true);
+    });
+
+    it('returns true when the verdict is missing from the shape', () => {
+        // Defensive default: an error serialized without the `expected` bit
+        // is treated as a defect rather than silently dropped.
+        const error = makeClientError({ code: 'NOT_FOUND' });
+        delete (error.data as { expected?: boolean }).expected;
         expect(isUnexpectedClientError(error)).toBe(true);
     });
 
@@ -59,7 +66,8 @@ describe('reportUnexpectedClientError', () => {
         reportUnexpectedClientError(error, { queryKey: ['files', 'list'] });
 
         expect(hoisted.sentry.captureException).toHaveBeenCalledOnce();
-        const [captured, options] = hoisted.sentry.captureException.mock.calls[0]!;
+        const [captured, options] =
+            hoisted.sentry.captureException.mock.calls[0]!;
         expect(captured).toBe(error);
         expect(options.contexts.trpc).toEqual({
             queryKey: ['files', 'list'],

--- a/apps/web/lib/trpc/error-reporting.test.ts
+++ b/apps/web/lib/trpc/error-reporting.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { TRPCClientError } from '@trpc/client';
+
+const hoisted = vi.hoisted(() => ({ captureException: vi.fn() }));
+
+vi.mock('@sentry/nextjs', () => ({
+    captureException: hoisted.captureException,
+}));
+
+import {
+    isUnexpectedClientError,
+    reportUnexpectedClientError,
+} from './error-reporting';
+import { makeClientError } from './test-fixtures';
+
+describe('isUnexpectedClientError', () => {
+    it('returns false for domain errors', () => {
+        const error = makeClientError({
+            code: 'PRECONDITION_FAILED',
+            domainCode: 'QUOTA_EXCEEDED',
+        });
+        expect(isUnexpectedClientError(error)).toBe(false);
+    });
+
+    it('returns false for input validation and auth-gate rejections', () => {
+        for (const code of ['BAD_REQUEST', 'UNAUTHORIZED', 'FORBIDDEN']) {
+            expect(isUnexpectedClientError(makeClientError({ code }))).toBe(
+                false
+            );
+        }
+    });
+
+    it('returns true for server 500s', () => {
+        const error = makeClientError({
+            code: 'INTERNAL_SERVER_ERROR',
+            httpStatus: 500,
+        });
+        expect(isUnexpectedClientError(error)).toBe(true);
+    });
+
+    it('returns true for network failures that never reached the server', () => {
+        const error = TRPCClientError.from(new TypeError('Failed to fetch'));
+        expect(isUnexpectedClientError(error)).toBe(true);
+    });
+
+    it('returns true for non-tRPC errors', () => {
+        expect(isUnexpectedClientError(new Error('cache exploded'))).toBe(true);
+    });
+});
+
+describe('reportUnexpectedClientError', () => {
+    beforeEach(() => {
+        hoisted.captureException.mockClear();
+    });
+
+    it('captures unexpected errors with the cache context', () => {
+        const error = makeClientError({ code: 'INTERNAL_SERVER_ERROR' });
+        reportUnexpectedClientError(error, { queryKey: ['files', 'list'] });
+
+        expect(hoisted.captureException).toHaveBeenCalledOnce();
+        const [captured, options] = hoisted.captureException.mock.calls[0]!;
+        expect(captured).toBe(error);
+        expect(options.contexts.trpc).toEqual({
+            queryKey: ['files', 'list'],
+        });
+    });
+
+    it('skips expected errors', () => {
+        const error = makeClientError({
+            code: 'FORBIDDEN',
+            domainCode: 'TRIAL_EXPIRED',
+        });
+        reportUnexpectedClientError(error, { mutationKey: ['upload'] });
+
+        expect(hoisted.captureException).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/lib/trpc/error-reporting.ts
+++ b/apps/web/lib/trpc/error-reporting.ts
@@ -1,0 +1,38 @@
+import * as Sentry from '@sentry/nextjs';
+import { TRPCClientError } from '@trpc/client';
+
+/**
+ * Client-side mirror of `isUnexpectedTrpcError` (server/trpc/middleware/
+ * logging.ts), applied to the serialized shape the client sees: domain errors
+ * (`data.domainCode`), input validation (bare BAD_REQUEST), and auth-gate
+ * rejections (bare UNAUTHORIZED/FORBIDDEN) are expected product behavior.
+ * Everything else is worth a Sentry event — server 500s (captured on both
+ * sides on purpose: the server event has the real stack, the client event
+ * links the on-error session replay), network failures that never reached
+ * the server (`data` absent), and non-tRPC errors thrown inside the caches.
+ */
+export function isUnexpectedClientError(error: unknown): boolean {
+    if (!(error instanceof TRPCClientError)) return true;
+
+    const data = error.data as
+        | { code?: string; domainCode?: string }
+        | undefined;
+    if (!data) return true;
+    if (data.domainCode) return false;
+
+    return (
+        data.code !== 'BAD_REQUEST' &&
+        data.code !== 'UNAUTHORIZED' &&
+        data.code !== 'FORBIDDEN'
+    );
+}
+
+/** Capture an unexpected query/mutation failure with its cache context. */
+export function reportUnexpectedClientError(
+    error: unknown,
+    context: Record<string, unknown>
+): void {
+    if (!isUnexpectedClientError(error)) return;
+
+    Sentry.captureException(error, { contexts: { trpc: context } });
+}

--- a/apps/web/lib/trpc/error-reporting.ts
+++ b/apps/web/lib/trpc/error-reporting.ts
@@ -2,29 +2,23 @@ import * as Sentry from '@sentry/nextjs';
 import { TRPCClientError } from '@trpc/client';
 
 /**
- * Client-side mirror of `isUnexpectedTrpcError` (server/trpc/middleware/
- * logging.ts), applied to the serialized shape the client sees: domain errors
- * (`data.domainCode`), input validation (bare BAD_REQUEST), and auth-gate
- * rejections (bare UNAUTHORIZED/FORBIDDEN) are expected product behavior.
- * Everything else is worth a Sentry event — server 500s (captured on both
- * sides on purpose: the server event has the real stack, the client event
- * links the on-error session replay), network failures that never reached
- * the server (`data` absent), and non-tRPC errors thrown inside the caches.
+ * Reads the server's expected-vs-defect verdict off the serialized error
+ * shape (`data.expected`, set by server/trpc/error-formatter.ts from
+ * `isUnexpectedTrpcError`): expected product behavior — domain errors, input
+ * validation, deliberate bare throws like auth-gate rejections — is not
+ * reported. Everything else is worth a Sentry event — server 500s (captured
+ * on both sides on purpose: the server event has the real stack, the client
+ * event links the on-error session replay), network failures that never
+ * reached the server (`data` absent), and non-tRPC errors thrown inside the
+ * caches.
  */
 export function isUnexpectedClientError(error: unknown): boolean {
     if (!(error instanceof TRPCClientError)) return true;
 
-    const data = error.data as
-        | { code?: string; domainCode?: string }
-        | undefined;
+    const data = error.data as { expected?: boolean } | undefined;
     if (!data) return true;
-    if (data.domainCode) return false;
 
-    return (
-        data.code !== 'BAD_REQUEST' &&
-        data.code !== 'UNAUTHORIZED' &&
-        data.code !== 'FORBIDDEN'
-    );
+    return data.expected !== true;
 }
 
 /** Capture an unexpected query/mutation failure with its cache context. */

--- a/apps/web/lib/trpc/query-client.test.ts
+++ b/apps/web/lib/trpc/query-client.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it, vi } from 'vitest';
 
-const hoisted = vi.hoisted(() => ({ logErrorMock: vi.fn() }));
+const hoisted = vi.hoisted(() => ({
+    logErrorMock: vi.fn(),
+    captureExceptionMock: vi.fn(),
+}));
 
 vi.mock('@/lib/logger/client', () => ({
     log: { error: hoisted.logErrorMock },
 }));
 
+vi.mock('@sentry/nextjs', () => ({
+    captureException: hoisted.captureExceptionMock,
+}));
+
 import { QueryClient } from '@tanstack/react-query';
 import { makeQueryClient } from './query-client';
+import { makeClientError } from './test-fixtures';
 
 describe('makeQueryClient', () => {
     it('logs query errors via QueryCache.onError', async () => {
@@ -55,5 +63,48 @@ describe('makeQueryClient', () => {
             mutationKey: ['createThing'],
         });
         expect(msg).toBe('mutation failed');
+    });
+});
+
+describe('makeQueryClient Sentry reporting', () => {
+    it('captures unexpected mutation errors', async () => {
+        hoisted.captureExceptionMock.mockClear();
+        const client: QueryClient = makeQueryClient();
+
+        const error = makeClientError({ code: 'INTERNAL_SERVER_ERROR' });
+        await client
+            .getMutationCache()
+            .build(client, {
+                mutationKey: ['createThing'],
+                mutationFn: () => {
+                    throw error;
+                },
+                retry: false,
+            })
+            .execute(undefined)
+            .catch(() => {});
+
+        expect(hoisted.captureExceptionMock).toHaveBeenCalledOnce();
+    });
+
+    it('does not capture expected domain errors', async () => {
+        hoisted.captureExceptionMock.mockClear();
+        const client: QueryClient = makeQueryClient();
+
+        const error = makeClientError({
+            code: 'PRECONDITION_FAILED',
+            domainCode: 'QUOTA_EXCEEDED',
+        });
+        await client
+            .fetchQuery({
+                queryKey: ['quota'],
+                queryFn: () => {
+                    throw error;
+                },
+                retry: false,
+            })
+            .catch(() => {});
+
+        expect(hoisted.captureExceptionMock).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/lib/trpc/query-client.test.ts
+++ b/apps/web/lib/trpc/query-client.test.ts
@@ -1,17 +1,15 @@
 import { describe, expect, it, vi } from 'vitest';
 
-const hoisted = vi.hoisted(() => ({
-    logErrorMock: vi.fn(),
-    captureExceptionMock: vi.fn(),
-}));
+const hoisted = await vi.hoisted(async () => {
+    const { createMockSentry } = await import('@/lib/sentry/testing');
+    return { logErrorMock: vi.fn(), sentry: createMockSentry() };
+});
 
 vi.mock('@/lib/logger/client', () => ({
     log: { error: hoisted.logErrorMock },
 }));
 
-vi.mock('@sentry/nextjs', () => ({
-    captureException: hoisted.captureExceptionMock,
-}));
+vi.mock('@sentry/nextjs', () => hoisted.sentry);
 
 import { QueryClient } from '@tanstack/react-query';
 import { makeQueryClient } from './query-client';
@@ -68,7 +66,7 @@ describe('makeQueryClient', () => {
 
 describe('makeQueryClient Sentry reporting', () => {
     it('captures unexpected mutation errors', async () => {
-        hoisted.captureExceptionMock.mockClear();
+        hoisted.sentry.captureException.mockClear();
         const client: QueryClient = makeQueryClient();
 
         const error = makeClientError({ code: 'INTERNAL_SERVER_ERROR' });
@@ -84,11 +82,11 @@ describe('makeQueryClient Sentry reporting', () => {
             .execute(undefined)
             .catch(() => {});
 
-        expect(hoisted.captureExceptionMock).toHaveBeenCalledOnce();
+        expect(hoisted.sentry.captureException).toHaveBeenCalledOnce();
     });
 
     it('does not capture expected domain errors', async () => {
-        hoisted.captureExceptionMock.mockClear();
+        hoisted.sentry.captureException.mockClear();
         const client: QueryClient = makeQueryClient();
 
         const error = makeClientError({
@@ -105,6 +103,6 @@ describe('makeQueryClient Sentry reporting', () => {
             })
             .catch(() => {});
 
-        expect(hoisted.captureExceptionMock).not.toHaveBeenCalled();
+        expect(hoisted.sentry.captureException).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/lib/trpc/query-client.ts
+++ b/apps/web/lib/trpc/query-client.ts
@@ -1,7 +1,8 @@
 import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
 
 import { log } from '@/lib/logger/client';
-import { reportUnexpectedClientError } from '@/lib/trpc/error-reporting';
+
+import { reportUnexpectedClientError } from './error-reporting';
 
 export function makeQueryClient(): QueryClient {
     return new QueryClient({

--- a/apps/web/lib/trpc/query-client.ts
+++ b/apps/web/lib/trpc/query-client.ts
@@ -1,6 +1,7 @@
 import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
 
 import { log } from '@/lib/logger/client';
+import { reportUnexpectedClientError } from '@/lib/trpc/error-reporting';
 
 export function makeQueryClient(): QueryClient {
     return new QueryClient({
@@ -15,6 +16,9 @@ export function makeQueryClient(): QueryClient {
                     { err: error, queryKey: query.queryKey },
                     error.message || 'query error'
                 );
+                reportUnexpectedClientError(error, {
+                    queryKey: query.queryKey,
+                });
             },
         }),
         mutationCache: new MutationCache({
@@ -23,6 +27,9 @@ export function makeQueryClient(): QueryClient {
                     { err: error, mutationKey: mutation.options.mutationKey },
                     error.message || 'mutation error'
                 );
+                reportUnexpectedClientError(error, {
+                    mutationKey: mutation.options.mutationKey,
+                });
             },
         }),
     });

--- a/apps/web/lib/trpc/test-fixtures.ts
+++ b/apps/web/lib/trpc/test-fixtures.ts
@@ -17,6 +17,9 @@ export function makeClientError(opts: {
     domainCode?: DomainErrorCode;
     message?: string;
     httpStatus?: number;
+    // The server's expected-vs-defect verdict (error-formatter.ts). Domain
+    // errors are always expected, so it defaults on when domainCode is set.
+    expected?: boolean;
 }): ClientError {
     const message = opts.message ?? 'test';
     // JSON-RPC outer `code` is arbitrary for client-side tests — consumers
@@ -31,6 +34,7 @@ export function makeClientError(opts: {
                     httpStatus: opts.httpStatus ?? 403,
                     path: 'test',
                     domainCode: opts.domainCode,
+                    expected: opts.expected ?? opts.domainCode !== undefined,
                 } as ErrorShape['data'],
             } as ErrorShape,
         },

--- a/apps/web/lib/upload/errors.test.ts
+++ b/apps/web/lib/upload/errors.test.ts
@@ -1,6 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const hoisted = await vi.hoisted(async () => {
+    const { createMockSentry } = await import('@/lib/sentry/testing');
+    return { sentry: createMockSentry() };
+});
+
+vi.mock('@sentry/nextjs', () => hoisted.sentry);
+
 import { UploadHttpError, UploadNetworkError } from '@/lib/http/xhr';
-import { isExpiredUrlError, isNetworkError, isAbortError } from './errors';
+import { makeClientError } from '@/lib/trpc/test-fixtures';
+import {
+    isExpiredUrlError,
+    isNetworkError,
+    isAbortError,
+    reportUploadFailure,
+} from './errors';
 
 describe('isExpiredUrlError', () => {
     it('is true for a 403', () => {
@@ -36,5 +50,48 @@ describe('isAbortError', () => {
 
     it('is false for other errors', () => {
         expect(isAbortError(new Error('nope'))).toBe(false);
+    });
+});
+
+describe('reportUploadFailure', () => {
+    beforeEach(() => {
+        hoisted.sentry.captureException.mockClear();
+    });
+
+    const upload = {
+        name: 'photo.raw',
+        size: 1024,
+        fileId: 'f_1',
+        batchId: 'b_1',
+    };
+
+    it('captures S3/transport failures with upload context', () => {
+        const error = new UploadHttpError(500);
+        reportUploadFailure(error, 'multipart', upload);
+
+        expect(hoisted.sentry.captureException).toHaveBeenCalledOnce();
+        const [captured, options] =
+            hoisted.sentry.captureException.mock.calls[0]!;
+        expect(captured).toBe(error);
+        expect(options.tags).toEqual({
+            feature: 'upload',
+            engine: 'multipart',
+        });
+        expect(options.contexts.upload).toEqual({
+            fileId: 'f_1',
+            fileName: 'photo.raw',
+            sizeBytes: 1024,
+            batchId: 'b_1',
+        });
+    });
+
+    it('skips tRPC failures — the MutationCache capture owns those', () => {
+        const error = makeClientError({
+            code: 'PRECONDITION_FAILED',
+            domainCode: 'QUOTA_EXCEEDED',
+        });
+        reportUploadFailure(error, 'single', upload);
+
+        expect(hoisted.sentry.captureException).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/lib/upload/errors.ts
+++ b/apps/web/lib/upload/errors.ts
@@ -1,3 +1,6 @@
+import * as Sentry from '@sentry/nextjs';
+import { TRPCClientError } from '@trpc/client';
+
 import { UploadHttpError, UploadNetworkError } from '@/lib/http/xhr';
 
 /**
@@ -19,4 +22,40 @@ export function isNetworkError(error: unknown): boolean {
 /** The upload was aborted (pause or cancel), not a real failure. */
 export function isAbortError(error: unknown): boolean {
     return error instanceof DOMException && error.name === 'AbortError';
+}
+
+/** The slice of an upload row a failure report needs. */
+export interface UploadFailureInfo {
+    name: string;
+    size: number;
+    fileId?: string;
+    batchId?: string;
+}
+
+/**
+ * Report a terminal upload failure to Sentry. tRPC mutation failures inside
+ * the upload flow (init/confirm/sign-parts) already reach Sentry through the
+ * MutationCache capture (lib/trpc/query-client.ts), which also filters
+ * expected domain errors like quota-exceeded — skipping them here keeps
+ * "captured once" true. What remains is exactly what the server never sees:
+ * the browser→S3 presigned PUTs and local upload-store bookkeeping.
+ */
+export function reportUploadFailure(
+    error: unknown,
+    engine: 'single' | 'multipart',
+    upload: UploadFailureInfo
+): void {
+    if (error instanceof TRPCClientError) return;
+
+    Sentry.captureException(error, {
+        tags: { feature: 'upload', engine },
+        contexts: {
+            upload: {
+                fileId: upload.fileId,
+                fileName: upload.name,
+                sizeBytes: upload.size,
+                batchId: upload.batchId,
+            },
+        },
+    });
 }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -19,16 +19,18 @@ export default withSentryConfig(nextConfig, {
     org: process.env.SENTRY_ORG,
     project: process.env.SENTRY_PROJECT,
     authToken: process.env.SENTRY_AUTH_TOKEN,
-    // Only Vercel builds hold SENTRY_AUTH_TOKEN; disabling upload explicitly
-    // keeps local/CI builds from warning about a missing token on every run.
+    // Only Vercel builds hold SENTRY_AUTH_TOKEN. Disabling stops tokenless
+    // builds (local, CI, e2e) from generating source maps and injecting
+    // debug IDs at all — not just from uploading.
     sourcemaps: { disable: !process.env.SENTRY_AUTH_TOKEN },
-    // Upload logs are useful in Vercel build output; everywhere else the
-    // plugin is inert, so keep it quiet.
+    // Turbopack builds run Sentry's after-compile hook on every production
+    // build — there is no webpack plugin to omit — and off-Vercel it warns
+    // about the missing auth token. `silent` is what keeps local/CI build
+    // output clean; on Vercel it stays off so the sentry-cli upload report
+    // lands in the build log.
     silent: !process.env.VERCEL,
-    // Upload the full client bundle so prod stack traces resolve through
-    // framework/vendor frames, not just app code.
-    widenClientFileUpload: true,
-    // Strip Sentry SDK debug-logger code from the client bundle.
-    disableLogger: true,
     telemetry: false,
+    // webpack-only options (widenClientFileUpload, disableLogger) are
+    // deliberately absent: Next 16 builds with Turbopack, where they are
+    // no-ops — Turbopack uploads the full client bundle unconditionally.
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,3 +1,4 @@
+import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 import path from 'node:path';
 
@@ -14,4 +15,20 @@ const nextConfig: NextConfig = {
     },
 };
 
-export default nextConfig;
+export default withSentryConfig(nextConfig, {
+    org: process.env.SENTRY_ORG,
+    project: process.env.SENTRY_PROJECT,
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    // Only Vercel builds hold SENTRY_AUTH_TOKEN; disabling upload explicitly
+    // keeps local/CI builds from warning about a missing token on every run.
+    sourcemaps: { disable: !process.env.SENTRY_AUTH_TOKEN },
+    // Upload logs are useful in Vercel build output; everywhere else the
+    // plugin is inert, so keep it quiet.
+    silent: !process.env.VERCEL,
+    // Upload the full client bundle so prod stack traces resolve through
+    // framework/vendor frames, not just app code.
+    widenClientFileUpload: true,
+    // Strip Sentry SDK debug-logger code from the client bundle.
+    disableLogger: true,
+    telemetry: false,
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
         "@base-ui/react": "^1.0.0",
         "@nexus/db": "workspace:*",
         "@react-email/components": "^1.0.12",
+        "@sentry/nextjs": "^10.65.0",
         "@tanstack/react-form": "^1.27.7",
         "@tanstack/react-query": "^5.90.16",
         "@trpc/client": "^11.8.1",

--- a/apps/web/scripts/check-vercel-env-parity.ts
+++ b/apps/web/scripts/check-vercel-env-parity.ts
@@ -23,23 +23,43 @@ import { alerts, getWorkflowRunUrl } from '@/lib/alerts';
 const TIERS = ['production', 'preview', 'development'] as const;
 type Tier = (typeof TIERS)[number];
 
-// Keys allowed to exist in only some tiers, with the reason. Vars whose
-// *values* differ per tier (DATABASE_URL, S3_BUCKET, …) don't belong here —
-// their keys exist everywhere. Add entries when a tier legitimately gains a
-// scoped key (e.g. a Production-only live-mode Stripe credential once #213
-// lands).
-const ASYMMETRY_ALLOWLIST: Record<string, string> = {
+// Keys allowed to be absent from the listed tiers, with the reason. The
+// asymmetry is directional: the key going missing from a tier NOT listed in
+// `missingFrom` (e.g. a Sentry key deleted from production) is still drift
+// and still fails. Vars whose *values* differ per tier (DATABASE_URL,
+// S3_BUCKET, …) don't belong here — their keys exist everywhere. Add entries
+// when a tier legitimately gains a scoped key (e.g. a Production-only
+// live-mode Stripe credential once #213 lands).
+const ASYMMETRY_ALLOWLIST: Record<
+    string,
+    { missingFrom: readonly Tier[]; reason: string }
+> = {
     // lib/env/schema.ts: unset disables the Discord alert transport, which
     // is the intended state for preview/dev runtimes; CI injects its own.
-    DISCORD_ALERT_WEBHOOK_URL: 'prod-only by design',
+    DISCORD_ALERT_WEBHOOK_URL: {
+        missingFrom: ['preview', 'development'],
+        reason: 'prod-only by design',
+    },
     // Sentry is production+preview only: a key in the development tier would
     // flow into .env.local via env:pull and turn Sentry on for local/e2e
     // production builds (DSN) or make local builds attempt source-map upload
     // (auth token). See instrumentation-client.ts / next.config.ts.
-    NEXT_PUBLIC_SENTRY_DSN: 'production+preview only by design',
-    SENTRY_ORG: 'production+preview only by design',
-    SENTRY_PROJECT: 'production+preview only by design',
-    SENTRY_AUTH_TOKEN: 'production+preview only by design',
+    NEXT_PUBLIC_SENTRY_DSN: {
+        missingFrom: ['development'],
+        reason: 'production+preview only by design',
+    },
+    SENTRY_ORG: {
+        missingFrom: ['development'],
+        reason: 'production+preview only by design',
+    },
+    SENTRY_PROJECT: {
+        missingFrom: ['development'],
+        reason: 'production+preview only by design',
+    },
+    SENTRY_AUTH_TOKEN: {
+        missingFrom: ['development'],
+        reason: 'production+preview only by design',
+    },
 };
 
 const DEFAULT_PROJECT_ID = 'prj_RuKjFko6iKwbyyIy55HYL5S5AabG';
@@ -113,11 +133,15 @@ async function main(): Promise<void> {
     const failures: string[] = [];
     for (const key of allKeys) {
         const missing = TIERS.filter((tier) => !byTier.get(tier)!.has(key));
+        const allowlisted = ASYMMETRY_ALLOWLIST[key];
         if (missing.length === 0) {
             console.log(`  ✓ ${key}`);
-        } else if (key in ASYMMETRY_ALLOWLIST) {
+        } else if (
+            allowlisted &&
+            missing.every((tier) => allowlisted.missingFrom.includes(tier))
+        ) {
             console.log(
-                `  ~ ${key} missing in ${missing.join(', ')} (allowlisted: ${ASYMMETRY_ALLOWLIST[key]})`
+                `  ~ ${key} missing in ${missing.join(', ')} (allowlisted: ${allowlisted.reason})`
             );
         } else {
             const present = TIERS.filter((tier) => !missing.includes(tier));

--- a/apps/web/scripts/check-vercel-env-parity.ts
+++ b/apps/web/scripts/check-vercel-env-parity.ts
@@ -32,6 +32,14 @@ const ASYMMETRY_ALLOWLIST: Record<string, string> = {
     // lib/env/schema.ts: unset disables the Discord alert transport, which
     // is the intended state for preview/dev runtimes; CI injects its own.
     DISCORD_ALERT_WEBHOOK_URL: 'prod-only by design',
+    // Sentry is production+preview only: a key in the development tier would
+    // flow into .env.local via env:pull and turn Sentry on for local/e2e
+    // production builds (DSN) or make local builds attempt source-map upload
+    // (auth token). See instrumentation-client.ts / next.config.ts.
+    NEXT_PUBLIC_SENTRY_DSN: 'production+preview only by design',
+    SENTRY_ORG: 'production+preview only by design',
+    SENTRY_PROJECT: 'production+preview only by design',
+    SENTRY_AUTH_TOKEN: 'production+preview only by design',
 };
 
 const DEFAULT_PROJECT_ID = 'prj_RuKjFko6iKwbyyIy55HYL5S5AabG';

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,13 +1,4 @@
-import * as Sentry from '@sentry/nextjs';
+// Covers the edge runtime (proxy.ts).
+import { initServerSentry } from '@/lib/sentry/init';
 
-import { resolveRuntimeEnvironment } from '@/lib/env/runtime';
-
-// Covers the edge runtime (proxy.ts). Same gate as sentry.server.config.ts.
-if (process.env.VERCEL && process.env.NEXT_PUBLIC_SENTRY_DSN) {
-    Sentry.init({
-        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-        environment: resolveRuntimeEnvironment(),
-        // Tracing is out of scope for #327 — errors only.
-        tracesSampleRate: 0,
-    });
-}
+initServerSentry();

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/nextjs';
+
+import { resolveRuntimeEnvironment } from '@/lib/env/runtime';
+
+// Covers the edge runtime (proxy.ts). Same gate as sentry.server.config.ts.
+if (process.env.VERCEL && process.env.NEXT_PUBLIC_SENTRY_DSN) {
+    Sentry.init({
+        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+        environment: resolveRuntimeEnvironment(),
+        // Tracing is out of scope for #327 — errors only.
+        tracesSampleRate: 0,
+    });
+}

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,17 +1,3 @@
-import * as Sentry from '@sentry/nextjs';
+import { initServerSentry } from '@/lib/sentry/init';
 
-import { resolveRuntimeEnvironment } from '@/lib/env/runtime';
-
-// Same deployment gate as Vercel Analytics (app/layout.tsx): off-Vercel
-// production builds (CI, e2e) must never send events. The DSN check alone
-// would do today — the DSN only exists in Vercel env tiers (see
-// ASYMMETRY_ALLOWLIST in scripts/check-vercel-env-parity.ts) — but the
-// VERCEL check keeps a stray .env.local DSN from turning Sentry on locally.
-if (process.env.VERCEL && process.env.NEXT_PUBLIC_SENTRY_DSN) {
-    Sentry.init({
-        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-        environment: resolveRuntimeEnvironment(),
-        // Tracing is out of scope for #327 — errors only.
-        tracesSampleRate: 0,
-    });
-}
+initServerSentry();

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/nextjs';
+
+import { resolveRuntimeEnvironment } from '@/lib/env/runtime';
+
+// Same deployment gate as Vercel Analytics (app/layout.tsx): off-Vercel
+// production builds (CI, e2e) must never send events. The DSN check alone
+// would do today — the DSN only exists in Vercel env tiers (see
+// ASYMMETRY_ALLOWLIST in scripts/check-vercel-env-parity.ts) — but the
+// VERCEL check keeps a stray .env.local DSN from turning Sentry on locally.
+if (process.env.VERCEL && process.env.NEXT_PUBLIC_SENTRY_DSN) {
+    Sentry.init({
+        dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+        environment: resolveRuntimeEnvironment(),
+        // Tracing is out of scope for #327 — errors only.
+        tracesSampleRate: 0,
+    });
+}

--- a/apps/web/server/trpc/error-classification.ts
+++ b/apps/web/server/trpc/error-classification.ts
@@ -1,0 +1,40 @@
+import { isDomainError } from '@/server/errors';
+import type { TRPCError } from '@trpc/server';
+
+// Kept free of heavy imports (logger, Sentry): the error formatter runs in
+// every tRPC init path, including minimal test setups that stub nothing.
+
+export interface ZodLikeIssue {
+    path: PropertyKey[];
+    message: string;
+}
+
+/** Duck-type check for ZodError (avoids cross-module instanceof issues). */
+export function isZodError(
+    error: unknown
+): error is Error & { issues: ZodLikeIssue[] } {
+    return (
+        error instanceof Error &&
+        'issues' in error &&
+        Array.isArray((error as { issues: unknown }).issues)
+    );
+}
+
+/**
+ * Expected failures are product behavior, not defects: domain errors (typed
+ * 4xx-class outcomes), Zod input validation, and bare non-500 TRPCErrors —
+ * a TRPCError with no cause is always a deliberate throw (auth gates,
+ * admin.retry's NOT_FOUND/BAD_REQUEST), since a real exception arrives
+ * wrapped with `cause` set. Everything else is a bug Sentry should own.
+ * The verdict is serialized to the client as `data.expected` by
+ * server/trpc/error-formatter.ts, so the client-side filter
+ * (lib/trpc/error-reporting.ts) reads it instead of mirroring the policy.
+ */
+export function isUnexpectedTrpcError(error: TRPCError): boolean {
+    if (isDomainError(error.cause)) return false;
+    if (isZodError(error.cause)) return false;
+    if (error.cause === undefined && error.code !== 'INTERNAL_SERVER_ERROR') {
+        return false;
+    }
+    return true;
+}

--- a/apps/web/server/trpc/error-formatter.ts
+++ b/apps/web/server/trpc/error-formatter.ts
@@ -3,9 +3,12 @@ import type { TRPCDefaultErrorShape, TRPCError } from '@trpc/server';
 import type { DomainErrorCode } from '@/lib/errors/codes';
 import { isDomainError } from '@/server/errors';
 
+import { isUnexpectedTrpcError } from './error-classification';
+
 export type DomainErrorShape = TRPCDefaultErrorShape & {
     data: TRPCDefaultErrorShape['data'] & {
         domainCode: DomainErrorCode | undefined;
+        expected: boolean;
     };
 };
 
@@ -14,6 +17,10 @@ export type DomainErrorShape = TRPCDefaultErrorShape & {
  * frontend can discriminate errors sharing a tRPC code (e.g. FORBIDDEN vs
  * TRIAL_EXPIRED). Non-DomainError causes (bare TRPCError, ZodError, etc.)
  * produce `domainCode: undefined`.
+ *
+ * Also serializes the expected-vs-defect verdict (`expected`) — the single
+ * source the client-side Sentry filter (lib/trpc/error-reporting.ts) reads,
+ * instead of re-deriving the classification from the shape.
  */
 export function domainErrorFormatter({
     shape,
@@ -31,6 +38,7 @@ export function domainErrorFormatter({
         data: {
             ...shape.data,
             domainCode,
+            expected: !isUnexpectedTrpcError(error),
         },
     };
 }

--- a/apps/web/server/trpc/middleware/logging.test.ts
+++ b/apps/web/server/trpc/middleware/logging.test.ts
@@ -7,8 +7,12 @@ const config = { errorVerbosity: 'full' as 'minimal' | 'standard' | 'full' };
 
 const hoisted = await vi.hoisted(async () => {
     const { createMockLogger } = await import('@/server/lib/logger/testing');
-    return { logger: createMockLogger() };
+    return { logger: createMockLogger(), captureException: vi.fn() };
 });
+
+vi.mock('@sentry/nextjs', () => ({
+    captureException: hoisted.captureException,
+}));
 
 vi.mock('@/server/lib/logger', () => ({
     get errorVerbosity() {
@@ -18,10 +22,13 @@ vi.mock('@/server/lib/logger', () => ({
     logger: hoisted.logger,
 }));
 
+import { NotFoundError } from '@/server/errors';
 import {
     formatError,
     formatZodMessage,
+    isUnexpectedTrpcError,
     isZodError,
+    logRequest,
     trimStackTrace,
 } from './logging';
 
@@ -276,5 +283,119 @@ describe('formatError', () => {
 
             expect(result).toEqual({ code: 'BAD_REQUEST' });
         });
+    });
+});
+
+describe('isUnexpectedTrpcError', () => {
+    it('returns false for DomainError causes (expected 4xx-class outcomes)', () => {
+        const trpcError = new TRPCError({
+            code: 'NOT_FOUND',
+            cause: new NotFoundError('file', 'f_1'),
+        });
+        expect(isUnexpectedTrpcError(trpcError)).toBe(false);
+    });
+
+    it('returns false for Zod input-validation causes', () => {
+        const zodError = createZodError(z.string(), 42);
+        const trpcError = new TRPCError({
+            code: 'BAD_REQUEST',
+            cause: zodError,
+        });
+        expect(isUnexpectedTrpcError(trpcError)).toBe(false);
+    });
+
+    it('returns false for bare auth-gate rejections', () => {
+        expect(
+            isUnexpectedTrpcError(new TRPCError({ code: 'UNAUTHORIZED' }))
+        ).toBe(false);
+        expect(
+            isUnexpectedTrpcError(new TRPCError({ code: 'FORBIDDEN' }))
+        ).toBe(false);
+    });
+
+    it('returns true for auth codes carrying an unexpected cause', () => {
+        const trpcError = new TRPCError({
+            code: 'UNAUTHORIZED',
+            cause: new Error('session store exploded'),
+        });
+        expect(isUnexpectedTrpcError(trpcError)).toBe(true);
+    });
+
+    it('returns true for internal errors', () => {
+        const trpcError = new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            cause: new Error('boom'),
+        });
+        expect(isUnexpectedTrpcError(trpcError)).toBe(true);
+    });
+
+    it('returns true for bare TRPCErrors with non-gate codes', () => {
+        expect(isUnexpectedTrpcError(new TRPCError({ code: 'TIMEOUT' }))).toBe(
+            true
+        );
+    });
+});
+
+describe('emitEvent Sentry reporting', () => {
+    beforeEach(() => {
+        hoisted.captureException.mockClear();
+    });
+
+    function emitFailure(error: TRPCError): void {
+        const { emitEvent } = logRequest({
+            ctx: { session: { user: { id: 'user_1' } } },
+            path: 'files.list',
+            type: 'query',
+        });
+        emitEvent(false, error);
+    }
+
+    it('captures the original cause with correlation tags', () => {
+        const cause = new Error('boom');
+        emitFailure(new TRPCError({ code: 'INTERNAL_SERVER_ERROR', cause }));
+
+        expect(hoisted.captureException).toHaveBeenCalledOnce();
+        const [captured, options] = hoisted.captureException.mock.calls[0]!;
+        expect(captured).toBe(cause);
+        expect(options.tags).toMatchObject({
+            path: 'files.list',
+            userId: 'user_1',
+        });
+        expect(options.tags.requestId).toBeDefined();
+        expect(options.contexts.trpc).toMatchObject({
+            type: 'query',
+            code: 'INTERNAL_SERVER_ERROR',
+        });
+    });
+
+    it('captures the TRPCError itself when there is no cause', () => {
+        const error = new TRPCError({ code: 'TIMEOUT' });
+        emitFailure(error);
+
+        expect(hoisted.captureException).toHaveBeenCalledOnce();
+        expect(hoisted.captureException.mock.calls[0]![0]).toBe(error);
+    });
+
+    it('does not capture expected failures', () => {
+        emitFailure(
+            new TRPCError({
+                code: 'NOT_FOUND',
+                cause: new NotFoundError('file'),
+            })
+        );
+        emitFailure(new TRPCError({ code: 'UNAUTHORIZED' }));
+
+        expect(hoisted.captureException).not.toHaveBeenCalled();
+    });
+
+    it('does not capture successful events', () => {
+        const { emitEvent } = logRequest({
+            ctx: { session: null },
+            path: 'files.list',
+            type: 'query',
+        });
+        emitEvent(true);
+
+        expect(hoisted.captureException).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/server/trpc/middleware/logging.test.ts
+++ b/apps/web/server/trpc/middleware/logging.test.ts
@@ -22,11 +22,10 @@ vi.mock('@/server/lib/logger', () => ({
 }));
 
 import { NotFoundError } from '@/server/errors';
+import { isUnexpectedTrpcError, isZodError } from '../error-classification';
 import {
     formatError,
     formatZodMessage,
-    isUnexpectedTrpcError,
-    isZodError,
     logRequest,
     trimStackTrace,
 } from './logging';
@@ -328,10 +327,26 @@ describe('isUnexpectedTrpcError', () => {
         expect(isUnexpectedTrpcError(trpcError)).toBe(true);
     });
 
-    it('returns true for bare TRPCErrors with non-gate codes', () => {
-        expect(isUnexpectedTrpcError(new TRPCError({ code: 'TIMEOUT' }))).toBe(
-            true
-        );
+    it('returns false for bare deliberate throws (no cause)', () => {
+        expect(
+            isUnexpectedTrpcError(new TRPCError({ code: 'NOT_FOUND' }))
+        ).toBe(false);
+        expect(
+            isUnexpectedTrpcError(
+                new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: 'Only failed jobs can be retried',
+                })
+            )
+        ).toBe(false);
+    });
+
+    it('returns true for bare INTERNAL_SERVER_ERROR', () => {
+        expect(
+            isUnexpectedTrpcError(
+                new TRPCError({ code: 'INTERNAL_SERVER_ERROR' })
+            )
+        ).toBe(true);
     });
 });
 
@@ -354,7 +369,8 @@ describe('emitEvent Sentry reporting', () => {
         emitFailure(new TRPCError({ code: 'INTERNAL_SERVER_ERROR', cause }));
 
         expect(hoisted.sentry.captureException).toHaveBeenCalledOnce();
-        const [captured, options] = hoisted.sentry.captureException.mock.calls[0]!;
+        const [captured, options] =
+            hoisted.sentry.captureException.mock.calls[0]!;
         expect(captured).toBe(cause);
         expect(options.tags).toMatchObject({
             path: 'files.list',
@@ -368,7 +384,7 @@ describe('emitEvent Sentry reporting', () => {
     });
 
     it('captures the TRPCError itself when there is no cause', () => {
-        const error = new TRPCError({ code: 'TIMEOUT' });
+        const error = new TRPCError({ code: 'INTERNAL_SERVER_ERROR' });
         emitFailure(error);
 
         expect(hoisted.sentry.captureException).toHaveBeenCalledOnce();
@@ -383,6 +399,7 @@ describe('emitEvent Sentry reporting', () => {
             })
         );
         emitFailure(new TRPCError({ code: 'UNAUTHORIZED' }));
+        emitFailure(new TRPCError({ code: 'BAD_REQUEST' }));
 
         expect(hoisted.sentry.captureException).not.toHaveBeenCalled();
     });

--- a/apps/web/server/trpc/middleware/logging.test.ts
+++ b/apps/web/server/trpc/middleware/logging.test.ts
@@ -7,12 +7,11 @@ const config = { errorVerbosity: 'full' as 'minimal' | 'standard' | 'full' };
 
 const hoisted = await vi.hoisted(async () => {
     const { createMockLogger } = await import('@/server/lib/logger/testing');
-    return { logger: createMockLogger(), captureException: vi.fn() };
+    const { createMockSentry } = await import('@/lib/sentry/testing');
+    return { logger: createMockLogger(), sentry: createMockSentry() };
 });
 
-vi.mock('@sentry/nextjs', () => ({
-    captureException: hoisted.captureException,
-}));
+vi.mock('@sentry/nextjs', () => hoisted.sentry);
 
 vi.mock('@/server/lib/logger', () => ({
     get errorVerbosity() {
@@ -338,7 +337,7 @@ describe('isUnexpectedTrpcError', () => {
 
 describe('emitEvent Sentry reporting', () => {
     beforeEach(() => {
-        hoisted.captureException.mockClear();
+        hoisted.sentry.captureException.mockClear();
     });
 
     function emitFailure(error: TRPCError): void {
@@ -354,8 +353,8 @@ describe('emitEvent Sentry reporting', () => {
         const cause = new Error('boom');
         emitFailure(new TRPCError({ code: 'INTERNAL_SERVER_ERROR', cause }));
 
-        expect(hoisted.captureException).toHaveBeenCalledOnce();
-        const [captured, options] = hoisted.captureException.mock.calls[0]!;
+        expect(hoisted.sentry.captureException).toHaveBeenCalledOnce();
+        const [captured, options] = hoisted.sentry.captureException.mock.calls[0]!;
         expect(captured).toBe(cause);
         expect(options.tags).toMatchObject({
             path: 'files.list',
@@ -372,8 +371,8 @@ describe('emitEvent Sentry reporting', () => {
         const error = new TRPCError({ code: 'TIMEOUT' });
         emitFailure(error);
 
-        expect(hoisted.captureException).toHaveBeenCalledOnce();
-        expect(hoisted.captureException.mock.calls[0]![0]).toBe(error);
+        expect(hoisted.sentry.captureException).toHaveBeenCalledOnce();
+        expect(hoisted.sentry.captureException.mock.calls[0]![0]).toBe(error);
     });
 
     it('does not capture expected failures', () => {
@@ -385,7 +384,7 @@ describe('emitEvent Sentry reporting', () => {
         );
         emitFailure(new TRPCError({ code: 'UNAUTHORIZED' }));
 
-        expect(hoisted.captureException).not.toHaveBeenCalled();
+        expect(hoisted.sentry.captureException).not.toHaveBeenCalled();
     });
 
     it('does not capture successful events', () => {
@@ -396,6 +395,6 @@ describe('emitEvent Sentry reporting', () => {
         });
         emitEvent(true);
 
-        expect(hoisted.captureException).not.toHaveBeenCalled();
+        expect(hoisted.sentry.captureException).not.toHaveBeenCalled();
     });
 });

--- a/apps/web/server/trpc/middleware/logging.ts
+++ b/apps/web/server/trpc/middleware/logging.ts
@@ -1,7 +1,11 @@
 import * as Sentry from '@sentry/nextjs';
 
 import { errorVerbosity, isDev, logger } from '@/server/lib/logger';
-import { isDomainError } from '@/server/errors';
+import {
+    isUnexpectedTrpcError,
+    isZodError,
+    type ZodLikeIssue,
+} from '../error-classification';
 import type { TRPCError } from '@trpc/server';
 
 export interface RequestLogger {
@@ -36,22 +40,6 @@ interface WideEvent {
 }
 
 const MAX_CAUSE_DEPTH = 5;
-
-interface ZodLikeIssue {
-    path: PropertyKey[];
-    message: string;
-}
-
-/** Duck-type check for ZodError (avoids cross-module instanceof issues). */
-export function isZodError(
-    error: unknown
-): error is Error & { issues: ZodLikeIssue[] } {
-    return (
-        error instanceof Error &&
-        'issues' in error &&
-        Array.isArray((error as { issues: unknown }).issues)
-    );
-}
 
 /** Format ZodError issues into a compact summary message. */
 export function formatZodMessage(issues: ZodLikeIssue[]): string {
@@ -116,26 +104,6 @@ export function formatError(error: TRPCError): FormattedError {
     }
 
     return formatted;
-}
-
-/**
- * Expected failures are product behavior, not defects: domain errors (typed
- * 4xx-class outcomes), Zod input validation, and bare auth-gate rejections
- * (UNAUTHORIZED/FORBIDDEN thrown by protectedProcedure/adminProcedure with no
- * cause — e.g. an expired session hitting a protected endpoint). Everything
- * else is a bug Sentry should own. Mirrored client-side in
- * lib/trpc/error-reporting.ts against the serialized error shape.
- */
-export function isUnexpectedTrpcError(error: TRPCError): boolean {
-    if (isDomainError(error.cause)) return false;
-    if (isZodError(error.cause)) return false;
-    if (
-        (error.code === 'UNAUTHORIZED' || error.code === 'FORBIDDEN') &&
-        error.cause === undefined
-    ) {
-        return false;
-    }
-    return true;
 }
 
 /**

--- a/apps/web/server/trpc/middleware/logging.ts
+++ b/apps/web/server/trpc/middleware/logging.ts
@@ -1,4 +1,7 @@
+import * as Sentry from '@sentry/nextjs';
+
 import { errorVerbosity, isDev, logger } from '@/server/lib/logger';
+import { isDomainError } from '@/server/errors';
 import type { TRPCError } from '@trpc/server';
 
 export interface RequestLogger {
@@ -115,6 +118,50 @@ export function formatError(error: TRPCError): FormattedError {
     return formatted;
 }
 
+/**
+ * Expected failures are product behavior, not defects: domain errors (typed
+ * 4xx-class outcomes), Zod input validation, and bare auth-gate rejections
+ * (UNAUTHORIZED/FORBIDDEN thrown by protectedProcedure/adminProcedure with no
+ * cause — e.g. an expired session hitting a protected endpoint). Everything
+ * else is a bug Sentry should own. Mirrored client-side in
+ * lib/trpc/error-reporting.ts against the serialized error shape.
+ */
+export function isUnexpectedTrpcError(error: TRPCError): boolean {
+    if (isDomainError(error.cause)) return false;
+    if (isZodError(error.cause)) return false;
+    if (
+        (error.code === 'UNAUTHORIZED' || error.code === 'FORBIDDEN') &&
+        error.cause === undefined
+    ) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Send an unexpected failure to Sentry with the wide event's correlation ids.
+ * Captures `cause` when present — that's the original throw with the real
+ * stack; the TRPCError is just the transport wrapper.
+ */
+function reportUnexpectedError(error: TRPCError, event: WideEvent): void {
+    if (!isUnexpectedTrpcError(error)) return;
+
+    Sentry.captureException(error.cause ?? error, {
+        tags: {
+            requestId: event.requestId,
+            path: event.path,
+            ...(event.userId ? { userId: event.userId } : {}),
+        },
+        contexts: {
+            trpc: {
+                type: event.type,
+                durationMs: event.durationMs,
+                code: error.code,
+            },
+        },
+    });
+}
+
 function createRequestLogger(): {
     logger: RequestLogger;
     getTimings: () => Record<string, number>;
@@ -223,6 +270,7 @@ export function logRequest<
 
             if (error) {
                 event.error = formatError(error);
+                reportUnexpectedError(error, event);
             }
 
             if (ok) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "packageManager": "pnpm@10.26.2",
     "pnpm": {
         "onlyBuiltDependencies": [
+            "@sentry/cli",
             "sharp",
             "unrs-resolver"
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@react-email/components':
         specifier: ^1.0.12
         version: 1.0.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@sentry/nextjs':
+        specifier: ^10.65.0
+        version: 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.108.4(lightningcss@1.30.2))
       '@tanstack/react-form':
         specifier: ^1.27.7
         version: 1.27.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -52,10 +55,10 @@ importers:
         version: 11.8.1(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.8.1(@trpc/server@11.8.1(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.8.1(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@vercel/analytics':
         specifier: ^1.6.1
-        version: 1.6.1(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.6.1(next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       better-auth:
         specifier: ^1.4.10
-        version: 1.4.10(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(kysely@0.28.9)(postgres@3.4.7))(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.10(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -70,7 +73,7 @@ importers:
         version: 17.2.3
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(kysely@0.28.9)(postgres@3.4.7)
+        version: 0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.9)(postgres@3.4.7)
       idb:
         specifier: ^8.0.3
         version: 8.0.3
@@ -79,7 +82,7 @@ importers:
         version: 0.562.0(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -146,10 +149,10 @@ importers:
         version: 0.3.3
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.0(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 5.1.2(vite@7.3.0(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))
       eslint:
         specifier: ^9
         version: 9.39.2(jiti@2.6.1)
@@ -191,7 +194,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
 
   apps/worker:
     dependencies:
@@ -200,7 +203,7 @@ importers:
         version: link:../../packages/db
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(kysely@0.28.9)(postgres@3.4.7)
+        version: 0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.9)(postgres@3.4.7)
       postgres:
         specifier: ^3.4.7
         version: 3.4.7
@@ -216,7 +219,7 @@ importers:
         version: 20.19.27
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))
       eslint:
         specifier: ^9.28.0
         version: 9.39.2(jiti@2.6.1)
@@ -231,13 +234,13 @@ importers:
         version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
 
   packages/db:
     dependencies:
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(kysely@0.28.9)(postgres@3.4.7)
+        version: 0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.9)(postgres@3.4.7)
       postgres:
         specifier: ^3.4.7
         version: 3.4.7
@@ -247,7 +250,7 @@ importers:
         version: 20.19.27
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -262,7 +265,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
 
   packages/trpc-devtools:
     dependencies:
@@ -283,7 +286,7 @@ importers:
         version: 0.562.0(react@19.2.3)
       next:
         specifier: ^14.0.0 || ^15.0.0 || ^16.0.0
-        version: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@19.2.3)
@@ -311,7 +314,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))
       concurrently:
         specifier: ^9.0.0
         version: 9.2.1
@@ -341,17 +344,17 @@ importers:
         version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^6.1.0
-        version: 6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
       zod:
         specifier: ^4.2.0
         version: 4.2.1
     optionalDependencies:
       better-auth:
         specifier: ^1.0.0
-        version: 1.4.10(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(kysely@0.28.9)(postgres@3.4.7))(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.10(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))
 
   tooling/capture:
     dependencies:
@@ -363,7 +366,7 @@ importers:
         version: 17.2.3
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(kysely@0.28.9)(postgres@3.4.7)
+        version: 0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.9)(postgres@3.4.7)
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.1
@@ -389,6 +392,17 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.5.0':
+    resolution: {integrity: sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.15.0':
+    resolution: {integrity: sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.10.1':
+    resolution: {integrity: sha512-w2OWXR7FWrKqSziuE9+QclaZrStxO/8+OwbXM635s/zs0Eez1Qo3ivSPdB2WsaPY/iznKTytONPx/PitD7IXcA==}
 
   '@asamuzakjp/css-color@4.1.1':
     resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
@@ -1630,6 +1644,9 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -1716,6 +1733,48 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.9.0':
+    resolution: {integrity: sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.9.0':
+    resolution: {integrity: sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.9.0':
+    resolution: {integrity: sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -2004,6 +2063,24 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
+  '@rollup/plugin-commonjs@28.0.1':
+    resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.54.0':
     resolution: {integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==}
     cpu: [arm]
@@ -2244,6 +2321,165 @@ packages:
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser-utils@10.65.0':
+    resolution: {integrity: sha512-4J0mkfNJAGUOkpg1ZggizyftFTn9N20b+Jl87UnWsDUkNG0Ic1l/FIzMPTVxXrAnhBGu0ULO0TFWMoQ5s3QtZw==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.65.0':
+    resolution: {integrity: sha512-XUDDsx0qxzeIlcOu1fDEqTcDl0eiOqghsgV+ReuuNP4jYjZ9kUQxE3rXWM5mlT1pBi4VaQ4FHqvQZZrRXy+oDw==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
+    engines: {node: '>= 18'}
+
+  '@sentry/bundler-plugins@10.65.0':
+    resolution: {integrity: sha512-AYgv31l4wY/CwYAD/2Og59RT+TNjvhatcLOrEe5tFOpi9VcPAQ4xfPZIM6fXYGawofT52p6LhUECNSfNkNnc7Q==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      webpack:
+        optional: true
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/conventions@0.15.1':
+    resolution: {integrity: sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.65.0':
+    resolution: {integrity: sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.65.0':
+    resolution: {integrity: sha512-ck8h7wgd3F3bYNk0v1OgohmyLBeXcKxqlfBJRtQq4k6KZUq+pXimOG7ckNguVMYjCo3PEfuG+ckKc21yqotKug==}
+    engines: {node: '>=18'}
+
+  '@sentry/nextjs@10.65.0':
+    resolution: {integrity: sha512-9gDKQAAXcWh210fMI/ZNCa7940HYt7dGjnJVP0Tk9ozUR57W4C9vXvHJDTYPJrFxYxTHw7lwxWGervk8a6Tf4g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      next: ^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0
+
+  '@sentry/node-core@10.65.0':
+    resolution: {integrity: sha512-U01X9mPT+jZnsLPmPWfBU67Ka+t/Sdd9RGAuvGoKdrI6N47a/9PDkM9oCW+kj0fmZwogZHTgSnzJU5oi3pImgA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.65.0':
+    resolution: {integrity: sha512-t35dcdyksysVch/m/XdLgGJqGKJhr9eMD30Ctn3TeQ8yMB0wNXySfjPR5Yg93fpjmfaHtzc6iYIXRAvgNVfrvA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.65.0':
+    resolution: {integrity: sha512-8C6FPvm3XBvUrkM52dX3Gz0p2H0Ij8t4sahUA+GTiCz0WM0fnyPeQPGC/b6I4jamV9UXyCZRnE1UEEGCoD+c7A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/react@10.65.0':
+    resolution: {integrity: sha512-fvHxpuvid0wt9/1N3itcKDyKOjqmYHw3MBSt5Pki3Iz4CL2CmgQp9ZFv/CA7UhMnEvn2Gd+Qc2UKxujZWd8FLg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.65.0':
+    resolution: {integrity: sha512-A7X3RVk1Gk+knK8Ip/2EjejckNCLgCfRZo6eGlsy6qyz904KBpYmys1a0o7QkzFRjhIndjHAfcVxwt6jSLJlrQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.65.0':
+    resolution: {integrity: sha512-aW988CcQBNArbOMzOFOziipHz6uQyXSa4i5CPWsu+nhVPTJHafosi5Lv9n6NM/icDX5e23VdnX6mZd8SyJuo8A==}
+    engines: {node: '>=18'}
+
+  '@sentry/server-utils@10.65.0':
+    resolution: {integrity: sha512-80toEFD6s+0Le7jrYB6pHWLF703WSg0WyavAWqrBGWG8JkREHgedAxzFYgoY5GlMI756qk6Ea7UzhJTHd2zAXA==}
+    engines: {node: '>=18'}
+
+  '@sentry/vercel-edge@10.65.0':
+    resolution: {integrity: sha512-Z1sk2yBHrcsk/QMIzgMRTHitUN1zogzn5eQEc7umWmWwpP6zpDLMDxeeH2F1Cy2vzQFKa53PaWz7HXk4n617eg==}
+    engines: {node: '>=18'}
+
+  '@sentry/webpack-plugin@5.4.0':
+    resolution: {integrity: sha512-J3a0BvUZ75Qxy+v/Ap3Hx4ZEcSjlPHZ/jDtxdRhXQCyNeEb8xq0uUBTI9VLtGk2eNeNucOxOEJ5ngqdNjnEH/A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      webpack: '>=5.0.0'
 
   '@smithy/abort-controller@4.2.8':
     resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
@@ -2991,6 +3227,63 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3001,12 +3294,37 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -3078,6 +3396,10 @@ packages:
   ast-v8-to-istanbul@0.3.11:
     resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -3100,6 +3422,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.9.11:
     resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
@@ -3184,6 +3510,10 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -3237,6 +3567,13 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -3261,9 +3598,15 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -3446,8 +3789,16 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   drizzle-kit@0.31.8:
@@ -3570,6 +3921,10 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  enhanced-resolve@5.24.2:
+    resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
+    engines: {node: '>=10.13.0'}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -3596,6 +3951,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3756,6 +4114,10 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3786,13 +4148,24 @@ packages:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
 
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -3803,6 +4176,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -3836,6 +4213,9 @@ packages:
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-xml-parser@5.2.5:
     resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
@@ -3952,6 +4332,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -4025,6 +4409,10 @@ packages:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -4049,6 +4437,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-in-the-middle@3.3.1:
+    resolution: {integrity: sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==}
+    engines: {node: '>=18'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -4140,6 +4532,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -4202,6 +4597,10 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -4242,6 +4641,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4361,6 +4763,10 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
+    engines: {node: '>=6.11.5'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -4413,17 +4819,32 @@ packages:
   mdn-data@2.23.0:
     resolution: {integrity: sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -4435,8 +4856,58 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minimizer-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   motion-dom@12.29.2:
     resolution: {integrity: sha512-/k+NuycVV8pykxyiTCoFzIVLA95Nb1BFIVvfSu9L50/6K6qNeAYtkxXILy/LRutt7AzaYDc2myj0wkCVVYAPPA==}
@@ -4476,6 +4947,9 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -4505,6 +4979,15 @@ packages:
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -4587,6 +5070,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -4715,8 +5202,15 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -4812,6 +5306,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
@@ -4890,11 +5388,18 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4991,6 +5496,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stacktrace-parser@0.1.11:
+    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
+    engines: {node: '>=6'}
 
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
@@ -5128,6 +5637,15 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  terser@5.49.0:
+    resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -5178,6 +5696,9 @@ packages:
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -5244,6 +5765,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -5429,9 +5954,30 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
+    engines: {node: '>=10.13.0'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  webpack-sources@3.5.1:
+    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.108.4:
+    resolution: {integrity: sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -5440,6 +5986,9 @@ packages:
   whatwg-url@15.1.0:
     resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
     engines: {node: '>=20'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5532,6 +6081,30 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.5.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.15.0
+      es-module-lexer: 2.3.1
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.15.0':
+    dependencies:
+      '@types/estree': 1.0.8
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.10.1':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.15.0
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@asamuzakjp/css-color@4.1.1':
     dependencies:
@@ -6881,6 +7454,11 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
@@ -6942,6 +7520,49 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -7149,6 +7770,26 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
+  '@rollup/plugin-commonjs@28.0.1(rollup@4.60.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.60.3)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      is-reference: 1.2.1
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.3
+
+  '@rollup/pluginutils@5.4.0(rollup@4.60.3)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.3
+
   '@rollup/rollup-android-arm-eabi@4.54.0':
     optional: true
 
@@ -7296,6 +7937,208 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser-utils@10.65.0':
+    dependencies:
+      '@sentry/conventions': 0.15.1
+      '@sentry/core': 10.65.0
+
+  '@sentry/browser@10.65.0':
+    dependencies:
+      '@sentry/browser-utils': 10.65.0
+      '@sentry/conventions': 0.15.1
+      '@sentry/core': 10.65.0
+      '@sentry/feedback': 10.65.0
+      '@sentry/replay': 10.65.0
+      '@sentry/replay-canvas': 10.65.0
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/bundler-plugins@10.65.0(rollup@4.60.3)(webpack@5.108.4(lightningcss@1.30.2))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@sentry/cli': 2.58.6
+      '@sentry/core': 10.65.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.60.3
+      webpack: 5.108.4(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/conventions@0.15.1': {}
+
+  '@sentry/core@10.65.0':
+    dependencies:
+      '@sentry/conventions': 0.15.1
+
+  '@sentry/feedback@10.65.0':
+    dependencies:
+      '@sentry/core': 10.65.0
+
+  '@sentry/nextjs@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.108.4(lightningcss@1.30.2))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.60.3)
+      '@sentry/browser-utils': 10.65.0
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/conventions': 0.15.1
+      '@sentry/core': 10.65.0
+      '@sentry/node': 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/react': 10.65.0(react@19.2.3)
+      '@sentry/vercel-edge': 10.65.0
+      '@sentry/webpack-plugin': 5.4.0(rollup@4.60.3)(webpack@5.108.4(lightningcss@1.30.2))
+      next: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      rollup: 4.60.3
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
+  '@sentry/node-core@10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.15.1
+      '@sentry/core': 10.65.0
+      '@sentry/opentelemetry': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.15.1
+      '@sentry/core': 10.65.0
+      '@sentry/node-core': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.65.0
+      import-in-the-middle: 3.3.1
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.15.1
+      '@sentry/core': 10.65.0
+
+  '@sentry/react@10.65.0(react@19.2.3)':
+    dependencies:
+      '@sentry/browser': 10.65.0
+      '@sentry/conventions': 0.15.1
+      '@sentry/core': 10.65.0
+      react: 19.2.3
+
+  '@sentry/replay-canvas@10.65.0':
+    dependencies:
+      '@sentry/core': 10.65.0
+      '@sentry/replay': 10.65.0
+
+  '@sentry/replay@10.65.0':
+    dependencies:
+      '@sentry/browser-utils': 10.65.0
+      '@sentry/core': 10.65.0
+
+  '@sentry/server-utils@10.65.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.15.0
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.5.0
+      '@apm-js-collab/tracing-hooks': 0.10.1
+      '@sentry/conventions': 0.15.1
+      '@sentry/core': 10.65.0
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/vercel-edge@10.65.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@sentry/core': 10.65.0
+
+  '@sentry/webpack-plugin@5.4.0(rollup@4.60.3)(webpack@5.108.4(lightningcss@1.30.2))':
+    dependencies:
+      '@sentry/bundler-plugins': 10.65.0(rollup@4.60.3)(webpack@5.108.4(lightningcss@1.30.2))
+      webpack: 5.108.4(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
 
   '@smithy/abort-controller@4.2.8':
     dependencies:
@@ -8065,12 +8908,12 @@ snapshots:
     dependencies:
       valibot: 1.3.1(typescript@5.9.3)
 
-  '@vercel/analytics@1.6.1(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/analytics@1.6.1(next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -8078,11 +8921,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.0(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.0(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -8094,7 +8937,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -8105,13 +8948,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -8135,13 +8978,114 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
+
+  acorn-import-phases@1.0.4(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
 
+  acorn@8.17.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
+
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-keywords@5.1.0(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
+      fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
     dependencies:
@@ -8149,6 +9093,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -8247,6 +9198,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  astring@1.9.0: {}
+
   async-function@1.0.0: {}
 
   atomic-sleep@1.0.0: {}
@@ -8261,9 +9214,11 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.9.11: {}
 
-  better-auth@1.4.10(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(kysely@0.28.9)(postgres@3.4.7))(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.10(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.9)(postgres@3.4.7))(next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.10(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.2.1))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.10(@better-auth/core@1.4.10(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.2.1))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))
@@ -8279,11 +9234,11 @@ snapshots:
       zod: 4.2.1
     optionalDependencies:
       drizzle-kit: 0.31.8
-      drizzle-orm: 0.45.1(kysely@0.28.9)(postgres@3.4.7)
-      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      drizzle-orm: 0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.9)(postgres@3.4.7)
+      next: 16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
 
   better-call@1.1.7(zod@4.2.1):
     dependencies:
@@ -8308,6 +9263,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -8362,6 +9321,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chrome-trace-event@1.0.4: {}
+
+  cjs-module-lexer@2.2.0: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -8384,7 +9347,11 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  commander@2.20.3: {}
+
   commander@4.1.1: {}
+
+  commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
 
@@ -8556,7 +9523,11 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dotenv@16.6.1: {}
+
   dotenv@17.2.3: {}
+
+  dotenv@17.4.2: {}
 
   drizzle-kit@0.31.8:
     dependencies:
@@ -8567,8 +9538,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.1(kysely@0.28.9)(postgres@3.4.7):
+  drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.9)(postgres@3.4.7):
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       kysely: 0.28.9
       postgres: 3.4.7
 
@@ -8597,6 +9569,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  enhanced-resolve@5.24.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   entities@4.5.0: {}
 
@@ -8683,6 +9660,8 @@ snapshots:
       safe-array-concat: 1.1.3
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -8992,6 +9971,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -9052,11 +10036,19 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
 
+  estraverse@4.3.0: {}
+
   estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -9065,6 +10057,8 @@ snapshots:
   esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
+
+  events@3.3.0: {}
 
   expect-type@1.3.0: {}
 
@@ -9091,6 +10085,8 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.3: {}
 
   fast-xml-parser@5.2.5:
     dependencies:
@@ -9213,6 +10209,12 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globals@14.0.0: {}
 
   globals@16.4.0: {}
@@ -9286,6 +10288,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -9307,6 +10316,12 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-in-the-middle@3.3.1:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
 
@@ -9397,6 +10412,10 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -9464,6 +10483,12 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 20.19.27
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
   jiti@2.6.1: {}
 
   jose@6.1.3: {}
@@ -9511,6 +10536,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -9601,6 +10628,8 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  loader-runner@4.3.2: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -9645,14 +10674,24 @@ snapshots:
 
   mdn-data@2.23.0: {}
 
+  merge-stream@2.0.0: {}
+
   merge2@1.4.1: {}
+
+  meriyah@6.1.4: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.54.0: {}
+
   min-indent@1.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
 
   minimatch@3.1.2:
     dependencies:
@@ -9664,12 +10703,26 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minimizer-webpack-plugin@5.6.1(lightningcss@1.30.2)(webpack@5.108.4(lightningcss@1.30.2)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.49.0
+      webpack: 5.108.4(lightningcss@1.30.2)
+    optionalDependencies:
+      lightningcss: 1.30.2
+
+  minipass@7.1.3: {}
+
   mlly@1.8.0:
     dependencies:
       acorn: 8.15.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  module-details-from-path@1.0.4: {}
 
   motion-dom@12.29.2:
     dependencies:
@@ -9697,12 +10750,14 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  neo-async@2.6.2: {}
+
   next-themes@0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -9721,6 +10776,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.1
       '@next/swc-win32-arm64-msvc': 16.1.1
       '@next/swc-win32-x64-msvc': 16.1.1
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -9728,6 +10784,10 @@ snapshots:
       - babel-plugin-macros
 
   node-addon-api@7.1.1: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-releases@2.0.27: {}
 
@@ -9822,6 +10882,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.4
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -9945,11 +11010,15 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  progress@2.0.3: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   pump@3.0.3:
     dependencies:
@@ -10047,6 +11116,13 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   reselect@5.1.1: {}
 
@@ -10173,11 +11249,20 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
+
   secure-json-parse@4.1.0: {}
 
   selderee@0.11.0:
     dependencies:
       parseley: 0.12.1
+
+  semifies@1.0.0: {}
 
   semver@6.3.1: {}
 
@@ -10304,6 +11389,10 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
 
   standardwebhooks@1.0.0:
     dependencies:
@@ -10444,6 +11533,15 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tapable@2.3.3: {}
+
+  terser@5.49.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.17.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -10489,6 +11587,8 @@ snapshots:
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.19
+
+  tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
@@ -10573,6 +11673,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.7.1: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -10690,7 +11792,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite@6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -10703,9 +11805,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      terser: 5.49.0
       tsx: 4.21.0
 
-  vite@7.3.0(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite@7.3.0(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -10718,12 +11821,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      terser: 5.49.0
       tsx: 4.21.0
 
-  vitest@4.0.18(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.27)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -10740,9 +11844,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@20.19.27)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.49.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.27
       jsdom: 27.4.0
     transitivePeerDependencies:
@@ -10762,7 +11867,53 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  watchpack@2.5.2:
+    dependencies:
+      graceful-fs: 4.2.11
+
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1: {}
+
+  webpack-sources@3.5.1: {}
+
+  webpack@5.108.4(lightningcss@1.30.2):
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.2
+      es-module-lexer: 2.3.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(lightningcss@1.30.2)(webpack@5.108.4(lightningcss@1.30.2))
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   whatwg-mimetype@4.0.0: {}
 
@@ -10770,6 +11921,11 @@ snapshots:
     dependencies:
       tr46: 6.0.0
       webidl-conversions: 8.0.1
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
         "build": {
             "dependsOn": ["^build"],
             "outputs": [".next/**", "dist/**"],
-            "env": ["NEXT_PUBLIC_*"]
+            "env": ["NEXT_PUBLIC_*", "SENTRY_*"]
         },
         "dev": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
Closes #327 (part of #326).

## What

Wires `@sentry/nextjs` (v10.65) so prod errors stop dying in the tester's browser / 1h of Vercel stdout. 29 files, +763/−53 (excl. lockfile), purely additive.

- **Bootstrap**: `instrumentation.ts` (node/edge init via shared `lib/sentry/init.ts`, plus `onRequestError` for RSC errors), `instrumentation-client.ts`, `withSentryConfig` with source-map upload on Vercel builds only. Tracing out of scope (`tracesSampleRate: 0`).
- **Server**: `server/trpc/error-classification.ts` owns the expected-vs-defect verdict — domain errors, Zod input validation, and bare non-500 `TRPCError`s (a throw with no `cause` is always deliberate: auth gates, `admin.retry`'s NOT_FOUND) are product behavior; everything else is a bug. The wide-event middleware reports unexpected failures once, capturing `error.cause` (the real stack, not the wrapper), tagged `requestId`/`path`/`userId`. Context-creation failures (session store/DB outage — the one class no middleware runs for) are captured by the fetch adapter's `onError` in the tRPC route.
- **Client**: the server's verdict is serialized onto the error shape as `data.expected` by the error formatter, and the queryCache/mutationCache `onError` filter reads it — no client-side re-derivation to drift. Both error boundaries capture; `ClientErrorReporter` syncs `Sentry.setUser`; its window listeners stay pino-only since the SDK auto-instruments those (no double capture). Server 500s are captured on both sides on purpose: server has the stack, client links the replay.
- **Uploads**: terminal failures in both engines report with upload context (`engine`, `fileId`, `fileName`, `sizeBytes`, `batchId`); `TRPCClientError`s are skipped there because the MutationCache capture owns them (and domain-filters quota-exceeded etc.). Confirm/complete retries moved from an external `retryAsync` loop into TanStack Query's in-mutation `retry`, so a retried failure captures once, not once per attempt.
- **Replay**: on-error only (50/mo free quota), fully unmasked (`maskAllText`/`maskAllInputs`/`blockAllMedia` off) — replays exist to debug known alpha testers' sessions; the SDK still masks password inputs unconditionally.
- **Gating**: two factors on every runtime — DSN present AND a deployment signal (`VERCEL` server/edge, `NEXT_PUBLIC_VERCEL_ENV` client). The DSN lives only in Vercel production+preview env tiers, so local dev, CI, and the e2e prod builds (zero-console-error assertions) never initialize Sentry, and a stray `.env.local` DSN can't either. The env-parity allowlist is now directional: a key allowed missing from `development` still fails the check if it vanishes from `production`.
- **Env/ops**: `NEXT_PUBLIC_SENTRY_DSN` in `clientSchema`, `.env.example` documents all keys, `SENTRY_*` in turbo's build env keys, `LOG_ERROR_VERBOSITY=full` set in all three Vercel tiers (belt-and-braces stdout stacks).

**Turbopack, not webpack.** Issue #327's research assumed prod builds were webpack; Next 16 builds with Turbopack. An SDK-source audit traced every `withSentryConfig` option through the Turbopack pipeline: `widenClientFileUpload` and `disableLogger` were no-ops there (the latter also caused a doubled deprecation warning per build) and were removed; `sourcemaps.disable`, `silent`, and the `@sentry/cli` postinstall allowlist are all load-bearing on the Turbopack path and stay.

## Verification

- `pnpm check` + smoke green; 20+ new unit tests over classification (both sides), capture wiring, and upload reporting.
- Local prod build with a fake DSN pointed at a local listener: SDK initialized, uncaught error produced an error envelope with the right message and environment, exactly one on-error replay envelope followed. Without a DSN the SDK never initializes.
- Live on preview deployments (env vars set): uncaught browser error → issue with alert to Discord; a forced render error in `FileBrowser.tsx` (corrupted tRPC payload) → stack resolves to `components/dashboard/file-browser/FileBrowser.tsx` with source context; a forced server 500 (bogus multipart `uploadId` → S3 `NoSuchUpload`) → issue tagged `requestId`/`path`/`userId` with server frames resolved.
- Source-map upload confirmed twice over: sentry-cli upload report in the Vercel build log (~280 artifact pairs with debug IDs, client + server) and the releases API showing each build registered.

## Already live (no post-merge setup)

Sentry project `nexus-l4/javascript-nextjs`, Vercel env vars (production+preview), Discord integration + new-issue alert rule, and GitHub code mapping are configured and verified end-to-end from preview deploys. Merging deploys the same to production. Four test issues in Sentry can be resolved/deleted.

## Out of scope

PostHog (#328); tracing; a Sentry tunnel route for ad-blockers (testers are known; revisit if events go missing).