### PR TITLE
fix: recent uploads table — column sizing, middle truncation, mobile stacked list

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
@@ -15,8 +15,14 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { TablePagination } from '@/components/ui/table-pagination';
+import { MiddleTruncateName } from '@/components/dashboard/MiddleTruncateName';
 import { cn } from '@/lib/cn';
-import { formatBytes, formatDate, formatRelativeTime } from '@/lib/format';
+import {
+    formatBytes,
+    formatDate,
+    formatRelativeTime,
+    formatRelativeTimeCompact,
+} from '@/lib/format';
 import { useTRPC } from '@/lib/trpc/client';
 import { SPONSORED_DEFAULT_STORAGE_LIMIT } from '@/server/services/constants';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -129,93 +135,169 @@ export default function AdminInvitesPage() {
                         </p>
                     </CardContent>
                 ) : (
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Recipient</TableHead>
-                                <TableHead>Status</TableHead>
-                                <TableHead>Storage</TableHead>
-                                <TableHead>Created</TableHead>
-                                <TableHead>Expires</TableHead>
-                                <TableHead className="w-20" />
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
+                    <>
+                        {/* Below sm the 6-column table starves the recipient
+                            column (same class as #311/#339), so it renders as
+                            stacked rows: email full-width, metadata demoted
+                            to a second line. */}
+                        <ul className="divide-y sm:hidden">
                             {data.invites.map((invite) => (
-                                <TableRow key={invite.id}>
-                                    {/* w-full + max-w-0: emails are unbounded
-                                        and unbreakable — truncate instead of
-                                        growing the column (#311). */}
-                                    <TableCell
-                                        className={cn(
-                                            'w-full max-w-0 font-medium',
-                                            !invite.email &&
-                                                'text-muted-foreground italic'
-                                        )}
-                                    >
-                                        <span className="block truncate">
-                                            {invite.email ?? 'Link only'}
-                                        </span>
-                                    </TableCell>
-                                    <TableCell>
-                                        <InviteStatusBadge
-                                            status={invite.status}
-                                        />
-                                    </TableCell>
-                                    <TableCell className="text-muted-foreground">
-                                        {formatBytes(
-                                            invite.storageLimit ??
-                                                SPONSORED_DEFAULT_STORAGE_LIMIT
-                                        )}
-                                        {invite.storageLimit === null && (
-                                            <span className="text-muted-foreground/60">
-                                                {' '}
-                                                (default)
+                                <li
+                                    key={invite.id}
+                                    className="flex items-center gap-3 px-4 py-3"
+                                >
+                                    <div className="min-w-0 flex-1">
+                                        {invite.email ? (
+                                            <MiddleTruncateName
+                                                name={invite.email}
+                                                className="font-medium"
+                                            />
+                                        ) : (
+                                            <span className="block font-medium text-muted-foreground italic">
+                                                Link only
                                             </span>
                                         )}
-                                    </TableCell>
-                                    <TableCell className="text-muted-foreground">
-                                        {formatRelativeTime(invite.createdAt)}
-                                    </TableCell>
-                                    <TableCell className="text-muted-foreground">
-                                        {invite.expiresAt
-                                            ? formatDate(invite.expiresAt)
-                                            : '—'}
-                                    </TableCell>
-                                    <TableCell>
-                                        {invite.status === 'pending' && (
-                                            <div className="flex justify-end gap-1">
-                                                <CopyLinkButton
-                                                    token={invite.token}
-                                                />
-                                                <Button
-                                                    variant="ghost"
-                                                    size="icon"
-                                                    onClick={() =>
-                                                        revokeMutation.mutate({
-                                                            id: invite.id,
-                                                        })
-                                                    }
-                                                    disabled={
-                                                        revokeMutation.isPending
-                                                    }
-                                                    title="Revoke invite"
-                                                >
-                                                    {revokeMutation.isPending &&
-                                                    revokeMutation.variables
-                                                        ?.id === invite.id ? (
-                                                        <Loader2 className="h-4 w-4 animate-spin" />
-                                                    ) : (
-                                                        <Ban className="h-4 w-4" />
+                                        <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                                            {formatBytes(
+                                                invite.storageLimit ??
+                                                    SPONSORED_DEFAULT_STORAGE_LIMIT
+                                            )}
+                                            {invite.storageLimit === null &&
+                                                ' (default)'}
+                                            <span aria-hidden> · </span>
+                                            {formatRelativeTimeCompact(
+                                                invite.createdAt
+                                            )}
+                                            {invite.expiresAt && (
+                                                <>
+                                                    <span aria-hidden> · </span>
+                                                    expires{' '}
+                                                    {formatDate(
+                                                        invite.expiresAt
                                                     )}
-                                                </Button>
-                                            </div>
-                                        )}
-                                    </TableCell>
-                                </TableRow>
+                                                </>
+                                            )}
+                                        </p>
+                                    </div>
+                                    <InviteStatusBadge status={invite.status} />
+                                    {invite.status === 'pending' && (
+                                        <PendingInviteActions
+                                            token={invite.token}
+                                            onRevoke={() =>
+                                                revokeMutation.mutate({
+                                                    id: invite.id,
+                                                })
+                                            }
+                                            isRevoking={
+                                                revokeMutation.isPending &&
+                                                revokeMutation.variables?.id ===
+                                                    invite.id
+                                            }
+                                            disabled={revokeMutation.isPending}
+                                        />
+                                    )}
+                                </li>
                             ))}
-                        </TableBody>
-                    </Table>
+                        </ul>
+                        <div className="hidden sm:block">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Recipient</TableHead>
+                                        <TableHead>Status</TableHead>
+                                        <TableHead>Storage</TableHead>
+                                        <TableHead>Created</TableHead>
+                                        <TableHead>Expires</TableHead>
+                                        <TableHead className="w-20" />
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {data.invites.map((invite) => (
+                                        <TableRow key={invite.id}>
+                                            {/* w-full + max-w-0: emails are unbounded
+                                        and unbreakable — truncate instead of
+                                        growing the column (#311). Middle
+                                        truncation keeps the domain visible. */}
+                                            <TableCell
+                                                className={cn(
+                                                    'w-full max-w-0 font-medium',
+                                                    !invite.email &&
+                                                        'text-muted-foreground italic'
+                                                )}
+                                            >
+                                                {invite.email ? (
+                                                    <MiddleTruncateName
+                                                        name={invite.email}
+                                                    />
+                                                ) : (
+                                                    <span className="block truncate">
+                                                        Link only
+                                                    </span>
+                                                )}
+                                            </TableCell>
+                                            <TableCell>
+                                                <InviteStatusBadge
+                                                    status={invite.status}
+                                                />
+                                            </TableCell>
+                                            <TableCell className="text-muted-foreground">
+                                                {formatBytes(
+                                                    invite.storageLimit ??
+                                                        SPONSORED_DEFAULT_STORAGE_LIMIT
+                                                )}
+                                                {invite.storageLimit ===
+                                                    null && (
+                                                    <span className="text-muted-foreground/60">
+                                                        {' '}
+                                                        (default)
+                                                    </span>
+                                                )}
+                                            </TableCell>
+                                            <TableCell className="text-muted-foreground">
+                                                {formatRelativeTime(
+                                                    invite.createdAt
+                                                )}
+                                            </TableCell>
+                                            <TableCell className="text-muted-foreground">
+                                                {invite.expiresAt
+                                                    ? formatDate(
+                                                          invite.expiresAt
+                                                      )
+                                                    : '—'}
+                                            </TableCell>
+                                            <TableCell>
+                                                {invite.status ===
+                                                    'pending' && (
+                                                    <div className="flex justify-end">
+                                                        <PendingInviteActions
+                                                            token={invite.token}
+                                                            onRevoke={() =>
+                                                                revokeMutation.mutate(
+                                                                    {
+                                                                        id: invite.id,
+                                                                    }
+                                                                )
+                                                            }
+                                                            isRevoking={
+                                                                revokeMutation.isPending &&
+                                                                revokeMutation
+                                                                    .variables
+                                                                    ?.id ===
+                                                                    invite.id
+                                                            }
+                                                            disabled={
+                                                                revokeMutation.isPending
+                                                            }
+                                                        />
+                                                    </div>
+                                                )}
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    </>
                 )}
             </Card>
 
@@ -402,6 +484,42 @@ function InviteStatusBadge({ status }: { status: InviteStatus }) {
                 </Badge>
             );
     }
+}
+
+interface PendingInviteActionsProps {
+    token: string;
+    onRevoke: () => void;
+    /** This row's revoke is in flight (spinner). */
+    isRevoking: boolean;
+    disabled: boolean;
+}
+
+/* Copy-link + revoke for pending invites — shared by the table cell and the
+   stacked mobile rows. */
+function PendingInviteActions({
+    token,
+    onRevoke,
+    isRevoking,
+    disabled,
+}: PendingInviteActionsProps) {
+    return (
+        <div className="flex shrink-0 gap-1">
+            <CopyLinkButton token={token} />
+            <Button
+                variant="ghost"
+                size="icon"
+                onClick={onRevoke}
+                disabled={disabled}
+                title="Revoke invite"
+            >
+                {isRevoking ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                    <Ban className="h-4 w-4" />
+                )}
+            </Button>
+        </div>
+    );
 }
 
 function CopyLinkButton({ token }: { token: string }) {

--- a/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
@@ -15,6 +15,8 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { TablePagination } from '@/components/ui/table-pagination';
+import { ResponsiveRows } from '@/components/ui/responsive-rows';
+import { StackedList, StackedListRow } from '@/components/ui/stacked-list';
 import { MiddleTruncateName } from '@/components/dashboard/MiddleTruncateName';
 import { cn } from '@/lib/cn';
 import {
@@ -135,71 +137,69 @@ export default function AdminInvitesPage() {
                         </p>
                     </CardContent>
                 ) : (
-                    <>
-                        {/* Below sm the 6-column table starves the recipient
-                            column (same class as #311/#339), so it renders as
-                            stacked rows: email full-width, metadata demoted
-                            to a second line. */}
-                        <ul className="divide-y sm:hidden">
-                            {data.invites.map((invite) => (
-                                <li
-                                    key={invite.id}
-                                    className="flex items-center gap-3 px-4 py-3"
-                                >
-                                    <div className="min-w-0 flex-1">
-                                        {invite.email ? (
-                                            <MiddleTruncateName
-                                                name={invite.email}
-                                                className="font-medium"
-                                            />
-                                        ) : (
-                                            <span className="block font-medium text-muted-foreground italic">
-                                                Link only
-                                            </span>
-                                        )}
-                                        <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                                            {formatBytes(
-                                                invite.storageLimit ??
-                                                    SPONSORED_DEFAULT_STORAGE_LIMIT
-                                            )}
-                                            {invite.storageLimit === null &&
-                                                ' (default)'}
-                                            <span aria-hidden> · </span>
-                                            {formatRelativeTimeCompact(
+                    <ResponsiveRows
+                        mobile={
+                            <StackedList>
+                                {data.invites.map((invite) => (
+                                    <StackedListRow
+                                        key={invite.id}
+                                        className="px-4"
+                                        primary={
+                                            invite.email ? (
+                                                <MiddleTruncateName
+                                                    name={invite.email}
+                                                    className="font-medium"
+                                                />
+                                            ) : (
+                                                <span className="block font-medium text-muted-foreground italic">
+                                                    Link only
+                                                </span>
+                                            )
+                                        }
+                                        meta={[
+                                            `${formatBytes(invite.storageLimit ?? SPONSORED_DEFAULT_STORAGE_LIMIT)}${invite.storageLimit === null ? ' (default)' : ''}`,
+                                            formatRelativeTimeCompact(
                                                 invite.createdAt
-                                            )}
-                                            {invite.expiresAt && (
-                                                <>
-                                                    <span aria-hidden> · </span>
-                                                    expires{' '}
-                                                    {formatDate(
-                                                        invite.expiresAt
-                                                    )}
-                                                </>
-                                            )}
-                                        </p>
-                                    </div>
-                                    <InviteStatusBadge status={invite.status} />
-                                    {invite.status === 'pending' && (
-                                        <PendingInviteActions
-                                            token={invite.token}
-                                            onRevoke={() =>
-                                                revokeMutation.mutate({
-                                                    id: invite.id,
-                                                })
-                                            }
-                                            isRevoking={
-                                                revokeMutation.isPending &&
-                                                revokeMutation.variables?.id ===
-                                                    invite.id
-                                            }
-                                            disabled={revokeMutation.isPending}
-                                        />
-                                    )}
-                                </li>
-                            ))}
-                        </ul>
-                        <div className="hidden sm:block">
+                                            ),
+                                            invite.expiresAt
+                                                ? `expires ${formatDate(invite.expiresAt)}`
+                                                : null,
+                                        ]}
+                                        trailing={
+                                            <>
+                                                <InviteStatusBadge
+                                                    status={invite.status}
+                                                />
+                                                {invite.status ===
+                                                    'pending' && (
+                                                    <PendingInviteActions
+                                                        token={invite.token}
+                                                        onRevoke={() =>
+                                                            revokeMutation.mutate(
+                                                                {
+                                                                    id: invite.id,
+                                                                }
+                                                            )
+                                                        }
+                                                        isRevoking={
+                                                            revokeMutation.isPending &&
+                                                            revokeMutation
+                                                                .variables
+                                                                ?.id ===
+                                                                invite.id
+                                                        }
+                                                        disabled={
+                                                            revokeMutation.isPending
+                                                        }
+                                                    />
+                                                )}
+                                            </>
+                                        }
+                                    />
+                                ))}
+                            </StackedList>
+                        }
+                        desktop={
                             <Table>
                                 <TableHeader>
                                     <TableRow>
@@ -296,8 +296,8 @@ export default function AdminInvitesPage() {
                                     ))}
                                 </TableBody>
                             </Table>
-                        </div>
-                    </>
+                        }
+                    />
                 )}
             </Card>
 

--- a/apps/web/app/(dashboard)/dashboard/admin/jobs/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/jobs/page.tsx
@@ -13,6 +13,7 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { cn } from '@/lib/cn';
+import { formatRelativeTimeCompact } from '@/lib/format';
 import { useTRPC } from '@/lib/trpc/client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
@@ -121,70 +122,120 @@ export default function AdminJobsPage() {
                         <p className="text-muted-foreground">No jobs found</p>
                     </CardContent>
                 ) : (
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Type</TableHead>
-                                <TableHead>Status</TableHead>
-                                <TableHead>Created</TableHead>
-                                <TableHead>Duration</TableHead>
-                                <TableHead>Attempts</TableHead>
-                                <TableHead className="w-12" />
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
+                    <>
+                        {/* Below sm the 6-column table forces sideways
+                            scrolling (same class as #311/#339), so it renders
+                            as stacked rows: type full-width, metadata demoted
+                            to a second line. */}
+                        <ul className="divide-y sm:hidden">
                             {data.jobs.map((job) => (
-                                <TableRow key={job.id}>
-                                    <TableCell className="font-medium font-mono text-sm">
-                                        {job.type}
-                                    </TableCell>
-                                    <TableCell>
-                                        <JobStatusBadge status={job.status} />
-                                    </TableCell>
-                                    <TableCell className="text-muted-foreground">
-                                        {formatDistanceToNow(
-                                            new Date(job.createdAt),
-                                            { addSuffix: true }
-                                        )}
-                                    </TableCell>
-                                    <TableCell className="text-muted-foreground">
-                                        {formatDuration(
-                                            job.startedAt,
-                                            job.completedAt
-                                        )}
-                                    </TableCell>
-                                    <TableCell className="text-muted-foreground">
-                                        {job.attempts}
-                                    </TableCell>
-                                    <TableCell>
-                                        {job.status === 'failed' && (
-                                            <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                onClick={() =>
-                                                    retryMutation.mutate({
-                                                        id: job.id,
-                                                    })
-                                                }
-                                                disabled={
-                                                    retryMutation.isPending
-                                                }
-                                                title="Retry job"
-                                            >
-                                                {retryMutation.isPending &&
+                                <li
+                                    key={job.id}
+                                    className="flex items-center gap-3 px-4 py-3"
+                                >
+                                    <div className="min-w-0 flex-1">
+                                        <p className="truncate font-mono text-sm font-medium">
+                                            {job.type}
+                                        </p>
+                                        <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                                            {formatRelativeTimeCompact(
+                                                job.createdAt
+                                            )}
+                                            <span aria-hidden> · </span>
+                                            {formatDuration(
+                                                job.startedAt,
+                                                job.completedAt
+                                            )}
+                                            <span aria-hidden> · </span>
+                                            {job.attempts} attempt
+                                            {job.attempts === 1 ? '' : 's'}
+                                        </p>
+                                    </div>
+                                    <JobStatusBadge status={job.status} />
+                                    {job.status === 'failed' && (
+                                        <RetryJobButton
+                                            onRetry={() =>
+                                                retryMutation.mutate({
+                                                    id: job.id,
+                                                })
+                                            }
+                                            isRetrying={
+                                                retryMutation.isPending &&
                                                 retryMutation.variables?.id ===
-                                                    job.id ? (
-                                                    <Loader2 className="h-4 w-4 animate-spin" />
-                                                ) : (
-                                                    <RotateCw className="h-4 w-4" />
-                                                )}
-                                            </Button>
-                                        )}
-                                    </TableCell>
-                                </TableRow>
+                                                    job.id
+                                            }
+                                            disabled={retryMutation.isPending}
+                                        />
+                                    )}
+                                </li>
                             ))}
-                        </TableBody>
-                    </Table>
+                        </ul>
+                        <div className="hidden sm:block">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Type</TableHead>
+                                        <TableHead>Status</TableHead>
+                                        <TableHead>Created</TableHead>
+                                        <TableHead>Duration</TableHead>
+                                        <TableHead>Attempts</TableHead>
+                                        <TableHead className="w-12" />
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {data.jobs.map((job) => (
+                                        <TableRow key={job.id}>
+                                            <TableCell className="font-medium font-mono text-sm">
+                                                {job.type}
+                                            </TableCell>
+                                            <TableCell>
+                                                <JobStatusBadge
+                                                    status={job.status}
+                                                />
+                                            </TableCell>
+                                            <TableCell className="text-muted-foreground">
+                                                {formatDistanceToNow(
+                                                    new Date(job.createdAt),
+                                                    { addSuffix: true }
+                                                )}
+                                            </TableCell>
+                                            <TableCell className="text-muted-foreground">
+                                                {formatDuration(
+                                                    job.startedAt,
+                                                    job.completedAt
+                                                )}
+                                            </TableCell>
+                                            <TableCell className="text-muted-foreground">
+                                                {job.attempts}
+                                            </TableCell>
+                                            <TableCell>
+                                                {job.status === 'failed' && (
+                                                    <RetryJobButton
+                                                        onRetry={() =>
+                                                            retryMutation.mutate(
+                                                                {
+                                                                    id: job.id,
+                                                                }
+                                                            )
+                                                        }
+                                                        isRetrying={
+                                                            retryMutation.isPending &&
+                                                            retryMutation
+                                                                .variables
+                                                                ?.id === job.id
+                                                        }
+                                                        disabled={
+                                                            retryMutation.isPending
+                                                        }
+                                                    />
+                                                )}
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    </>
                 )}
             </Card>
 
@@ -233,6 +284,38 @@ function StatusCounts({ counts }: { counts?: Record<JobStatus, number> }) {
                 </Card>
             ))}
         </div>
+    );
+}
+
+interface RetryJobButtonProps {
+    onRetry: () => void;
+    /** This row's retry is in flight (spinner). */
+    isRetrying: boolean;
+    disabled: boolean;
+}
+
+/* Retry for failed jobs — shared by the table cell and the stacked mobile
+   rows. */
+function RetryJobButton({
+    onRetry,
+    isRetrying,
+    disabled,
+}: RetryJobButtonProps) {
+    return (
+        <Button
+            variant="ghost"
+            size="icon"
+            onClick={onRetry}
+            disabled={disabled}
+            title="Retry job"
+            className="shrink-0"
+        >
+            {isRetrying ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+                <RotateCw className="h-4 w-4" />
+            )}
+        </Button>
     );
 }
 

--- a/apps/web/app/(dashboard)/dashboard/admin/jobs/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/jobs/page.tsx
@@ -20,6 +20,8 @@ import { formatDistanceToNow } from 'date-fns';
 import { Loader2, RotateCw } from 'lucide-react';
 import type { Job } from '@nexus/db/repo/jobs';
 import { TablePagination } from '@/components/ui/table-pagination';
+import { ResponsiveRows } from '@/components/ui/responsive-rows';
+import { StackedList, StackedListRow } from '@/components/ui/stacked-list';
 
 type JobStatus = Job['status'];
 
@@ -122,55 +124,58 @@ export default function AdminJobsPage() {
                         <p className="text-muted-foreground">No jobs found</p>
                     </CardContent>
                 ) : (
-                    <>
-                        {/* Below sm the 6-column table forces sideways
-                            scrolling (same class as #311/#339), so it renders
-                            as stacked rows: type full-width, metadata demoted
-                            to a second line. */}
-                        <ul className="divide-y sm:hidden">
-                            {data.jobs.map((job) => (
-                                <li
-                                    key={job.id}
-                                    className="flex items-center gap-3 px-4 py-3"
-                                >
-                                    <div className="min-w-0 flex-1">
-                                        <p className="truncate font-mono text-sm font-medium">
-                                            {job.type}
-                                        </p>
-                                        <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                                            {formatRelativeTimeCompact(
+                    <ResponsiveRows
+                        mobile={
+                            <StackedList>
+                                {data.jobs.map((job) => (
+                                    <StackedListRow
+                                        key={job.id}
+                                        className="px-4"
+                                        primary={
+                                            <p className="truncate font-mono text-sm font-medium">
+                                                {job.type}
+                                            </p>
+                                        }
+                                        meta={[
+                                            formatRelativeTimeCompact(
                                                 job.createdAt
-                                            )}
-                                            <span aria-hidden> · </span>
-                                            {formatDuration(
+                                            ),
+                                            formatDuration(
                                                 job.startedAt,
                                                 job.completedAt
-                                            )}
-                                            <span aria-hidden> · </span>
-                                            {job.attempts} attempt
-                                            {job.attempts === 1 ? '' : 's'}
-                                        </p>
-                                    </div>
-                                    <JobStatusBadge status={job.status} />
-                                    {job.status === 'failed' && (
-                                        <RetryJobButton
-                                            onRetry={() =>
-                                                retryMutation.mutate({
-                                                    id: job.id,
-                                                })
-                                            }
-                                            isRetrying={
-                                                retryMutation.isPending &&
-                                                retryMutation.variables?.id ===
-                                                    job.id
-                                            }
-                                            disabled={retryMutation.isPending}
-                                        />
-                                    )}
-                                </li>
-                            ))}
-                        </ul>
-                        <div className="hidden sm:block">
+                                            ),
+                                            `${job.attempts} attempt${job.attempts === 1 ? '' : 's'}`,
+                                        ]}
+                                        trailing={
+                                            <>
+                                                <JobStatusBadge
+                                                    status={job.status}
+                                                />
+                                                {job.status === 'failed' && (
+                                                    <RetryJobButton
+                                                        onRetry={() =>
+                                                            retryMutation.mutate(
+                                                                { id: job.id }
+                                                            )
+                                                        }
+                                                        isRetrying={
+                                                            retryMutation.isPending &&
+                                                            retryMutation
+                                                                .variables
+                                                                ?.id === job.id
+                                                        }
+                                                        disabled={
+                                                            retryMutation.isPending
+                                                        }
+                                                    />
+                                                )}
+                                            </>
+                                        }
+                                    />
+                                ))}
+                            </StackedList>
+                        }
+                        desktop={
                             <Table>
                                 <TableHeader>
                                     <TableRow>
@@ -234,8 +239,8 @@ export default function AdminJobsPage() {
                                     ))}
                                 </TableBody>
                             </Table>
-                        </div>
-                    </>
+                        }
+                    />
                 )}
             </Card>
 

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -14,6 +14,8 @@ import {
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ResponsiveRows } from '@/components/ui/responsive-rows';
+import { StackedList, StackedListRow } from '@/components/ui/stacked-list';
 import { useSession } from '@/lib/auth/client';
 import { useTRPC } from '@/lib/trpc/client';
 import {
@@ -153,110 +155,107 @@ export default function DashboardPage() {
                                 ))}
                             </div>
                         ) : filesData?.files && filesData.files.length > 0 ? (
-                            <>
-                                {/* Below sm a 4-column table can't give the
-                                    name meaningful width, so the same data
-                                    renders as stacked rows: name on its own
-                                    line, metadata demoted to a second line.
-                                    This list must precede the table in the
-                                    DOM — the mobile-overflow spec asserts on
-                                    getByText(...).first(), which has to hit
-                                    the visible copy at 390px. */}
-                                <ul className="divide-y sm:hidden">
-                                    {filesData.files.map((file) => (
-                                        <li
-                                            key={file.id}
-                                            className="flex items-center gap-3 py-3"
-                                        >
-                                            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-muted">
-                                                <FileIcon className="h-4 w-4 text-muted-foreground" />
-                                            </div>
-                                            <div className="min-w-0 flex-1">
-                                                <MiddleTruncateName
-                                                    name={file.name}
-                                                    className="font-medium"
-                                                />
-                                                <div className="mt-0.5 flex items-center gap-1.5 text-xs whitespace-nowrap text-muted-foreground">
-                                                    <span>
-                                                        {formatBytes(file.size)}
-                                                    </span>
-                                                    <span aria-hidden>·</span>
-                                                    <span>
-                                                        {formatRelativeTimeCompact(
-                                                            file.createdAt
-                                                        )}
-                                                    </span>
-                                                </div>
-                                            </div>
-                                            <MobileFileStatus
-                                                status={file.status}
+                            <ResponsiveRows
+                                mobile={
+                                    <StackedList>
+                                        {filesData.files.map((file) => (
+                                            <StackedListRow
+                                                key={file.id}
+                                                leading={
+                                                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-muted">
+                                                        <FileIcon className="h-4 w-4 text-muted-foreground" />
+                                                    </div>
+                                                }
+                                                primary={
+                                                    <MiddleTruncateName
+                                                        name={file.name}
+                                                        className="font-medium"
+                                                    />
+                                                }
+                                                meta={[
+                                                    formatBytes(file.size),
+                                                    formatRelativeTimeCompact(
+                                                        file.createdAt
+                                                    ),
+                                                ]}
+                                                trailing={
+                                                    <MobileFileStatus
+                                                        status={file.status}
+                                                    />
+                                                }
                                             />
-                                        </li>
-                                    ))}
-                                </ul>
-                                <div className="hidden overflow-x-auto sm:block">
-                                    <table className="w-full">
-                                        <thead>
-                                            <tr className="border-b text-left text-xs text-muted-foreground">
-                                                <th className="pr-4 pb-3 font-medium">
-                                                    Name
-                                                </th>
-                                                <th className="pr-4 pb-3 text-right font-medium">
-                                                    Size
-                                                </th>
-                                                <th className="pr-4 pb-3 font-medium">
-                                                    Uploaded
-                                                </th>
-                                                <th className="pb-3 text-right font-medium">
-                                                    Status
-                                                </th>
-                                            </tr>
-                                        </thead>
-                                        <tbody className="divide-y">
-                                            {filesData.files.map((file) => (
-                                                <tr
-                                                    key={file.id}
-                                                    className="group"
-                                                >
-                                                    {/* w-full + max-w-0: the name
+                                        ))}
+                                    </StackedList>
+                                }
+                                desktop={
+                                    <div className="overflow-x-auto">
+                                        <table className="w-full">
+                                            <thead>
+                                                <tr className="border-b text-left text-xs text-muted-foreground">
+                                                    <th className="pr-4 pb-3 font-medium">
+                                                        Name
+                                                    </th>
+                                                    <th className="pr-4 pb-3 text-right font-medium">
+                                                        Size
+                                                    </th>
+                                                    <th className="pr-4 pb-3 font-medium">
+                                                        Uploaded
+                                                    </th>
+                                                    <th className="pb-3 text-right font-medium">
+                                                        Status
+                                                    </th>
+                                                </tr>
+                                            </thead>
+                                            <tbody className="divide-y">
+                                                {filesData.files.map((file) => (
+                                                    <tr
+                                                        key={file.id}
+                                                        className="group"
+                                                    >
+                                                        {/* w-full + max-w-0: the name
                                                     column absorbs leftover
                                                     width and its content
                                                     truncates instead of
                                                     growing the column to the
                                                     full string (#311). */}
-                                                    <td className="w-full max-w-0 py-3 pr-4">
-                                                        <div className="flex items-center gap-3">
-                                                            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-muted">
-                                                                <FileIcon className="h-4 w-4 text-muted-foreground" />
+                                                        <td className="w-full max-w-0 py-3 pr-4">
+                                                            <div className="flex items-center gap-3">
+                                                                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-muted">
+                                                                    <FileIcon className="h-4 w-4 text-muted-foreground" />
+                                                                </div>
+                                                                <MiddleTruncateName
+                                                                    name={
+                                                                        file.name
+                                                                    }
+                                                                    className="flex-1 font-medium"
+                                                                />
                                                             </div>
-                                                            <MiddleTruncateName
-                                                                name={file.name}
-                                                                className="flex-1 font-medium"
-                                                            />
-                                                        </div>
-                                                    </td>
-                                                    <td className="py-3 pr-4 text-right text-sm whitespace-nowrap tabular-nums text-muted-foreground">
-                                                        {formatBytes(file.size)}
-                                                    </td>
-                                                    <td className="py-3 pr-4 text-sm whitespace-nowrap text-muted-foreground">
-                                                        {formatRelativeTime(
-                                                            file.createdAt
-                                                        )}
-                                                    </td>
-                                                    <td className="py-3 text-right whitespace-nowrap">
-                                                        <Badge
-                                                            variant="secondary"
-                                                            className="capitalize"
-                                                        >
-                                                            {file.status}
-                                                        </Badge>
-                                                    </td>
-                                                </tr>
-                                            ))}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </>
+                                                        </td>
+                                                        <td className="py-3 pr-4 text-right text-sm whitespace-nowrap tabular-nums text-muted-foreground">
+                                                            {formatBytes(
+                                                                file.size
+                                                            )}
+                                                        </td>
+                                                        <td className="py-3 pr-4 text-sm whitespace-nowrap text-muted-foreground">
+                                                            {formatRelativeTime(
+                                                                file.createdAt
+                                                            )}
+                                                        </td>
+                                                        <td className="py-3 text-right whitespace-nowrap">
+                                                            <Badge
+                                                                variant="secondary"
+                                                                className="capitalize"
+                                                            >
+                                                                {file.status}
+                                                            </Badge>
+                                                        </td>
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                }
+                            />
                         ) : (
                             <div className="py-8 text-center text-sm text-muted-foreground">
                                 No files uploaded yet
@@ -345,18 +344,17 @@ interface MobileFileStatusProps {
     status: string;
 }
 
-/* "Available" is the happy default — on mobile it earns a dot (with sr-only
-   text; color is never the only channel), not a badge. Transitional states
-   keep the text badge — those are the ones the user needs to notice — and
-   restoring adds a glyph so it differs from the rest by more than hue. */
+/* "Available" is the happy default — on mobile it stays understated as a dot
+   plus muted label (a bare dot leaves the status color-only for touch users,
+   where title/hover never fires). Transitional states get the fuller text
+   badge — those are the ones the user needs to notice — and restoring adds a
+   glyph so it differs from the rest by more than hue. */
 function MobileFileStatus({ status }: MobileFileStatusProps) {
     if (status === 'available') {
         return (
-            <span
-                className="size-2 shrink-0 self-center rounded-full bg-emerald-500"
-                title="Available"
-            >
-                <span className="sr-only">Available</span>
+            <span className="flex shrink-0 items-center gap-1.5 self-center text-xs text-muted-foreground">
+                <span className="size-2 rounded-full bg-emerald-500" />
+                Available
             </span>
         );
     }

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -118,8 +118,10 @@ export default function DashboardPage() {
                         owns the full width below — long copy (translations
                         run 20–30% longer) wraps under the button instead of
                         colliding with it. The subtitle nearly restates the
-                        title, so below sm it yields its line. */}
-                    <CardHeader>
+                        title, so below sm it yields its line — and the
+                        header's row gap goes with it, or the empty second
+                        grid row leaves a phantom 8px under the title. */}
+                    <CardHeader className="gap-0 sm:gap-2">
                         <div className="flex items-center justify-between gap-4">
                             <CardTitle className="text-base">
                                 Recent Uploads
@@ -367,8 +369,21 @@ function fitMiddleTruncatedName(wrapper: HTMLElement, name: string): string {
         new Intl.Segmenter().segment(name),
         (segment) => segment.segment
     );
-    const tail = graphemes.slice(-NAME_TAIL_GRAPHEMES).join('');
-    const headGraphemes = graphemes.slice(0, -NAME_TAIL_GRAPHEMES);
+    /* The tail may never eat more than half the width — at very narrow
+       widths a full 12-grapheme tail leaves the head a single identifying
+       character, and the head is what tells burst siblings apart. */
+    const tailGraphemes = graphemes.slice(-NAME_TAIL_GRAPHEMES);
+    while (
+        tailGraphemes.length > 1 &&
+        context.measureText(tailGraphemes.join('')).width > available / 2
+    ) {
+        tailGraphemes.shift();
+    }
+    const tail = tailGraphemes.join('');
+    const headGraphemes = graphemes.slice(
+        0,
+        graphemes.length - tailGraphemes.length
+    );
     let low = 0;
     let high = headGraphemes.length;
     while (low < high) {

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -20,6 +20,7 @@ import {
     formatBytes,
     formatDownloadWindow,
     formatRelativeTime,
+    formatRelativeTimeCompact,
 } from '@/lib/format';
 import { StorageUsageBar } from '@/components/dashboard/StorageUsageBar';
 import { StorageByType } from '@/components/dashboard/StorageByType';
@@ -146,64 +147,108 @@ export default function DashboardPage() {
                                 ))}
                             </div>
                         ) : filesData?.files && filesData.files.length > 0 ? (
-                            <div className="overflow-x-auto">
-                                <table className="w-full">
-                                    <thead>
-                                        <tr className="border-b text-left text-xs text-muted-foreground">
-                                            <th className="pr-4 pb-3 font-medium">
-                                                Name
-                                            </th>
-                                            <th className="pr-4 pb-3 font-medium">
-                                                Size
-                                            </th>
-                                            <th className="pr-4 pb-3 font-medium">
-                                                Uploaded
-                                            </th>
-                                            <th className="pb-3 text-right font-medium">
-                                                Status
-                                            </th>
-                                        </tr>
-                                    </thead>
-                                    <tbody className="divide-y">
-                                        {filesData.files.map((file) => (
-                                            <tr key={file.id} className="group">
-                                                {/* w-full + max-w-0: the name
+                            <>
+                                {/* Below sm a 4-column table can't give the
+                                    name meaningful width, so the same data
+                                    renders as stacked rows: name on its own
+                                    line, metadata demoted to a second line.
+                                    This list must precede the table in the
+                                    DOM — the mobile-overflow spec asserts on
+                                    getByText(...).first(), which has to hit
+                                    the visible copy at 390px. */}
+                                <ul className="divide-y sm:hidden">
+                                    {filesData.files.map((file) => (
+                                        <li
+                                            key={file.id}
+                                            className="flex items-center gap-3 py-3"
+                                        >
+                                            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-muted">
+                                                <FileIcon className="h-4 w-4 text-muted-foreground" />
+                                            </div>
+                                            <div className="min-w-0 flex-1">
+                                                <MiddleTruncateName
+                                                    name={file.name}
+                                                />
+                                                <div className="mt-0.5 flex items-center gap-1.5 text-xs whitespace-nowrap text-muted-foreground">
+                                                    <span>
+                                                        {formatBytes(file.size)}
+                                                    </span>
+                                                    <span aria-hidden>·</span>
+                                                    <span>
+                                                        {formatRelativeTimeCompact(
+                                                            file.createdAt
+                                                        )}
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <MobileFileStatus
+                                                status={file.status}
+                                            />
+                                        </li>
+                                    ))}
+                                </ul>
+                                <div className="hidden overflow-x-auto sm:block">
+                                    <table className="w-full">
+                                        <thead>
+                                            <tr className="border-b text-left text-xs text-muted-foreground">
+                                                <th className="pr-4 pb-3 font-medium">
+                                                    Name
+                                                </th>
+                                                <th className="pr-4 pb-3 text-right font-medium">
+                                                    Size
+                                                </th>
+                                                <th className="pr-4 pb-3 font-medium">
+                                                    Uploaded
+                                                </th>
+                                                <th className="pb-3 text-right font-medium">
+                                                    Status
+                                                </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody className="divide-y">
+                                            {filesData.files.map((file) => (
+                                                <tr
+                                                    key={file.id}
+                                                    className="group"
+                                                >
+                                                    {/* w-full + max-w-0: the name
                                                     column absorbs leftover
                                                     width and its content
                                                     truncates instead of
                                                     growing the column to the
                                                     full string (#311). */}
-                                                <td className="w-full max-w-0 py-3 pr-4">
-                                                    <div className="flex items-center gap-3">
-                                                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-muted">
-                                                            <FileIcon className="h-4 w-4 text-muted-foreground" />
+                                                    <td className="w-full max-w-0 py-3 pr-4">
+                                                        <div className="flex items-center gap-3">
+                                                            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-muted">
+                                                                <FileIcon className="h-4 w-4 text-muted-foreground" />
+                                                            </div>
+                                                            <MiddleTruncateName
+                                                                name={file.name}
+                                                            />
                                                         </div>
-                                                        <span className="truncate font-medium">
-                                                            {file.name}
-                                                        </span>
-                                                    </div>
-                                                </td>
-                                                <td className="py-3 pr-4 text-sm whitespace-nowrap text-muted-foreground">
-                                                    {formatBytes(file.size)}
-                                                </td>
-                                                <td className="py-3 pr-4 text-sm whitespace-nowrap text-muted-foreground">
-                                                    {formatRelativeTime(
-                                                        file.createdAt
-                                                    )}
-                                                </td>
-                                                <td className="py-3 text-right whitespace-nowrap">
-                                                    <Badge
-                                                        variant="secondary"
-                                                        className="capitalize"
-                                                    >
-                                                        {file.status}
-                                                    </Badge>
-                                                </td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            </div>
+                                                    </td>
+                                                    <td className="py-3 pr-4 text-right text-sm whitespace-nowrap tabular-nums text-muted-foreground">
+                                                        {formatBytes(file.size)}
+                                                    </td>
+                                                    <td className="py-3 pr-4 text-sm whitespace-nowrap text-muted-foreground">
+                                                        {formatRelativeTime(
+                                                            file.createdAt
+                                                        )}
+                                                    </td>
+                                                    <td className="py-3 text-right whitespace-nowrap">
+                                                        <Badge
+                                                            variant="secondary"
+                                                            className="capitalize"
+                                                        >
+                                                            {file.status}
+                                                        </Badge>
+                                                    </td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </>
                         ) : (
                             <div className="py-8 text-center text-sm text-muted-foreground">
                                 No files uploaded yet
@@ -286,4 +331,64 @@ function getRetrievalBadge(
 ): string {
     if (status === 'ready') return 'Ready';
     return tier.charAt(0).toUpperCase() + tier.slice(1);
+}
+
+/* Tail length for middle truncation. Burst shots share a prefix and differ
+   only in the trailing digits, and the extension (.dng vs .jpg) is real
+   information — so the end of the name must survive truncation, not the
+   start. 12 graphemes covers "<counter>.<ext>". */
+const NAME_TAIL_GRAPHEMES = 12;
+
+interface MiddleTruncateNameProps {
+    name: string;
+}
+
+/* CSS can only end-truncate, so the name splits into a truncating head span
+   and a fixed tail span. Split on graphemes, not code units — filenames here
+   carry emoji and CJK, and a blind slice() can shear a surrogate pair. */
+function MiddleTruncateName({ name }: MiddleTruncateNameProps) {
+    const graphemes = Array.from(
+        new Intl.Segmenter().segment(name),
+        (segment) => segment.segment
+    );
+    if (graphemes.length <= NAME_TAIL_GRAPHEMES) {
+        return (
+            <span className="truncate font-medium" title={name}>
+                {name}
+            </span>
+        );
+    }
+    const head = graphemes.slice(0, -NAME_TAIL_GRAPHEMES).join('');
+    const tail = graphemes.slice(-NAME_TAIL_GRAPHEMES).join('');
+    return (
+        <span className="flex min-w-0 font-medium" title={name}>
+            <span className="truncate">{head}</span>
+            <span className="shrink-0 whitespace-pre">{tail}</span>
+        </span>
+    );
+}
+
+interface MobileFileStatusProps {
+    status: string;
+}
+
+/* "Available" is the happy default — on mobile it earns a dot, not a badge.
+   Transitional states (uploading, restoring) keep the text badge; those are
+   the ones the user needs to notice. */
+function MobileFileStatus({ status }: MobileFileStatusProps) {
+    if (status === 'available') {
+        return (
+            <span
+                className="size-2 shrink-0 rounded-full bg-emerald-500"
+                title="Available"
+            >
+                <span className="sr-only">Available</span>
+            </span>
+        );
+    }
+    return (
+        <Badge variant="secondary" className="shrink-0 capitalize">
+            {status}
+        </Badge>
+    );
 }

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -109,8 +109,10 @@ export default function DashboardPage() {
             <UploadHistory />
 
             <div className="flex flex-col gap-6 lg:flex-row">
-                <Card className="min-w-0 flex-1">
-                    <CardHeader className="pb-3">
+                {/* gap-4: tighten Card's default gap-6 so the table header
+                    sits closer to the card description. */}
+                <Card className="min-w-0 flex-1 gap-4">
+                    <CardHeader>
                         <div className="flex items-center justify-between">
                             <div>
                                 <CardTitle className="text-base">
@@ -148,13 +150,13 @@ export default function DashboardPage() {
                                 <table className="w-full">
                                     <thead>
                                         <tr className="border-b text-left text-xs text-muted-foreground">
-                                            <th className="pb-3 font-medium">
+                                            <th className="pr-4 pb-3 font-medium">
                                                 Name
                                             </th>
-                                            <th className="pb-3 font-medium">
+                                            <th className="pr-4 pb-3 font-medium">
                                                 Size
                                             </th>
-                                            <th className="pb-3 font-medium">
+                                            <th className="pr-4 pb-3 font-medium">
                                                 Uploaded
                                             </th>
                                             <th className="pb-3 text-right font-medium">
@@ -171,7 +173,7 @@ export default function DashboardPage() {
                                                     truncates instead of
                                                     growing the column to the
                                                     full string (#311). */}
-                                                <td className="w-full max-w-0 py-3">
+                                                <td className="w-full max-w-0 py-3 pr-4">
                                                     <div className="flex items-center gap-3">
                                                         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-muted">
                                                             <FileIcon className="h-4 w-4 text-muted-foreground" />
@@ -181,15 +183,15 @@ export default function DashboardPage() {
                                                         </span>
                                                     </div>
                                                 </td>
-                                                <td className="py-3 text-sm text-muted-foreground">
+                                                <td className="py-3 pr-4 text-sm whitespace-nowrap text-muted-foreground">
                                                     {formatBytes(file.size)}
                                                 </td>
-                                                <td className="py-3 text-sm text-muted-foreground">
+                                                <td className="py-3 pr-4 text-sm whitespace-nowrap text-muted-foreground">
                                                     {formatRelativeTime(
                                                         file.createdAt
                                                     )}
                                                 </td>
-                                                <td className="py-3 text-right">
+                                                <td className="py-3 text-right whitespace-nowrap">
                                                     <Badge
                                                         variant="secondary"
                                                         className="capitalize"

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { FileIcon, ArrowRight, RotateCw, Archive } from 'lucide-react';
@@ -23,6 +22,7 @@ import {
     formatRelativeTime,
     formatRelativeTimeCompact,
 } from '@/lib/format';
+import { MiddleTruncateName } from '@/components/dashboard/MiddleTruncateName';
 import { StorageUsageBar } from '@/components/dashboard/StorageUsageBar';
 import { StorageByType } from '@/components/dashboard/StorageByType';
 import { UploadHistory } from '@/components/dashboard/UploadHistory';
@@ -174,6 +174,7 @@ export default function DashboardPage() {
                                             <div className="min-w-0 flex-1">
                                                 <MiddleTruncateName
                                                     name={file.name}
+                                                    className="font-medium"
                                                 />
                                                 <div className="mt-0.5 flex items-center gap-1.5 text-xs whitespace-nowrap text-muted-foreground">
                                                     <span>
@@ -230,6 +231,7 @@ export default function DashboardPage() {
                                                             </div>
                                                             <MiddleTruncateName
                                                                 name={file.name}
+                                                                className="flex-1 font-medium"
                                                             />
                                                         </div>
                                                     </td>
@@ -337,113 +339,6 @@ function getRetrievalBadge(
 ): string {
     if (status === 'ready') return 'Ready';
     return tier.charAt(0).toUpperCase() + tier.slice(1);
-}
-
-/* Tail length for middle truncation. Burst shots share a prefix and differ
-   only in the trailing digits, and the extension (.dng vs .jpg) is real
-   information — so the end of the name must survive truncation, not the
-   start. 12 graphemes covers "<counter>.<ext>". */
-const NAME_TAIL_GRAPHEMES = 12;
-
-let measureContext: CanvasRenderingContext2D | null = null;
-
-function getMeasureContext(): CanvasRenderingContext2D | null {
-    measureContext ??= document.createElement('canvas').getContext('2d');
-    return measureContext;
-}
-
-/* Longest "head…tail" that fits the wrapper, measured with canvas
-   measureText against the wrapper's computed font. Graphemes, not code
-   units — filenames here carry emoji and CJK, and a blind slice() can shear
-   a surrogate pair. */
-function fitMiddleTruncatedName(wrapper: HTMLElement, name: string): string {
-    const context = getMeasureContext();
-    if (!context) return name;
-    const style = getComputedStyle(wrapper);
-    context.font = `${style.fontStyle} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
-    // 1px slack for subpixel rounding; the wrapper's overflow-hidden clips
-    // any residue.
-    const available = wrapper.clientWidth - 1;
-    if (context.measureText(name).width <= available) return name;
-    const graphemes = Array.from(
-        new Intl.Segmenter().segment(name),
-        (segment) => segment.segment
-    );
-    /* The tail may never eat more than half the width — at very narrow
-       widths a full 12-grapheme tail leaves the head a single identifying
-       character, and the head is what tells burst siblings apart. */
-    const tailGraphemes = graphemes.slice(-NAME_TAIL_GRAPHEMES);
-    while (
-        tailGraphemes.length > 1 &&
-        context.measureText(tailGraphemes.join('')).width > available / 2
-    ) {
-        tailGraphemes.shift();
-    }
-    const tail = tailGraphemes.join('');
-    const headGraphemes = graphemes.slice(
-        0,
-        graphemes.length - tailGraphemes.length
-    );
-    let low = 0;
-    let high = headGraphemes.length;
-    while (low < high) {
-        const mid = Math.ceil((low + high) / 2);
-        const candidate = headGraphemes.slice(0, mid).join('') + '…' + tail;
-        if (context.measureText(candidate).width <= available) {
-            low = mid;
-        } else {
-            high = mid - 1;
-        }
-    }
-    return headGraphemes.slice(0, low).join('') + '…' + tail;
-}
-
-interface MiddleTruncateNameProps {
-    name: string;
-}
-
-/* Middle truncation has to be JS-measured: the CSS two-span trick leaves a
-   hole at the seam, because text-overflow paints "…" after the last glyph
-   that fully fits and the rest of the head's box stays blank. Rendering the
-   fitted "head…tail" as one text run puts the ellipsis flush against the
-   tail. The full name stays in the DOM (sr-only + title) for screen readers,
-   hover, and the e2e specs that locate rows by full filename; the truncated
-   copy is aria-hidden. flex-1 keeps the wrapper's width set by the layout,
-   not its content, so refitting can't ratchet the available width down. */
-function MiddleTruncateName({ name }: MiddleTruncateNameProps) {
-    const wrapperRef = useRef<HTMLSpanElement>(null);
-    const [display, setDisplay] = useState(name);
-
-    useEffect(() => {
-        const wrapper = wrapperRef.current;
-        if (!wrapper) return;
-        let isActive = true;
-        const fit = () => {
-            if (isActive) {
-                setDisplay(fitMiddleTruncatedName(wrapper, name));
-            }
-        };
-        const observer = new ResizeObserver(fit);
-        observer.observe(wrapper);
-        fit();
-        // A web-font swap changes glyph widths without resizing the wrapper.
-        document.fonts.ready.then(fit, () => undefined);
-        return () => {
-            isActive = false;
-            observer.disconnect();
-        };
-    }, [name]);
-
-    return (
-        <span
-            ref={wrapperRef}
-            className="block min-w-0 flex-1 overflow-hidden font-medium whitespace-nowrap"
-            title={name}
-        >
-            <span className="sr-only">{name}</span>
-            <span aria-hidden>{display}</span>
-        </span>
-    );
 }
 
 interface MobileFileStatusProps {

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -114,22 +114,25 @@ export default function DashboardPage() {
                 {/* gap-4: tighten Card's default gap-6 so the table header
                     sits closer to the card description. */}
                 <Card className="min-w-0 flex-1 gap-4">
+                    {/* The action pairs with the title row and the subtitle
+                        owns the full width below — long copy (translations
+                        run 20–30% longer) wraps under the button instead of
+                        colliding with it. The subtitle nearly restates the
+                        title, so below sm it yields its line. */}
                     <CardHeader>
-                        <div className="flex items-center justify-between">
-                            <div>
-                                <CardTitle className="text-base">
-                                    Recent Uploads
-                                </CardTitle>
-                                <CardDescription>
-                                    Your most recently archived files
-                                </CardDescription>
-                            </div>
-                            <Link href="/dashboard/files">
+                        <div className="flex items-center justify-between gap-4">
+                            <CardTitle className="text-base">
+                                Recent Uploads
+                            </CardTitle>
+                            <Link href="/dashboard/files" className="shrink-0">
                                 <Button variant="outline" size="sm">
                                     View all
                                 </Button>
                             </Link>
                         </div>
+                        <CardDescription className="hidden sm:block">
+                            Your most recently archived files
+                        </CardDescription>
                     </CardHeader>
                     <CardContent>
                         {isLoadingFiles ? (

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { FileIcon, ArrowRight, RotateCw, Archive } from 'lucide-react';
@@ -339,31 +340,90 @@ function getRetrievalBadge(
    start. 12 graphemes covers "<counter>.<ext>". */
 const NAME_TAIL_GRAPHEMES = 12;
 
-interface MiddleTruncateNameProps {
-    name: string;
+let measureContext: CanvasRenderingContext2D | null = null;
+
+function getMeasureContext(): CanvasRenderingContext2D | null {
+    measureContext ??= document.createElement('canvas').getContext('2d');
+    return measureContext;
 }
 
-/* CSS can only end-truncate, so the name splits into a truncating head span
-   and a fixed tail span. Split on graphemes, not code units — filenames here
-   carry emoji and CJK, and a blind slice() can shear a surrogate pair. */
-function MiddleTruncateName({ name }: MiddleTruncateNameProps) {
+/* Longest "head…tail" that fits the wrapper, measured with canvas
+   measureText against the wrapper's computed font. Graphemes, not code
+   units — filenames here carry emoji and CJK, and a blind slice() can shear
+   a surrogate pair. */
+function fitMiddleTruncatedName(wrapper: HTMLElement, name: string): string {
+    const context = getMeasureContext();
+    if (!context) return name;
+    const style = getComputedStyle(wrapper);
+    context.font = `${style.fontStyle} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+    // 1px slack for subpixel rounding; the wrapper's overflow-hidden clips
+    // any residue.
+    const available = wrapper.clientWidth - 1;
+    if (context.measureText(name).width <= available) return name;
     const graphemes = Array.from(
         new Intl.Segmenter().segment(name),
         (segment) => segment.segment
     );
-    if (graphemes.length <= NAME_TAIL_GRAPHEMES) {
-        return (
-            <span className="truncate font-medium" title={name}>
-                {name}
-            </span>
-        );
-    }
-    const head = graphemes.slice(0, -NAME_TAIL_GRAPHEMES).join('');
     const tail = graphemes.slice(-NAME_TAIL_GRAPHEMES).join('');
+    const headGraphemes = graphemes.slice(0, -NAME_TAIL_GRAPHEMES);
+    let low = 0;
+    let high = headGraphemes.length;
+    while (low < high) {
+        const mid = Math.ceil((low + high) / 2);
+        const candidate = headGraphemes.slice(0, mid).join('') + '…' + tail;
+        if (context.measureText(candidate).width <= available) {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+    return headGraphemes.slice(0, low).join('') + '…' + tail;
+}
+
+interface MiddleTruncateNameProps {
+    name: string;
+}
+
+/* Middle truncation has to be JS-measured: the CSS two-span trick leaves a
+   hole at the seam, because text-overflow paints "…" after the last glyph
+   that fully fits and the rest of the head's box stays blank. Rendering the
+   fitted "head…tail" as one text run puts the ellipsis flush against the
+   tail. The full name stays in the DOM (sr-only + title) for screen readers,
+   hover, and the e2e specs that locate rows by full filename; the truncated
+   copy is aria-hidden. flex-1 keeps the wrapper's width set by the layout,
+   not its content, so refitting can't ratchet the available width down. */
+function MiddleTruncateName({ name }: MiddleTruncateNameProps) {
+    const wrapperRef = useRef<HTMLSpanElement>(null);
+    const [display, setDisplay] = useState(name);
+
+    useEffect(() => {
+        const wrapper = wrapperRef.current;
+        if (!wrapper) return;
+        let isActive = true;
+        const fit = () => {
+            if (isActive) {
+                setDisplay(fitMiddleTruncatedName(wrapper, name));
+            }
+        };
+        const observer = new ResizeObserver(fit);
+        observer.observe(wrapper);
+        fit();
+        // A web-font swap changes glyph widths without resizing the wrapper.
+        document.fonts.ready.then(fit, () => undefined);
+        return () => {
+            isActive = false;
+            observer.disconnect();
+        };
+    }, [name]);
+
     return (
-        <span className="flex min-w-0 font-medium" title={name}>
-            <span className="truncate">{head}</span>
-            <span className="shrink-0 whitespace-pre">{tail}</span>
+        <span
+            ref={wrapperRef}
+            className="block min-w-0 flex-1 overflow-hidden font-medium whitespace-nowrap"
+            title={name}
+        >
+            <span className="sr-only">{name}</span>
+            <span aria-hidden>{display}</span>
         </span>
     );
 }
@@ -372,14 +432,15 @@ interface MobileFileStatusProps {
     status: string;
 }
 
-/* "Available" is the happy default — on mobile it earns a dot, not a badge.
-   Transitional states (uploading, restoring) keep the text badge; those are
-   the ones the user needs to notice. */
+/* "Available" is the happy default — on mobile it earns a dot (with sr-only
+   text; color is never the only channel), not a badge. Transitional states
+   keep the text badge — those are the ones the user needs to notice — and
+   restoring adds a glyph so it differs from the rest by more than hue. */
 function MobileFileStatus({ status }: MobileFileStatusProps) {
     if (status === 'available') {
         return (
             <span
-                className="size-2 shrink-0 rounded-full bg-emerald-500"
+                className="size-2 shrink-0 self-center rounded-full bg-emerald-500"
                 title="Available"
             >
                 <span className="sr-only">Available</span>
@@ -387,7 +448,8 @@ function MobileFileStatus({ status }: MobileFileStatusProps) {
         );
     }
     return (
-        <Badge variant="secondary" className="shrink-0 capitalize">
+        <Badge variant="secondary" className="shrink-0 self-center capitalize">
+            {status === 'restoring' && <RotateCw aria-hidden />}
             {status}
         </Badge>
     );

--- a/apps/web/components/dashboard/MiddleTruncateName.tsx
+++ b/apps/web/components/dashboard/MiddleTruncateName.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/cn';
 
 /* Tail length for middle truncation. Burst shots share a prefix and differ
@@ -9,30 +9,34 @@ import { cn } from '@/lib/cn';
    start. 12 graphemes covers "<counter>.<ext>". */
 const NAME_TAIL_GRAPHEMES = 12;
 
-let measureContext: CanvasRenderingContext2D | null = null;
+/* Grapheme splitting depends only on the name, never the wrapper width — the
+   Segmenter is stateless, so one shared instance serves every call and each
+   name is segmented once (memoized in the component). The old code built a
+   fresh Segmenter and re-split the whole string on every ResizeObserver tick. */
+const graphemeSegmenter = new Intl.Segmenter();
 
-function getMeasureContext(): CanvasRenderingContext2D | null {
-    measureContext ??= document.createElement('canvas').getContext('2d');
-    return measureContext;
+function segmentGraphemes(name: string): string[] {
+    return Array.from(graphemeSegmenter.segment(name), (s) => s.segment);
 }
 
 /* Longest "head…tail" that fits the wrapper, measured with canvas
    measureText against the wrapper's computed font. Graphemes, not code
    units — filenames here carry emoji and CJK, and a blind slice() can shear
-   a surrogate pair. */
-function fitMiddleTruncatedName(wrapper: HTMLElement, name: string): string {
-    const context = getMeasureContext();
-    if (!context) return name;
+   a surrogate pair. The context is owned by the calling instance: a shared
+   module-global one can be left on a sibling row's font when a malformed
+   shorthand assignment is silently rejected, mis-measuring this name. */
+function fitMiddleTruncatedName(
+    wrapper: HTMLElement,
+    context: CanvasRenderingContext2D,
+    name: string,
+    graphemes: string[]
+): string {
     const style = getComputedStyle(wrapper);
     context.font = `${style.fontStyle} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
     // 1px slack for subpixel rounding; the wrapper's overflow-hidden clips
     // any residue.
     const available = wrapper.clientWidth - 1;
     if (context.measureText(name).width <= available) return name;
-    const graphemes = Array.from(
-        new Intl.Segmenter().segment(name),
-        (segment) => segment.segment
-    );
     /* The tail may never eat more than half the width — at very narrow
        widths a full 12-grapheme tail leaves the head a single identifying
        character, and the head is what tells burst siblings apart. */
@@ -87,15 +91,28 @@ export function MiddleTruncateName({
     className,
 }: MiddleTruncateNameProps) {
     const wrapperRef = useRef<HTMLSpanElement>(null);
+    // One canvas context per instance — see fitMiddleTruncatedName. Lazily
+    // created on first fit, reused across resizes (no per-tick allocation).
+    const measureContextRef = useRef<CanvasRenderingContext2D | null>(null);
+    const graphemes = useMemo(() => segmentGraphemes(name), [name]);
     const [display, setDisplay] = useState(name);
 
     useEffect(() => {
         const wrapper = wrapperRef.current;
         if (!wrapper) return;
+        measureContextRef.current ??= document
+            .createElement('canvas')
+            .getContext('2d');
+        const context = measureContextRef.current;
+        // No canvas support: leave the full name in place and let the CSS
+        // text-ellipsis on the wrapper end-truncate it.
+        if (!context) return;
         let isActive = true;
         const fit = () => {
             if (isActive) {
-                setDisplay(fitMiddleTruncatedName(wrapper, name));
+                setDisplay(
+                    fitMiddleTruncatedName(wrapper, context, name, graphemes)
+                );
             }
         };
         const observer = new ResizeObserver(fit);
@@ -107,13 +124,16 @@ export function MiddleTruncateName({
             isActive = false;
             observer.disconnect();
         };
-    }, [name]);
+    }, [name, graphemes]);
 
     return (
         <span
             ref={wrapperRef}
             className={cn(
-                'block min-w-0 overflow-hidden whitespace-nowrap',
+                // text-ellipsis so a long name still shows "…" via CSS before
+                // the fit effect runs (SSR first paint, slow hydration, no JS);
+                // once fitted, "head…tail" fits and the CSS ellipsis is inert.
+                'block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap',
                 className
             )}
             title={name}

--- a/apps/web/components/dashboard/MiddleTruncateName.tsx
+++ b/apps/web/components/dashboard/MiddleTruncateName.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/cn';
+
+/* Tail length for middle truncation. Burst shots share a prefix and differ
+   only in the trailing digits, and the extension (.dng vs .jpg) is real
+   information — so the end of the name must survive truncation, not the
+   start. 12 graphemes covers "<counter>.<ext>". */
+const NAME_TAIL_GRAPHEMES = 12;
+
+let measureContext: CanvasRenderingContext2D | null = null;
+
+function getMeasureContext(): CanvasRenderingContext2D | null {
+    measureContext ??= document.createElement('canvas').getContext('2d');
+    return measureContext;
+}
+
+/* Longest "head…tail" that fits the wrapper, measured with canvas
+   measureText against the wrapper's computed font. Graphemes, not code
+   units — filenames here carry emoji and CJK, and a blind slice() can shear
+   a surrogate pair. */
+function fitMiddleTruncatedName(wrapper: HTMLElement, name: string): string {
+    const context = getMeasureContext();
+    if (!context) return name;
+    const style = getComputedStyle(wrapper);
+    context.font = `${style.fontStyle} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+    // 1px slack for subpixel rounding; the wrapper's overflow-hidden clips
+    // any residue.
+    const available = wrapper.clientWidth - 1;
+    if (context.measureText(name).width <= available) return name;
+    const graphemes = Array.from(
+        new Intl.Segmenter().segment(name),
+        (segment) => segment.segment
+    );
+    /* The tail may never eat more than half the width — at very narrow
+       widths a full 12-grapheme tail leaves the head a single identifying
+       character, and the head is what tells burst siblings apart. */
+    const tailGraphemes = graphemes.slice(-NAME_TAIL_GRAPHEMES);
+    while (
+        tailGraphemes.length > 1 &&
+        context.measureText(tailGraphemes.join('')).width > available / 2
+    ) {
+        tailGraphemes.shift();
+    }
+    const tail = tailGraphemes.join('');
+    const headGraphemes = graphemes.slice(
+        0,
+        graphemes.length - tailGraphemes.length
+    );
+    let low = 0;
+    let high = headGraphemes.length;
+    while (low < high) {
+        const mid = Math.ceil((low + high) / 2);
+        const candidate = headGraphemes.slice(0, mid).join('') + '…' + tail;
+        if (context.measureText(candidate).width <= available) {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+    return headGraphemes.slice(0, low).join('') + '…' + tail;
+}
+
+interface MiddleTruncateNameProps {
+    name: string;
+    className?: string;
+}
+
+/* Middle truncation for user-supplied filenames — use this, not
+   `className="truncate"`: end-truncation makes burst siblings
+   (_MG_4501.CR2 vs _MG_4524.CR2) indistinguishable and hides the extension.
+
+   It has to be JS-measured: the CSS two-span trick leaves a hole at the
+   seam, because text-overflow paints "…" after the last glyph that fully
+   fits and the rest of the head's box stays blank. Rendering the fitted
+   "head…tail" as one text run puts the ellipsis flush against the tail.
+   The full name stays in the DOM (sr-only + title) for screen readers,
+   hover, and the e2e specs that locate rows by full filename; the truncated
+   copy is aria-hidden.
+
+   The wrapper must get its width from the layout, not its content —
+   a width-constrained ancestor (min-w-0 chain), or flex-1 when it sits in
+   a flex row — so refitting can't ratchet the available width down. */
+export function MiddleTruncateName({
+    name,
+    className,
+}: MiddleTruncateNameProps) {
+    const wrapperRef = useRef<HTMLSpanElement>(null);
+    const [display, setDisplay] = useState(name);
+
+    useEffect(() => {
+        const wrapper = wrapperRef.current;
+        if (!wrapper) return;
+        let isActive = true;
+        const fit = () => {
+            if (isActive) {
+                setDisplay(fitMiddleTruncatedName(wrapper, name));
+            }
+        };
+        const observer = new ResizeObserver(fit);
+        observer.observe(wrapper);
+        fit();
+        // A web-font swap changes glyph widths without resizing the wrapper.
+        document.fonts.ready.then(fit, () => undefined);
+        return () => {
+            isActive = false;
+            observer.disconnect();
+        };
+    }, [name]);
+
+    return (
+        <span
+            ref={wrapperRef}
+            className={cn(
+                'block min-w-0 overflow-hidden whitespace-nowrap',
+                className
+            )}
+            title={name}
+        >
+            <span className="sr-only">{name}</span>
+            <span aria-hidden>{display}</span>
+        </span>
+    );
+}

--- a/apps/web/components/dashboard/file-browser/FileBrowser.tsx
+++ b/apps/web/components/dashboard/file-browser/FileBrowser.tsx
@@ -21,6 +21,8 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import { Card } from '@/components/ui/card';
+import { ResponsiveRows } from '@/components/ui/responsive-rows';
+import { StackedList } from '@/components/ui/stacked-list';
 import {
     Search,
     LayoutGrid,
@@ -350,164 +352,194 @@ export function FileBrowser({ focusFileId }: FileBrowserProps) {
                         </p>
                     </div>
                 ) : viewMode === 'list' ? (
-                    <>
-                        {/* Below sm the 6-column table starves the name
-                            column — the same class as #311, invisible on an
-                            empty account — so the list view renders as
-                            stacked rows, reusing the grid view's group
-                            structure. The mobile list precedes the table in
-                            the DOM so filename locators' .first() hits the
-                            visible copy at phone widths. Select-all lives in
-                            the hidden table header; per-file selection via
-                            the icon still feeds the floating bulk bar. */}
-                        <div className="space-y-6 sm:hidden">
-                            {filteredGroups.map((group) => {
-                                const key = group.batchId ?? '__ungrouped__';
-                                const expanded = isExpanded(key);
-                                return (
-                                    <section key={key}>
-                                        <BatchHeader
-                                            group={group}
-                                            expanded={expanded}
-                                            onToggle={() => toggleExpanded(key)}
-                                        />
-                                        {expanded && (
-                                            <ul className="divide-y">
-                                                {group.files.map((file) => (
-                                                    <MobileFileRow
-                                                        key={file.id}
-                                                        ref={
-                                                            file.id ===
-                                                            focusFileId
-                                                                ? focusRowRef
-                                                                : undefined
-                                                        }
-                                                        file={file}
-                                                        isSelected={selectedFiles.includes(
-                                                            file.id
-                                                        )}
-                                                        isHighlighted={
-                                                            file.id ===
-                                                            highlightedFileId
-                                                        }
-                                                        hasSelection={
-                                                            hasSelection
-                                                        }
-                                                        onSelect={(shiftKey) =>
-                                                            handleSelect(
-                                                                file.id,
-                                                                fileIndexMap.get(
-                                                                    file.id
-                                                                ) ?? 0,
-                                                                shiftKey
-                                                            )
-                                                        }
-                                                    />
-                                                ))}
-                                            </ul>
-                                        )}
-                                    </section>
-                                );
-                            })}
-                        </div>
-                        <Card className="hidden py-0 sm:block">
-                            <Table>
-                                <TableHeader>
-                                    <TableRow className="hover:bg-transparent">
-                                        <TableHead className="w-[52px] pl-4">
-                                            <div className="flex size-8 items-center justify-center">
-                                                <Checkbox
-                                                    checked={
-                                                        hasSelection &&
-                                                        selectedFiles.length ===
-                                                            visibleFiles.length
-                                                    }
-                                                    onCheckedChange={
-                                                        toggleSelectAll
-                                                    }
-                                                    aria-label="Select all"
-                                                />
-                                            </div>
-                                        </TableHead>
-                                        <TableHead>
-                                            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                                                Name
-                                            </span>
-                                        </TableHead>
-                                        <TableHead>
-                                            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                                                Size
-                                            </span>
-                                        </TableHead>
-                                        <TableHead>
-                                            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                                                Uploaded
-                                            </span>
-                                        </TableHead>
-                                        <TableHead>
-                                            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                                                Status
-                                            </span>
-                                        </TableHead>
-                                        <TableHead className="w-12" />
-                                    </TableRow>
-                                </TableHeader>
-                                <TableBody>
+                    <ResponsiveRows
+                        mobile={
+                            <>
+                                {/* The desktop table's select-all lives in its
+                                    (hidden) header, so the stacked list carries
+                                    its own select-all row. */}
+                                <div className="flex items-center gap-2.5 px-2 pb-3">
+                                    <Checkbox
+                                        checked={
+                                            hasSelection &&
+                                            selectedFiles.length ===
+                                                visibleFiles.length
+                                        }
+                                        onCheckedChange={toggleSelectAll}
+                                        aria-label="Select all"
+                                    />
+                                    <span className="text-xs font-medium text-muted-foreground">
+                                        Select all
+                                    </span>
+                                </div>
+                                <div className="space-y-6">
                                     {filteredGroups.map((group) => {
                                         const key =
                                             group.batchId ?? '__ungrouped__';
                                         const expanded = isExpanded(key);
                                         return (
-                                            <Fragment key={key}>
-                                                <BatchHeaderRow
+                                            <section key={key}>
+                                                <BatchHeader
                                                     group={group}
                                                     expanded={expanded}
                                                     onToggle={() =>
                                                         toggleExpanded(key)
                                                     }
-                                                    colSpan={6}
                                                 />
-                                                {expanded &&
-                                                    group.files.map((file) => (
-                                                        <FileRow
-                                                            key={file.id}
-                                                            ref={
-                                                                file.id ===
-                                                                focusFileId
-                                                                    ? focusRowRef
-                                                                    : undefined
-                                                            }
-                                                            file={file}
-                                                            isSelected={selectedFiles.includes(
-                                                                file.id
-                                                            )}
-                                                            isHighlighted={
-                                                                file.id ===
-                                                                highlightedFileId
-                                                            }
-                                                            hasSelection={
-                                                                hasSelection
-                                                            }
-                                                            onSelect={(
-                                                                shiftKey
-                                                            ) =>
-                                                                handleSelect(
-                                                                    file.id,
-                                                                    fileIndexMap.get(
+                                                {expanded && (
+                                                    <StackedList>
+                                                        {group.files.map(
+                                                            (file) => (
+                                                                <MobileFileRow
+                                                                    key={
                                                                         file.id
-                                                                    ) ?? 0,
-                                                                    shiftKey
-                                                                )
-                                                            }
-                                                        />
-                                                    ))}
-                                            </Fragment>
+                                                                    }
+                                                                    ref={
+                                                                        file.id ===
+                                                                        focusFileId
+                                                                            ? focusRowRef
+                                                                            : undefined
+                                                                    }
+                                                                    file={file}
+                                                                    isSelected={selectedFiles.includes(
+                                                                        file.id
+                                                                    )}
+                                                                    isHighlighted={
+                                                                        file.id ===
+                                                                        highlightedFileId
+                                                                    }
+                                                                    hasSelection={
+                                                                        hasSelection
+                                                                    }
+                                                                    onSelect={(
+                                                                        shiftKey
+                                                                    ) =>
+                                                                        handleSelect(
+                                                                            file.id,
+                                                                            fileIndexMap.get(
+                                                                                file.id
+                                                                            ) ??
+                                                                                0,
+                                                                            shiftKey
+                                                                        )
+                                                                    }
+                                                                />
+                                                            )
+                                                        )}
+                                                    </StackedList>
+                                                )}
+                                            </section>
                                         );
                                     })}
-                                </TableBody>
-                            </Table>
-                        </Card>
-                    </>
+                                </div>
+                            </>
+                        }
+                        desktop={
+                            <Card className="py-0">
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow className="hover:bg-transparent">
+                                            <TableHead className="w-[52px] pl-4">
+                                                <div className="flex size-8 items-center justify-center">
+                                                    <Checkbox
+                                                        checked={
+                                                            hasSelection &&
+                                                            selectedFiles.length ===
+                                                                visibleFiles.length
+                                                        }
+                                                        onCheckedChange={
+                                                            toggleSelectAll
+                                                        }
+                                                        aria-label="Select all"
+                                                    />
+                                                </div>
+                                            </TableHead>
+                                            <TableHead>
+                                                <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                                    Name
+                                                </span>
+                                            </TableHead>
+                                            <TableHead>
+                                                <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                                    Size
+                                                </span>
+                                            </TableHead>
+                                            <TableHead>
+                                                <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                                    Uploaded
+                                                </span>
+                                            </TableHead>
+                                            <TableHead>
+                                                <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                                    Status
+                                                </span>
+                                            </TableHead>
+                                            <TableHead className="w-12" />
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {filteredGroups.map((group) => {
+                                            const key =
+                                                group.batchId ??
+                                                '__ungrouped__';
+                                            const expanded = isExpanded(key);
+                                            return (
+                                                <Fragment key={key}>
+                                                    <BatchHeaderRow
+                                                        group={group}
+                                                        expanded={expanded}
+                                                        onToggle={() =>
+                                                            toggleExpanded(key)
+                                                        }
+                                                        colSpan={6}
+                                                    />
+                                                    {expanded &&
+                                                        group.files.map(
+                                                            (file) => (
+                                                                <FileRow
+                                                                    key={
+                                                                        file.id
+                                                                    }
+                                                                    ref={
+                                                                        file.id ===
+                                                                        focusFileId
+                                                                            ? focusRowRef
+                                                                            : undefined
+                                                                    }
+                                                                    file={file}
+                                                                    isSelected={selectedFiles.includes(
+                                                                        file.id
+                                                                    )}
+                                                                    isHighlighted={
+                                                                        file.id ===
+                                                                        highlightedFileId
+                                                                    }
+                                                                    hasSelection={
+                                                                        hasSelection
+                                                                    }
+                                                                    onSelect={(
+                                                                        shiftKey
+                                                                    ) =>
+                                                                        handleSelect(
+                                                                            file.id,
+                                                                            fileIndexMap.get(
+                                                                                file.id
+                                                                            ) ??
+                                                                                0,
+                                                                            shiftKey
+                                                                        )
+                                                                    }
+                                                                />
+                                                            )
+                                                        )}
+                                                </Fragment>
+                                            );
+                                        })}
+                                    </TableBody>
+                                </Table>
+                            </Card>
+                        }
+                    />
                 ) : (
                     <div className="space-y-6">
                         {filteredGroups.map((group) => {

--- a/apps/web/components/dashboard/file-browser/FileBrowser.tsx
+++ b/apps/web/components/dashboard/file-browser/FileBrowser.tsx
@@ -42,6 +42,7 @@ import { deriveStatus } from './status';
 import { BatchHeader, BatchHeaderRow } from './BatchHeader';
 import { FileRow } from './FileRow';
 import { FileCard } from './FileCard';
+import { MobileFileRow } from './MobileFileRow';
 
 const SEARCH_DEBOUNCE_MS = 300;
 
@@ -88,6 +89,10 @@ export function FileBrowser({ focusFileId }: FileBrowserProps) {
     // remounts (search filter, view-mode toggle) don't re-scroll.
     const focusRowRef = useCallback((node: HTMLElement | null) => {
         if (!node || hasScrolledToFocus.current) return;
+        // The list view is dual markup (stacked rows below sm, table above)
+        // and both copies carry this ref — skip the display:none one so the
+        // guard isn't consumed by a copy that can't scroll.
+        if (node.offsetParent === null) return;
         hasScrolledToFocus.current = true;
 
         node.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -345,66 +350,31 @@ export function FileBrowser({ focusFileId }: FileBrowserProps) {
                         </p>
                     </div>
                 ) : viewMode === 'list' ? (
-                    <Card className="py-0">
-                        <Table>
-                            <TableHeader>
-                                <TableRow className="hover:bg-transparent">
-                                    <TableHead className="w-[52px] pl-4">
-                                        <div className="flex size-8 items-center justify-center">
-                                            <Checkbox
-                                                checked={
-                                                    hasSelection &&
-                                                    selectedFiles.length ===
-                                                        visibleFiles.length
-                                                }
-                                                onCheckedChange={
-                                                    toggleSelectAll
-                                                }
-                                                aria-label="Select all"
-                                            />
-                                        </div>
-                                    </TableHead>
-                                    <TableHead>
-                                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                                            Name
-                                        </span>
-                                    </TableHead>
-                                    <TableHead>
-                                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                                            Size
-                                        </span>
-                                    </TableHead>
-                                    <TableHead>
-                                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                                            Uploaded
-                                        </span>
-                                    </TableHead>
-                                    <TableHead>
-                                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                                            Status
-                                        </span>
-                                    </TableHead>
-                                    <TableHead className="w-12" />
-                                </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                {filteredGroups.map((group) => {
-                                    const key =
-                                        group.batchId ?? '__ungrouped__';
-                                    const expanded = isExpanded(key);
-                                    return (
-                                        <Fragment key={key}>
-                                            <BatchHeaderRow
-                                                group={group}
-                                                expanded={expanded}
-                                                onToggle={() =>
-                                                    toggleExpanded(key)
-                                                }
-                                                colSpan={6}
-                                            />
-                                            {expanded &&
-                                                group.files.map((file) => (
-                                                    <FileRow
+                    <>
+                        {/* Below sm the 6-column table starves the name
+                            column — the same class as #311, invisible on an
+                            empty account — so the list view renders as
+                            stacked rows, reusing the grid view's group
+                            structure. The mobile list precedes the table in
+                            the DOM so filename locators' .first() hits the
+                            visible copy at phone widths. Select-all lives in
+                            the hidden table header; per-file selection via
+                            the icon still feeds the floating bulk bar. */}
+                        <div className="space-y-6 sm:hidden">
+                            {filteredGroups.map((group) => {
+                                const key = group.batchId ?? '__ungrouped__';
+                                const expanded = isExpanded(key);
+                                return (
+                                    <section key={key}>
+                                        <BatchHeader
+                                            group={group}
+                                            expanded={expanded}
+                                            onToggle={() => toggleExpanded(key)}
+                                        />
+                                        {expanded && (
+                                            <ul className="divide-y">
+                                                {group.files.map((file) => (
+                                                    <MobileFileRow
                                                         key={file.id}
                                                         ref={
                                                             file.id ===
@@ -434,12 +404,110 @@ export function FileBrowser({ focusFileId }: FileBrowserProps) {
                                                         }
                                                     />
                                                 ))}
-                                        </Fragment>
-                                    );
-                                })}
-                            </TableBody>
-                        </Table>
-                    </Card>
+                                            </ul>
+                                        )}
+                                    </section>
+                                );
+                            })}
+                        </div>
+                        <Card className="hidden py-0 sm:block">
+                            <Table>
+                                <TableHeader>
+                                    <TableRow className="hover:bg-transparent">
+                                        <TableHead className="w-[52px] pl-4">
+                                            <div className="flex size-8 items-center justify-center">
+                                                <Checkbox
+                                                    checked={
+                                                        hasSelection &&
+                                                        selectedFiles.length ===
+                                                            visibleFiles.length
+                                                    }
+                                                    onCheckedChange={
+                                                        toggleSelectAll
+                                                    }
+                                                    aria-label="Select all"
+                                                />
+                                            </div>
+                                        </TableHead>
+                                        <TableHead>
+                                            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                                Name
+                                            </span>
+                                        </TableHead>
+                                        <TableHead>
+                                            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                                Size
+                                            </span>
+                                        </TableHead>
+                                        <TableHead>
+                                            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                                Uploaded
+                                            </span>
+                                        </TableHead>
+                                        <TableHead>
+                                            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                                                Status
+                                            </span>
+                                        </TableHead>
+                                        <TableHead className="w-12" />
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {filteredGroups.map((group) => {
+                                        const key =
+                                            group.batchId ?? '__ungrouped__';
+                                        const expanded = isExpanded(key);
+                                        return (
+                                            <Fragment key={key}>
+                                                <BatchHeaderRow
+                                                    group={group}
+                                                    expanded={expanded}
+                                                    onToggle={() =>
+                                                        toggleExpanded(key)
+                                                    }
+                                                    colSpan={6}
+                                                />
+                                                {expanded &&
+                                                    group.files.map((file) => (
+                                                        <FileRow
+                                                            key={file.id}
+                                                            ref={
+                                                                file.id ===
+                                                                focusFileId
+                                                                    ? focusRowRef
+                                                                    : undefined
+                                                            }
+                                                            file={file}
+                                                            isSelected={selectedFiles.includes(
+                                                                file.id
+                                                            )}
+                                                            isHighlighted={
+                                                                file.id ===
+                                                                highlightedFileId
+                                                            }
+                                                            hasSelection={
+                                                                hasSelection
+                                                            }
+                                                            onSelect={(
+                                                                shiftKey
+                                                            ) =>
+                                                                handleSelect(
+                                                                    file.id,
+                                                                    fileIndexMap.get(
+                                                                        file.id
+                                                                    ) ?? 0,
+                                                                    shiftKey
+                                                                )
+                                                            }
+                                                        />
+                                                    ))}
+                                            </Fragment>
+                                        );
+                                    })}
+                                </TableBody>
+                            </Table>
+                        </Card>
+                    </>
                 ) : (
                     <div className="space-y-6">
                         {filteredGroups.map((group) => {

--- a/apps/web/components/dashboard/file-browser/FileCard.tsx
+++ b/apps/web/components/dashboard/file-browser/FileCard.tsx
@@ -10,6 +10,7 @@ import {
 } from './status';
 import { SelectableIcon, StatusDot } from './SelectableIcon';
 import { FileActions, useFileActions } from './FileActions';
+import { MiddleTruncateName } from '../MiddleTruncateName';
 import type { FileItemProps } from './types';
 
 export function FileCard({
@@ -64,9 +65,10 @@ export function FileCard({
                         />
                     </div>
                 </div>
-                <p className="truncate text-sm/tight font-medium">
-                    {file.name}
-                </p>
+                <MiddleTruncateName
+                    name={file.name}
+                    className="text-sm/tight font-medium"
+                />
                 <div className="mt-1.5 flex items-center justify-between">
                     <span className="text-xs tabular-nums text-muted-foreground">
                         {formatBytes(file.size)}

--- a/apps/web/components/dashboard/file-browser/FileRow.tsx
+++ b/apps/web/components/dashboard/file-browser/FileRow.tsx
@@ -10,6 +10,7 @@ import {
 } from './status';
 import { SelectableIcon, StatusDot } from './SelectableIcon';
 import { FileActions, useFileActions } from './FileActions';
+import { MiddleTruncateName } from '../MiddleTruncateName';
 import type { FileItemProps } from './types';
 
 export function FileRow({
@@ -50,9 +51,10 @@ export function FileRow({
                 truncates instead of growing to the full string (#311). */}
             <TableCell className="w-full max-w-0">
                 <div className="min-w-0">
-                    <p className="truncate font-medium leading-tight">
-                        {file.name}
-                    </p>
+                    <MiddleTruncateName
+                        name={file.name}
+                        className="font-medium leading-tight"
+                    />
                     {ext && (
                         <p className="text-xs uppercase text-muted-foreground">
                             {ext}

--- a/apps/web/components/dashboard/file-browser/MobileFileRow.tsx
+++ b/apps/web/components/dashboard/file-browser/MobileFileRow.tsx
@@ -6,13 +6,14 @@ import { deriveStatus, getDownloadWindowLabel } from './status';
 import { SelectableIcon, StatusDot } from './SelectableIcon';
 import { FileActions, useFileActions } from './FileActions';
 import { MiddleTruncateName } from '../MiddleTruncateName';
+import { StackedListRow } from '@/components/ui/stacked-list';
 import type { FileItemProps } from './types';
 
 /* Below sm the 6-column table can't give the name meaningful width, so the
-   list view renders these stacked rows instead (same treatment as the
-   dashboard's Recent Uploads): name on its own line, metadata demoted to a
-   second line, status demoted to a dot. Selection and actions keep the same
-   entry points as FileRow — icon tap and the actions menu. */
+   list view renders these stacked rows instead (the same StackedListRow
+   anatomy as the dashboard's Recent Uploads): name on its own line, metadata
+   demoted to a second line. Selection and actions keep the same entry points
+   as FileRow — icon tap and the actions menu. */
 export function MobileFileRow({
     file,
     isSelected,
@@ -26,48 +27,47 @@ export function MobileFileRow({
     const downloadWindow = getDownloadWindowLabel(file);
 
     return (
-        <li
+        <StackedListRow
             ref={ref}
             data-state={isSelected ? 'selected' : undefined}
             className={cn(
-                'flex cursor-pointer items-center gap-3 px-2 py-3 transition-colors',
+                'cursor-pointer px-2 transition-colors',
                 isSelected && 'bg-primary/4 dark:bg-primary/8',
                 isHighlighted && 'bg-primary/10 dark:bg-primary/15'
             )}
             onClick={(e) => onSelect(e.shiftKey)}
-        >
-            <SelectableIcon
-                name={file.name}
-                checked={isSelected}
-                onCheckedChange={() => onSelect(false)}
-                showCheckbox={hasSelection}
-                size="sm"
-            />
-            <div className="min-w-0 flex-1">
+            leading={
+                <SelectableIcon
+                    name={file.name}
+                    checked={isSelected}
+                    onCheckedChange={() => onSelect(false)}
+                    showCheckbox={hasSelection}
+                    size="sm"
+                />
+            }
+            primary={
                 <MiddleTruncateName
                     name={file.name}
                     className="font-medium leading-tight"
                 />
-                <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                    {formatBytes(file.size)}
-                    <span aria-hidden> · </span>
-                    {formatDate(file.createdAt)}
-                    {downloadWindow && (
-                        <>
-                            <span aria-hidden> · </span>
-                            {downloadWindow}
-                        </>
-                    )}
-                </p>
-            </div>
-            <StatusDot status={status} compact />
-            <div onClick={(e) => e.stopPropagation()}>
-                <FileActions
-                    status={status}
-                    storageTier={file.storageTier}
-                    {...actions}
-                />
-            </div>
-        </li>
+            }
+            meta={[
+                formatBytes(file.size),
+                formatDate(file.createdAt),
+                downloadWindow,
+            ]}
+            trailing={
+                <>
+                    <StatusDot status={status} />
+                    <div onClick={(e) => e.stopPropagation()}>
+                        <FileActions
+                            status={status}
+                            storageTier={file.storageTier}
+                            {...actions}
+                        />
+                    </div>
+                </>
+            }
+        />
     );
 }

--- a/apps/web/components/dashboard/file-browser/MobileFileRow.tsx
+++ b/apps/web/components/dashboard/file-browser/MobileFileRow.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { cn } from '@/lib/cn';
+import { formatBytes, formatDate } from '@/lib/format';
+import { deriveStatus, getDownloadWindowLabel } from './status';
+import { SelectableIcon, StatusDot } from './SelectableIcon';
+import { FileActions, useFileActions } from './FileActions';
+import { MiddleTruncateName } from '../MiddleTruncateName';
+import type { FileItemProps } from './types';
+
+/* Below sm the 6-column table can't give the name meaningful width, so the
+   list view renders these stacked rows instead (same treatment as the
+   dashboard's Recent Uploads): name on its own line, metadata demoted to a
+   second line, status demoted to a dot. Selection and actions keep the same
+   entry points as FileRow — icon tap and the actions menu. */
+export function MobileFileRow({
+    file,
+    isSelected,
+    isHighlighted,
+    hasSelection,
+    onSelect,
+    ref,
+}: FileItemProps) {
+    const status = deriveStatus(file);
+    const actions = useFileActions(file);
+    const downloadWindow = getDownloadWindowLabel(file);
+
+    return (
+        <li
+            ref={ref}
+            data-state={isSelected ? 'selected' : undefined}
+            className={cn(
+                'flex cursor-pointer items-center gap-3 px-2 py-3 transition-colors',
+                isSelected && 'bg-primary/4 dark:bg-primary/8',
+                isHighlighted && 'bg-primary/10 dark:bg-primary/15'
+            )}
+            onClick={(e) => onSelect(e.shiftKey)}
+        >
+            <SelectableIcon
+                name={file.name}
+                checked={isSelected}
+                onCheckedChange={() => onSelect(false)}
+                showCheckbox={hasSelection}
+                size="sm"
+            />
+            <div className="min-w-0 flex-1">
+                <MiddleTruncateName
+                    name={file.name}
+                    className="font-medium leading-tight"
+                />
+                <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                    {formatBytes(file.size)}
+                    <span aria-hidden> · </span>
+                    {formatDate(file.createdAt)}
+                    {downloadWindow && (
+                        <>
+                            <span aria-hidden> · </span>
+                            {downloadWindow}
+                        </>
+                    )}
+                </p>
+            </div>
+            <StatusDot status={status} compact />
+            <div onClick={(e) => e.stopPropagation()}>
+                <FileActions
+                    status={status}
+                    storageTier={file.storageTier}
+                    {...actions}
+                />
+            </div>
+        </li>
+    );
+}

--- a/apps/web/components/dashboard/file-browser/SelectableIcon.tsx
+++ b/apps/web/components/dashboard/file-browser/SelectableIcon.tsx
@@ -4,9 +4,19 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { cn } from '@/lib/cn';
 import { getFileTypeInfo, type DerivedStatus } from './status';
 
-export function StatusDot({ status }: { status: DerivedStatus }) {
+export function StatusDot({
+    status,
+    compact = false,
+}: {
+    status: DerivedStatus;
+    /** Dot only, label demoted to sr-only — for width-starved mobile rows. */
+    compact?: boolean;
+}) {
     return (
-        <span className="inline-flex items-center gap-1.5">
+        <span
+            className="inline-flex items-center gap-1.5"
+            title={compact ? status : undefined}
+        >
             <span
                 className={cn(
                     'relative inline-block size-2 rounded-full',
@@ -21,12 +31,16 @@ export function StatusDot({ status }: { status: DerivedStatus }) {
             </span>
             <span
                 className={cn(
-                    'text-xs capitalize',
-                    status === 'archived' && 'text-muted-foreground',
-                    status === 'retrieving' &&
-                        'text-blue-600 dark:text-blue-400',
-                    status === 'available' &&
-                        'text-emerald-600 dark:text-emerald-400'
+                    compact
+                        ? 'sr-only'
+                        : cn(
+                              'text-xs capitalize',
+                              status === 'archived' && 'text-muted-foreground',
+                              status === 'retrieving' &&
+                                  'text-blue-600 dark:text-blue-400',
+                              status === 'available' &&
+                                  'text-emerald-600 dark:text-emerald-400'
+                          )
                 )}
             >
                 {status}

--- a/apps/web/components/dashboard/file-browser/SelectableIcon.tsx
+++ b/apps/web/components/dashboard/file-browser/SelectableIcon.tsx
@@ -4,19 +4,9 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { cn } from '@/lib/cn';
 import { getFileTypeInfo, type DerivedStatus } from './status';
 
-export function StatusDot({
-    status,
-    compact = false,
-}: {
-    status: DerivedStatus;
-    /** Dot only, label demoted to sr-only — for width-starved mobile rows. */
-    compact?: boolean;
-}) {
+export function StatusDot({ status }: { status: DerivedStatus }) {
     return (
-        <span
-            className="inline-flex items-center gap-1.5"
-            title={compact ? status : undefined}
-        >
+        <span className="inline-flex items-center gap-1.5">
             <span
                 className={cn(
                     'relative inline-block size-2 rounded-full',
@@ -31,16 +21,12 @@ export function StatusDot({
             </span>
             <span
                 className={cn(
-                    compact
-                        ? 'sr-only'
-                        : cn(
-                              'text-xs capitalize',
-                              status === 'archived' && 'text-muted-foreground',
-                              status === 'retrieving' &&
-                                  'text-blue-600 dark:text-blue-400',
-                              status === 'available' &&
-                                  'text-emerald-600 dark:text-emerald-400'
-                          )
+                    'text-xs capitalize',
+                    status === 'archived' && 'text-muted-foreground',
+                    status === 'retrieving' &&
+                        'text-blue-600 dark:text-blue-400',
+                    status === 'available' &&
+                        'text-emerald-600 dark:text-emerald-400'
                 )}
             >
                 {status}

--- a/apps/web/components/ui/responsive-rows.tsx
+++ b/apps/web/components/ui/responsive-rows.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+interface ResponsiveRowsProps {
+    /* Stacked-row copy, shown below `sm`. Rendered FIRST in the DOM: the e2e
+       filename locators use `.first()` and must resolve to the visible copy at
+       phone widths (390px). Both copies mount, so any per-row ref or effect
+       fires twice — a focus/scroll effect must skip the display:none copy
+       (see FileBrowser's focusRowRef `offsetParent === null` guard). */
+    mobile: ReactNode;
+    /* Real-table copy, shown at `sm` and up. */
+    desktop: ReactNode;
+}
+
+/* Pairs a stacked mobile list with a desktop table under one breakpoint, so
+   the `sm:hidden` / `hidden sm:block` split and the mobile-first DOM order it
+   depends on live in one place instead of being hand-copied per table
+   (a name-starved 6-column table below sm — #311/#339). Both halves render
+   from the same data source; this only owns which one is visible. */
+export function ResponsiveRows({ mobile, desktop }: ResponsiveRowsProps) {
+    return (
+        <>
+            <div className="sm:hidden">{mobile}</div>
+            <div className="hidden sm:block">{desktop}</div>
+        </>
+    );
+}

--- a/apps/web/components/ui/stacked-list.tsx
+++ b/apps/web/components/ui/stacked-list.tsx
@@ -1,0 +1,64 @@
+import { Fragment, type ComponentProps, type ReactNode } from 'react';
+import { cn } from '@/lib/cn';
+
+/* The `<ul>` that holds StackedListRow items — the mobile counterpart to a
+   `<tbody>`. Kept separate so a caller can group rows (batch sections) or add
+   padding without the row primitive knowing about it. */
+export function StackedList({ className, ...props }: ComponentProps<'ul'>) {
+    return <ul className={cn('divide-y', className)} {...props} />;
+}
+
+interface StackedListRowProps extends ComponentProps<'li'> {
+    /** Leading slot: file icon, avatar, or a selection control. Omit for none. */
+    leading?: ReactNode;
+    /** Primary line — the row's title/name. */
+    primary: ReactNode;
+    /** Secondary metadata segments, joined with aria-hidden `·` separators.
+        Falsy entries are dropped, so a conditional segment (an optional expiry,
+        a download window) can't leave a dangling separator. */
+    meta?: ReactNode[];
+    /** Trailing slot: status, actions. Rendered as direct flex children, so a
+        fragment of several nodes keeps the row's gap between them. */
+    trailing?: ReactNode;
+}
+
+/* The mobile counterpart to a table row: an optional leading control, a
+   min-w-0 title plus a truncated metadata line, and a trailing status/actions
+   slot. The four responsive dashboard tables render their below-sm rows
+   through this, so they can't drift on spacing, truncation, or the metadata
+   separator. Extends the `<li>` props: a caller adds row padding, a click
+   handler, a highlight class, or a focus ref without any of that leaking into
+   the primitive. Anything richer than these four slots should be a bespoke
+   `<li>`, not a new prop here. */
+export function StackedListRow({
+    leading,
+    primary,
+    meta,
+    trailing,
+    className,
+    ...props
+}: StackedListRowProps) {
+    const segments = meta?.filter(Boolean) ?? [];
+    return (
+        <li
+            className={cn('flex items-center gap-3 py-3', className)}
+            {...props}
+        >
+            {leading}
+            <div className="min-w-0 flex-1">
+                {primary}
+                {segments.length > 0 && (
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                        {segments.map((segment, i) => (
+                            <Fragment key={i}>
+                                {i > 0 && <span aria-hidden> · </span>}
+                                {segment}
+                            </Fragment>
+                        ))}
+                    </p>
+                )}
+            </div>
+            {trailing}
+        </li>
+    );
+}

--- a/apps/web/e2e/admin/files.spec.ts
+++ b/apps/web/e2e/admin/files.spec.ts
@@ -3,7 +3,7 @@ import type { Page } from '@playwright/test';
 import { findUserByEmail, type File } from '@nexus/db/test-db';
 import { ADMIN_USER } from '../helpers/auth';
 import { seedFiles, cleanupFiles } from '../helpers/scenarios';
-import { waitForTableLoad } from '../helpers/table';
+import { fileName, waitForTableLoad } from '../helpers/table';
 
 const PAGE_URL = '/dashboard/files';
 
@@ -30,19 +30,17 @@ test.describe('sequential file deletion', () => {
             await page.goto(PAGE_URL);
             await waitForTableLoad(page, 'No files yet');
 
-            // Verify all 3 seeded files are visible. visible+first: each name
-            // renders several times — dual markup (stacked rows below sm +
-            // table) × MiddleTruncateName's two copies.
-            const fileName = (name: string) =>
-                page.getByText(name).filter({ visible: true }).first();
+            // Verify all 3 seeded files are visible. fileName scopes to the
+            // visible copy — each name renders several times (dual mobile/
+            // desktop markup × MiddleTruncateName's two copies).
             for (const file of seededFiles) {
-                await expect(fileName(file.name)).toBeVisible();
+                await expect(fileName(page, file.name)).toBeVisible();
             }
 
             // Delete first file. 30s: on a cold dev server this is the first
             // S3-touching mutation (route compile + SDK init can exceed 10s).
             await deleteFileByName(page, seededFiles[0].name);
-            await expect(fileName(seededFiles[0].name)).toBeHidden({
+            await expect(fileName(page, seededFiles[0].name)).toBeHidden({
                 timeout: 30_000,
             });
 
@@ -51,12 +49,12 @@ test.describe('sequential file deletion', () => {
             // initialized by the first delete), so the timeout stays tight
             // to keep guarding the no-refresh sequential-delete regression.
             await deleteFileByName(page, seededFiles[1].name);
-            await expect(fileName(seededFiles[1].name)).toBeHidden({
+            await expect(fileName(page, seededFiles[1].name)).toBeHidden({
                 timeout: 10_000,
             });
 
             // Third file should still be visible
-            await expect(fileName(seededFiles[2].name)).toBeVisible();
+            await expect(fileName(page, seededFiles[2].name)).toBeVisible();
 
             // Remove deleted files from cleanup list (already gone from DB)
             seededFiles = seededFiles.slice(2);

--- a/apps/web/e2e/admin/files.spec.ts
+++ b/apps/web/e2e/admin/files.spec.ts
@@ -30,15 +30,19 @@ test.describe('sequential file deletion', () => {
             await page.goto(PAGE_URL);
             await waitForTableLoad(page, 'No files yet');
 
-            // Verify all 3 seeded files are visible
+            // Verify all 3 seeded files are visible. visible+first: each name
+            // renders several times — dual markup (stacked rows below sm +
+            // table) × MiddleTruncateName's two copies.
+            const fileName = (name: string) =>
+                page.getByText(name).filter({ visible: true }).first();
             for (const file of seededFiles) {
-                await expect(page.getByText(file.name)).toBeVisible();
+                await expect(fileName(file.name)).toBeVisible();
             }
 
             // Delete first file. 30s: on a cold dev server this is the first
             // S3-touching mutation (route compile + SDK init can exceed 10s).
             await deleteFileByName(page, seededFiles[0].name);
-            await expect(page.getByText(seededFiles[0].name)).toBeHidden({
+            await expect(fileName(seededFiles[0].name)).toBeHidden({
                 timeout: 30_000,
             });
 
@@ -47,12 +51,12 @@ test.describe('sequential file deletion', () => {
             // initialized by the first delete), so the timeout stays tight
             // to keep guarding the no-refresh sequential-delete regression.
             await deleteFileByName(page, seededFiles[1].name);
-            await expect(page.getByText(seededFiles[1].name)).toBeHidden({
+            await expect(fileName(seededFiles[1].name)).toBeHidden({
                 timeout: 10_000,
             });
 
             // Third file should still be visible
-            await expect(page.getByText(seededFiles[2].name)).toBeVisible();
+            await expect(fileName(seededFiles[2].name)).toBeVisible();
 
             // Remove deleted files from cleanup list (already gone from DB)
             seededFiles = seededFiles.slice(2);

--- a/apps/web/e2e/flows/files-browser.spec.ts
+++ b/apps/web/e2e/flows/files-browser.spec.ts
@@ -145,7 +145,10 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             await expect(page.getByText('4 files')).toBeVisible();
@@ -180,20 +183,32 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             const search = page.getByPlaceholder('Search files...');
             await search.fill('aaa');
 
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
             await expect(
-                page.getByText(seededLibrary.archivedB.name).first()
+                page
+                    .getByText(seededLibrary.archivedB.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeHidden();
             await expect(
-                page.getByText(seededLibrary.readyDoc.name).first()
+                page
+                    .getByText(seededLibrary.readyDoc.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeHidden();
 
             await search.fill('zzz-no-such-file');
@@ -201,7 +216,10 @@ test.describe('with a seeded library', () => {
 
             await search.clear();
             await expect(
-                page.getByText(seededLibrary.archivedB.name).first()
+                page
+                    .getByText(seededLibrary.archivedB.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
         }
     );
@@ -216,7 +234,10 @@ test.describe('with a seeded library', () => {
             await page.getByRole('button', { name: 'Grid view' }).click();
             await expect(page.locator('table')).toHaveCount(0);
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             await page.getByRole('button', { name: 'List view' }).click();
@@ -230,7 +251,10 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             const batchToggle = page.getByRole('button', {
@@ -240,15 +264,24 @@ test.describe('with a seeded library', () => {
 
             await batchToggle.click();
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeHidden();
             await expect(
-                page.getByText(seededLibrary.readyDoc.name).first()
+                page
+                    .getByText(seededLibrary.readyDoc.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible(); // other group untouched
 
             await batchToggle.click();
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
         }
     );
@@ -259,7 +292,10 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             await page.getByRole('checkbox', { name: 'Select all' }).click();
@@ -276,7 +312,10 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             // Click the first file's icon-checkbox, then shift-click the last
@@ -313,7 +352,10 @@ test.describe('with a seeded library', () => {
 
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             // Archived files selected → Retrieve opens the estimate dialog.
@@ -353,7 +395,10 @@ test.describe('with a seeded library', () => {
 
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedB.name).first()
+                page
+                    .getByText(seededLibrary.archivedB.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             await page
@@ -388,7 +433,10 @@ test.describe('with a seeded library', () => {
 
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
             await expect(
                 page.getByRole('button', { name: /Restore batch/i })
@@ -411,7 +459,10 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.readyDoc.name).first()
+                page
+                    .getByText(seededLibrary.readyDoc.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             // The synthetic 7-day window (#257) renders exactly like a real
@@ -456,7 +507,10 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.standardDoc.name).first()
+                page
+                    .getByText(seededLibrary.standardDoc.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             // No retrieval yet → archived with Retrieve only, no Download,
@@ -493,7 +547,10 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             await page
@@ -515,18 +572,30 @@ test.describe('with a seeded library', () => {
                 .click();
 
             await expect(
-                page.getByText(seededLibrary.archivedA.name).first()
+                page
+                    .getByText(seededLibrary.archivedA.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeHidden({
                 timeout: 10_000,
             });
             await expect(
-                page.getByText(seededLibrary.archivedB.name).first()
+                page
+                    .getByText(seededLibrary.archivedB.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeHidden();
             await expect(
-                page.getByText(seededLibrary.readyDoc.name).first()
+                page
+                    .getByText(seededLibrary.readyDoc.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
             await expect(
-                page.getByText(seededLibrary.standardDoc.name).first()
+                page
+                    .getByText(seededLibrary.standardDoc.name)
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
         }
     );

--- a/apps/web/e2e/flows/files-browser.spec.ts
+++ b/apps/web/e2e/flows/files-browser.spec.ts
@@ -145,7 +145,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
 
             await expect(page.getByText('4 files')).toBeVisible();
@@ -180,20 +180,20 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
 
             const search = page.getByPlaceholder('Search files...');
             await search.fill('aaa');
 
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
             await expect(
-                page.getByText(seededLibrary.archivedB.name)
+                page.getByText(seededLibrary.archivedB.name).first()
             ).toBeHidden();
             await expect(
-                page.getByText(seededLibrary.readyDoc.name)
+                page.getByText(seededLibrary.readyDoc.name).first()
             ).toBeHidden();
 
             await search.fill('zzz-no-such-file');
@@ -201,7 +201,7 @@ test.describe('with a seeded library', () => {
 
             await search.clear();
             await expect(
-                page.getByText(seededLibrary.archivedB.name)
+                page.getByText(seededLibrary.archivedB.name).first()
             ).toBeVisible();
         }
     );
@@ -216,7 +216,7 @@ test.describe('with a seeded library', () => {
             await page.getByRole('button', { name: 'Grid view' }).click();
             await expect(page.locator('table')).toHaveCount(0);
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
 
             await page.getByRole('button', { name: 'List view' }).click();
@@ -230,7 +230,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
 
             const batchToggle = page.getByRole('button', {
@@ -240,15 +240,15 @@ test.describe('with a seeded library', () => {
 
             await batchToggle.click();
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeHidden();
             await expect(
-                page.getByText(seededLibrary.readyDoc.name)
+                page.getByText(seededLibrary.readyDoc.name).first()
             ).toBeVisible(); // other group untouched
 
             await batchToggle.click();
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
         }
     );
@@ -259,7 +259,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
 
             await page.getByRole('checkbox', { name: 'Select all' }).click();
@@ -276,7 +276,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
 
             // Click the first file's icon-checkbox, then shift-click the last
@@ -313,7 +313,7 @@ test.describe('with a seeded library', () => {
 
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
 
             // Archived files selected → Retrieve opens the estimate dialog.
@@ -353,7 +353,7 @@ test.describe('with a seeded library', () => {
 
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedB.name)
+                page.getByText(seededLibrary.archivedB.name).first()
             ).toBeVisible();
 
             await page
@@ -388,7 +388,7 @@ test.describe('with a seeded library', () => {
 
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
             await expect(
                 page.getByRole('button', { name: /Restore batch/i })
@@ -411,7 +411,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.readyDoc.name)
+                page.getByText(seededLibrary.readyDoc.name).first()
             ).toBeVisible();
 
             // The synthetic 7-day window (#257) renders exactly like a real
@@ -456,7 +456,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.standardDoc.name)
+                page.getByText(seededLibrary.standardDoc.name).first()
             ).toBeVisible();
 
             // No retrieval yet → archived with Retrieve only, no Download,
@@ -493,7 +493,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeVisible();
 
             await page
@@ -515,18 +515,18 @@ test.describe('with a seeded library', () => {
                 .click();
 
             await expect(
-                page.getByText(seededLibrary.archivedA.name)
+                page.getByText(seededLibrary.archivedA.name).first()
             ).toBeHidden({
                 timeout: 10_000,
             });
             await expect(
-                page.getByText(seededLibrary.archivedB.name)
+                page.getByText(seededLibrary.archivedB.name).first()
             ).toBeHidden();
             await expect(
-                page.getByText(seededLibrary.readyDoc.name)
+                page.getByText(seededLibrary.readyDoc.name).first()
             ).toBeVisible();
             await expect(
-                page.getByText(seededLibrary.standardDoc.name)
+                page.getByText(seededLibrary.standardDoc.name).first()
             ).toBeVisible();
         }
     );

--- a/apps/web/e2e/flows/files-browser.spec.ts
+++ b/apps/web/e2e/flows/files-browser.spec.ts
@@ -26,6 +26,7 @@ import {
     deleteUserData,
 } from '@nexus/db/test-db';
 import { interceptTrpcCalls } from '../helpers/trpc';
+import { fileName } from '../helpers/table';
 
 const FILES_USER: TestUser = {
     email: 'files-browser-e2e@test.local',
@@ -145,10 +146,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
 
             await expect(page.getByText('4 files')).toBeVisible();
@@ -183,32 +181,20 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
 
             const search = page.getByPlaceholder('Search files...');
             await search.fill('aaa');
 
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
             await expect(
-                page
-                    .getByText(seededLibrary.archivedB.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedB.name)
             ).toBeHidden();
             await expect(
-                page
-                    .getByText(seededLibrary.readyDoc.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.readyDoc.name)
             ).toBeHidden();
 
             await search.fill('zzz-no-such-file');
@@ -216,10 +202,7 @@ test.describe('with a seeded library', () => {
 
             await search.clear();
             await expect(
-                page
-                    .getByText(seededLibrary.archivedB.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedB.name)
             ).toBeVisible();
         }
     );
@@ -234,10 +217,7 @@ test.describe('with a seeded library', () => {
             await page.getByRole('button', { name: 'Grid view' }).click();
             await expect(page.locator('table')).toHaveCount(0);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
 
             await page.getByRole('button', { name: 'List view' }).click();
@@ -251,10 +231,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
 
             const batchToggle = page.getByRole('button', {
@@ -264,24 +241,15 @@ test.describe('with a seeded library', () => {
 
             await batchToggle.click();
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeHidden();
             await expect(
-                page
-                    .getByText(seededLibrary.readyDoc.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.readyDoc.name)
             ).toBeVisible(); // other group untouched
 
             await batchToggle.click();
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
         }
     );
@@ -292,10 +260,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
 
             await page.getByRole('checkbox', { name: 'Select all' }).click();
@@ -312,10 +277,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
 
             // Click the first file's icon-checkbox, then shift-click the last
@@ -352,10 +314,7 @@ test.describe('with a seeded library', () => {
 
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
 
             // Archived files selected → Retrieve opens the estimate dialog.
@@ -395,10 +354,7 @@ test.describe('with a seeded library', () => {
 
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedB.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedB.name)
             ).toBeVisible();
 
             await page
@@ -433,10 +389,7 @@ test.describe('with a seeded library', () => {
 
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
             await expect(
                 page.getByRole('button', { name: /Restore batch/i })
@@ -459,10 +412,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.readyDoc.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.readyDoc.name)
             ).toBeVisible();
 
             // The synthetic 7-day window (#257) renders exactly like a real
@@ -507,10 +457,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.standardDoc.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.standardDoc.name)
             ).toBeVisible();
 
             // No retrieval yet → archived with Retrieve only, no Download,
@@ -547,10 +494,7 @@ test.describe('with a seeded library', () => {
         async ({ page, seededLibrary }) => {
             await page.goto(PAGE_URL);
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeVisible();
 
             await page
@@ -572,30 +516,18 @@ test.describe('with a seeded library', () => {
                 .click();
 
             await expect(
-                page
-                    .getByText(seededLibrary.archivedA.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedA.name)
             ).toBeHidden({
                 timeout: 10_000,
             });
             await expect(
-                page
-                    .getByText(seededLibrary.archivedB.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.archivedB.name)
             ).toBeHidden();
             await expect(
-                page
-                    .getByText(seededLibrary.readyDoc.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.readyDoc.name)
             ).toBeVisible();
             await expect(
-                page
-                    .getByText(seededLibrary.standardDoc.name)
-                    .filter({ visible: true })
-                    .first()
+                fileName(page, seededLibrary.standardDoc.name)
             ).toBeVisible();
         }
     );

--- a/apps/web/e2e/helpers/table.ts
+++ b/apps/web/e2e/helpers/table.ts
@@ -1,4 +1,15 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * Locates a file by (sub)string of its name in the file list, tolerant of the
+ * dual mobile/desktop markup and MiddleTruncateName's twin copies (a full
+ * sr-only span + a fitted aria-hidden span). Each name renders several times,
+ * so a bare `getByText(name)` trips Playwright strict mode — scope to the
+ * visible copy and take the first match.
+ */
+export function fileName(page: Page, name: string): Locator {
+    return page.getByText(name).filter({ visible: true }).first();
+}
 
 /**
  * Waits for a data-table page to finish loading: either the table itself or

--- a/apps/web/e2e/smoke/authenticated/files-grouped.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/files-grouped.spec.ts
@@ -80,14 +80,18 @@ test.describe('grouped files page', () => {
             ).toBeVisible();
 
             // Files inside the batch are visible by default (expanded).
-            await expect(page.getByText('batched-a.txt')).toBeVisible();
-            await expect(page.getByText('batched-b.txt')).toBeVisible();
+            // .first(): MiddleTruncateName renders the name twice (sr-only
+            // full copy + aria-hidden fitted copy).
+            await expect(page.getByText('batched-a.txt').first()).toBeVisible();
+            await expect(page.getByText('batched-b.txt').first()).toBeVisible();
 
             // Ungrouped section renders for the legacy file.
             await expect(
                 page.getByRole('heading', { name: 'Ungrouped' })
             ).toBeVisible();
-            await expect(page.getByText('legacy-orphan.txt')).toBeVisible();
+            await expect(
+                page.getByText('legacy-orphan.txt').first()
+            ).toBeVisible();
 
             expect(consoleErrors).toEqual([]);
         }

--- a/apps/web/e2e/smoke/authenticated/files-grouped.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/files-grouped.spec.ts
@@ -71,8 +71,12 @@ test.describe('grouped files page', () => {
                 page.getByRole('heading', { name: groupedFiles.batchName })
             ).toBeVisible();
 
-            // Metadata line shows "2 files · 300 Bytes · ..."
-            await expect(page.getByText(/2 files · 300 Bytes/)).toBeVisible();
+            // Metadata line shows "2 files · 300 Bytes · ...". The list view
+            // is dual markup (stacked rows below sm + table), so the batch
+            // header renders twice — filter to the copy the viewport shows.
+            await expect(
+                page.getByText(/2 files · 300 Bytes/).filter({ visible: true })
+            ).toBeVisible();
 
             // Restore batch button is visible (both files are glacier+available).
             await expect(
@@ -80,17 +84,31 @@ test.describe('grouped files page', () => {
             ).toBeVisible();
 
             // Files inside the batch are visible by default (expanded).
-            // .first(): MiddleTruncateName renders the name twice (sr-only
-            // full copy + aria-hidden fitted copy).
-            await expect(page.getByText('batched-a.txt').first()).toBeVisible();
-            await expect(page.getByText('batched-b.txt').first()).toBeVisible();
+            // visible+first: each name renders four times — dual markup
+            // (stacked rows below sm + table) × MiddleTruncateName's two
+            // copies (sr-only full name + aria-hidden fitted).
+            await expect(
+                page
+                    .getByText('batched-a.txt')
+                    .filter({ visible: true })
+                    .first()
+            ).toBeVisible();
+            await expect(
+                page
+                    .getByText('batched-b.txt')
+                    .filter({ visible: true })
+                    .first()
+            ).toBeVisible();
 
             // Ungrouped section renders for the legacy file.
             await expect(
                 page.getByRole('heading', { name: 'Ungrouped' })
             ).toBeVisible();
             await expect(
-                page.getByText('legacy-orphan.txt').first()
+                page
+                    .getByText('legacy-orphan.txt')
+                    .filter({ visible: true })
+                    .first()
             ).toBeVisible();
 
             expect(consoleErrors).toEqual([]);

--- a/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
+++ b/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
@@ -31,6 +31,7 @@ import {
     insertStorageUsage,
 } from '@nexus/db/test-db';
 import { REGULAR_USER } from '../helpers/auth';
+import { fileName } from '../helpers/table';
 import { PLAN_LIMITS } from '@nexus/db/plans';
 
 // Single shared user → tests must run serially. Belt-and-braces: the
@@ -161,7 +162,9 @@ test.describe('upload batches + storage quota', () => {
                 page.getByRole('heading', { name: /^Upload \d{4}-\d{2}-\d{2}/ })
             ).toBeVisible();
             // The single uploaded file should be visible (default expanded).
-            await expect(page.getByText('validate-')).toBeVisible();
+            // visible+first: each name renders several times (dual mobile/
+            // desktop markup × MiddleTruncateName's two copies).
+            await expect(fileName(page, 'validate-')).toBeVisible();
 
             await page.screenshot({
                 path: `${SCREENSHOTS}/05-grouped-files-page.png`,

--- a/apps/web/lib/format.test.ts
+++ b/apps/web/lib/format.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { formatBytes, formatDate } from './format';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { formatBytes, formatDate, formatRelativeTimeCompact } from './format';
 
 describe('formatBytes', () => {
     it('returns "0 Bytes" for zero', () => {
@@ -36,5 +36,58 @@ describe('formatDate', () => {
 
     it('formats an ISO string', () => {
         expect(formatDate('2025-12-30T12:00:00.000Z')).toBe('Dec 30, 2025');
+    });
+});
+
+describe('formatRelativeTimeCompact', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-13T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns "just now" under a minute', () => {
+        expect(formatRelativeTimeCompact('2026-07-13T11:59:30Z')).toBe(
+            'just now'
+        );
+    });
+
+    it('formats minutes', () => {
+        expect(formatRelativeTimeCompact('2026-07-13T11:35:00Z')).toBe(
+            '25m ago'
+        );
+    });
+
+    it('formats hours', () => {
+        expect(formatRelativeTimeCompact('2026-07-13T09:00:00Z')).toBe(
+            '3h ago'
+        );
+    });
+
+    it('formats days', () => {
+        expect(formatRelativeTimeCompact('2026-07-12T11:00:00Z')).toBe(
+            '1d ago'
+        );
+    });
+
+    it('formats months', () => {
+        expect(formatRelativeTimeCompact('2026-05-01T12:00:00Z')).toBe(
+            '2mo ago'
+        );
+    });
+
+    it('formats years', () => {
+        expect(formatRelativeTimeCompact('2024-07-01T12:00:00Z')).toBe(
+            '2y ago'
+        );
+    });
+
+    it('accepts a Date object', () => {
+        expect(
+            formatRelativeTimeCompact(new Date('2026-07-13T10:00:00Z'))
+        ).toBe('2h ago');
     });
 });

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -34,7 +34,9 @@ export function formatRelativeTimeCompact(date: Date | string): string {
     if (hours < 24) return `${hours}h ago`;
     const days = Math.floor(hours / 24);
     if (days < 30) return `${days}d ago`;
-    if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+    // Cap at 11mo: 30-day months overshoot the 365-day year, so days 360-364
+    // would floor to a nonsensical "12mo ago" before the year branch is hit.
+    if (days < 365) return `${Math.min(11, Math.floor(days / 30))}mo ago`;
     return `${Math.floor(days / 365)}y ago`;
 }
 

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -19,6 +19,26 @@ export function formatRelativeTime(date: Date | string): string {
 }
 
 /**
+ * Compact relative time for narrow layouts ("25m ago", "1d ago") where the
+ * full formatRelativeTime copy ("25 minutes ago") costs pixels it doesn't
+ * earn. Month/year buckets are calendar-approximate (30/365 days) — fine at
+ * this granularity.
+ */
+export function formatRelativeTimeCompact(date: Date | string): string {
+    const elapsedMinutes = Math.floor(
+        (Date.now() - new Date(date).getTime()) / 60_000
+    );
+    if (elapsedMinutes < 1) return 'just now';
+    if (elapsedMinutes < 60) return `${elapsedMinutes}m ago`;
+    const hours = Math.floor(elapsedMinutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+    return `${Math.floor(days / 365)}y ago`;
+}
+
+/**
  * Download-window copy for a ready retrieval, identical for both storage
  * tiers: standard fast-path rows carry a synthetic expiresAt, Deep Archive
  * rows the real S3 restore expiry (#257). Null when there is no window to

--- a/docs/ai/conventions.md
+++ b/docs/ai/conventions.md
@@ -1,7 +1,7 @@
 ---
 title: Code Conventions
 created: 2025-12-29
-updated: 2026-07-09
+updated: 2026-07-13
 status: active
 tags:
     - ai
@@ -88,6 +88,12 @@ looked perfect, so it shipped.
   the child refuses to shrink below its content and drags the whole layout
   past the viewport. This silently defeats any `overflow-x-auto` wrapper
   below it — the wrapper can never engage.
+- **User-supplied filenames render through `MiddleTruncateName`**
+  (`components/dashboard/MiddleTruncateName.tsx`), never `truncate` —
+  end-truncation makes burst siblings (`_MG_4501.CR2` vs `_MG_4524.CR2`)
+  indistinguishable and hides the extension. The component middle-truncates
+  (grapheme-safe, JS-measured) and keeps the full name in the DOM for screen
+  readers, tooltips, and e2e locators.
 - **`truncate` only works inside a width-constrained ancestor.** In an
   auto-layout table the column just grows to the full string; constrain the
   cell (`w-full max-w-0` for a greedy truncating column, or `table-fixed`).


### PR DESCRIPTION
## Summary

The dashboard Recent Uploads table let Size/Uploaded cells wrap when squeezed, interleaving "433.26 KB" and "25 minutes ago" into a garbled blob and inflating row heights, while the Name column sat mostly empty. Review iterations then pushed it further: end-truncation made burst siblings indistinguishable and hid extensions, below ~640px the 4-column table left the name a single visible character, and the CSS middle-truncation pass left a visible hole at the ellipsis seam.

**`d32ae64` — column sizing:**

- Size / Uploaded / Status cells: `whitespace-nowrap` + `pr-4` separation. Metadata takes natural width; Name (already `w-full max-w-0` from #311) is the one flexible column. Row heights are uniform.
- Tightened the subtitle-to-header gap: the CardHeader `pb-3` was a no-op under Card's `flex-col gap-6`; the card now uses `gap-4`.

**`081734f` — truncation + responsive rework:**

- Middle truncation so burst counters and the `.dng` vs `.jpg` extension survive; full name in a `title` tooltip.
- Size column right-aligned + `tabular-nums`.
- Below `sm` the table becomes a stacked list: full-width name line, `48 MB · 1d ago` secondary line (new `formatRelativeTimeCompact`, unit-tested), status demoted to a green dot for `available`. Dual markup (`sm:hidden` list / `hidden sm:block` table); the list precedes the table in the DOM so the #311 overflow spec's `.first()` assertion hits the visible copy.

**`ced542d` — truncation seam + status a11y:**

- The CSS two-span middle truncation left a blank hole at the seam. Measured empirically: the spans were flush (`tailRect.left - headRect.right = 0`) — the gap was _inside_ the head span, where `text-overflow` paints "…" after the last fully-fitting glyph and leaves the rest of the box blank. CSS can't close that, so truncation is now JS-measured (`ResizeObserver` + canvas `measureText`, binary search over graphemes) and renders one `head…tail` text run — ellipsis flush against the tail, and spare width falls after the name instead of inside it.
- The full filename stays in the DOM (`sr-only`) with the fitted copy `aria-hidden` — screen readers get the clean name, e2e locators keep matching, `title` covers hover.
- Status dot keeps `sr-only` "Available" text (never color-only); mobile `restoring` badge gains a `RotateCw` glyph so it differs from other states by more than hue; dot and badge get an explicit `self-center` anchor.

**`ef2ca25` — card header structure:**

- The header was a flexible two-line text block and a fixed button sharing one flex row — the subtitle happened to be the widest line, ran up against the button at narrow widths (and any longer localized copy would collide), and the button centered against the two-line block aligned with neither line. Now the View-all button pairs with the title row (`items-center`, `gap-4`, `shrink-0`) and the subtitle owns the full width below, so long copy wraps harmlessly.
- The subtitle nearly restates the title, so below `sm` it's hidden — buys back a line where vertical space is scarcest.

**`86be090` — review follow-ups (tail cap + phantom header gap):**

- The 12-grapheme truncation tail was unconditional — at very narrow widths it left the head a single identifying character. The tail now sheds graphemes until it measures ≤ half the available width, so head and tail stay balanced all the way down (also fixes the short-name edge where a name under 12 graphemes became all tail).
- Hiding the subtitle below `sm` left a phantom 8px: `CardHeader` is a `grid grid-rows-[auto_auto] gap-2`, and `display:none` removes the grid item but not the explicit second row — the row gap stayed. Header now uses `gap-0 sm:gap-2`.

**`82fbffc` — extract `MiddleTruncateName`, adopt in the file browser:**

- The dashboard widget middle-truncated while the actual browser (where burst culling happens) still end-truncated via CSS, rendering `_MG_4501.CR2` through `_MG_4524.CR2` identically. The component moves to `components/dashboard/MiddleTruncateName.tsx` and replaces `truncate` in `FileRow`/`FileCard`; convention documented in `docs/ai/conventions.md`.
- E2E filename locators gain `.first()` — the component renders the full name twice (sr-only copy + aria-hidden fitted copy).

**`1fe6f30` — files list view stacked below `sm`:**

- The files-page list view had the identical structural bug this PR opened with: below `sm` the 6-column table starved the name column to a few characters (invisible on an empty account, same as #311). The list view now dual-renders like the dashboard widget — compact stacked rows below `sm` (new `MobileFileRow`: middle-truncated name, `size · date` second line, status demoted to a dot with an sr-only label via a `StatusDot compact` prop, selection via icon tap + actions menu kept), table above.
- The deep-link focus ref skips `display:none` copies so `?file={id}` scrolls whichever copy the viewport shows.
- E2E filename/batch locators use `.filter({ visible: true })` — dual markup doubles the text matches, and which copy is visible depends on the viewport.
- Audit of other surfaces found the same class only in the two admin tables, fixed in the next commit.

**`95893a5` — admin invites/jobs tables stacked below `sm`:**

- Invites had the exact starved-`max-w-0` pattern (recipient email behind five nowrap metadata columns); jobs was the sideways-scroll variant. Both dual-render now: stacked rows below `sm` with metadata compacted onto a second line (`formatRelativeTimeCompact`), badge + actions kept.
- Recipient emails middle-truncate via `MiddleTruncateName` in both copies — the domain stays visible.
- Copy-link/revoke and retry buttons extracted (`PendingInviteActions`, `RetryJobButton`) so table and mobile rows share them; `admin/files.spec.ts` locators gain the `filter({ visible: true })` treatment.

## Evidence

Dark mode, adversarial filenames seeded.

Desktop (1280px) — button anchored to the title line, subtitle full-width below, ellipsis flush at the seam (`…ort_KEEP.jpg`), sizes right-aligned:

![Recent Uploads table, desktop](https://github.com/user-attachments/assets/b2d113b9-563b-4609-875a-7b0febeda697)

Mobile (340px, the width where the subtitle used to crowd the button) — single-row header, stacked list rows, extensions still visible:

![Recent Uploads stacked list, mobile](https://github.com/user-attachments/assets/72fa1f8f-de34-411b-b1f6-edd3eda7c617)

## Testing

- `pnpm check` 10/10 (includes `formatRelativeTimeCompact` unit tests)
- `pnpm -F web test:e2e:smoke` 41/41 — includes the #311 mobile-overflow regression spec at 390px with adversarial filenames
- `pnpm -F web test:e2e:flows` 21/21 — file browser interactions with the extracted component
- `pnpm -F web test:e2e:admin` 20/20 — invites/jobs tables + files-page deletion flow against the dual markup

No-Issue: minor UI polish, no behavior change
