### PR TITLE
feat: PostHog — all-session replay, product events, identify, in-app feedback survey (#328)

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -39,3 +39,12 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # SENTRY_ORG=xxx
 # SENTRY_PROJECT=xxx
 # SENTRY_AUTH_TOKEN=sntrys_xxx
+
+# PostHog product analytics (deployed Vercel envs only — leave unset locally!)
+# Same rule as Sentry: the key's presence is half the gate that turns session
+# replay and autocapture on, so setting it here would break the
+# zero-console-error smoke assertions. Configured in Vercel env (production +
+# preview tiers). NEXT_PUBLIC_POSTHOG_HOST is the ingestion host; unset falls
+# back to US cloud (see lib/posthog/hosts.ts).
+# NEXT_PUBLIC_POSTHOG_KEY=phc_xxx
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import { ClientErrorReporter } from '@/components/ClientErrorReporter';
+import { PostHogAnalytics } from '@/components/PostHogAnalytics';
 import { ThemeProvider } from '@/components/theme-provider';
 import { TRPCReactProvider } from '@/lib/trpc/client';
 import { Analytics } from '@vercel/analytics/next';
@@ -42,6 +43,7 @@ export default function RootLayout({
                 >
                     <TRPCReactProvider>
                         <ClientErrorReporter />
+                        <PostHogAnalytics />
                         {children}
                     </TRPCReactProvider>
                 </ThemeProvider>

--- a/apps/web/components/PostHogAnalytics.tsx
+++ b/apps/web/components/PostHogAnalytics.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useSession } from '@/lib/auth/client';
+import { identifyUser, initAnalytics } from '@/lib/posthog/client';
+
+/**
+ * Boots PostHog and keeps the identified person in sync with the session.
+ * Renders nothing — posthog-js is a singleton, so nothing downstream needs
+ * React context; this mirrors ClientErrorReporter rather than wrapping the
+ * tree in a provider that would carry no value.
+ *
+ * `reset()` deliberately isn't here. useSession reports no user while the
+ * session is still loading, which is indistinguishable at this level from a
+ * sign-out, so an effect that reset on "user went away" would wipe the
+ * distinct id on every cold load. Sign-out calls resetAnalytics() directly
+ * (components/dashboard/header.tsx), where the intent is unambiguous.
+ */
+export function PostHogAnalytics(): null {
+    const { data: session } = useSession();
+    const userId = session?.user?.id;
+
+    useEffect(() => {
+        initAnalytics();
+    }, []);
+
+    useEffect(() => {
+        if (userId) identifyUser(userId);
+    }, [userId]);
+
+    return null;
+}

--- a/apps/web/components/auth/sign-up-form.tsx
+++ b/apps/web/components/auth/sign-up-form.tsx
@@ -14,6 +14,8 @@ import { GoogleIcon } from '@/components/icons/google-icon';
 import { OAuthDivider } from '@/components/auth/oauth-divider';
 import { signUp } from '@/lib/auth/client';
 import { DEFAULT_REDIRECT } from '@/lib/auth/sanitizeRedirect';
+import { captureEvent } from '@/lib/posthog/client';
+import { PostHogEvent } from '@/lib/posthog/events';
 
 interface SignUpFormProps {
     /** Sanitized path to land on after a successful sign-up. */
@@ -64,6 +66,14 @@ export function SignUpForm({
             setError(result.error.message ?? 'Failed to create account');
             return;
         }
+
+        // Fires before identify(): the session hasn't propagated yet, so this
+        // lands on the anonymous distinct id and PostHog stitches it to the
+        // person once PostHogAnalytics identifies on the next page.
+        captureEvent(PostHogEvent.SignedUp, {
+            method: 'email',
+            isInvited: inviteToken !== undefined,
+        });
 
         router.push(redirectTo);
     }

--- a/apps/web/components/dashboard/file-browser/FileActions.tsx
+++ b/apps/web/components/dashboard/file-browser/FileActions.tsx
@@ -22,6 +22,8 @@ import { useTRPC } from '@/lib/trpc/client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useInvalidateFileList } from '@/lib/hooks/useInvalidateFileList';
+import { captureEvent } from '@/lib/posthog/client';
+import { PostHogEvent } from '@/lib/posthog/events';
 import { RetrieveDialog } from '@/components/dashboard/RetrieveDialog';
 import type { FileWithRetrieval } from '@nexus/db/repo/files';
 import type { DerivedStatus } from './status';
@@ -41,6 +43,10 @@ export function useFileActions(file: FileWithRetrieval) {
         trpc.files.requestRetrieval.mutationOptions({
             onSuccess() {
                 invalidateFileList();
+                captureEvent(PostHogEvent.RetrievalRequested, {
+                    fileCount: 1,
+                    storageTier: file.storageTier,
+                });
                 toast.success('Retrieval request submitted');
             },
         })
@@ -51,6 +57,11 @@ export function useFileActions(file: FileWithRetrieval) {
             const { url } = await queryClient.fetchQuery(
                 trpc.files.getDownloadUrl.queryOptions({ fileId: file.id })
             );
+            captureEvent(PostHogEvent.FileDownloaded, {
+                fileId: file.id,
+                sizeBytes: file.size,
+                storageTier: file.storageTier,
+            });
             window.open(url, '_blank');
         } catch {
             toast.error('Failed to get download URL');

--- a/apps/web/components/dashboard/file-browser/FileBrowser.tsx
+++ b/apps/web/components/dashboard/file-browser/FileBrowser.tsx
@@ -39,6 +39,8 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useDebouncedValue } from '@/lib/hooks/useDebouncedValue';
 import { useInvalidateFileList } from '@/lib/hooks/useInvalidateFileList';
+import { captureEvent } from '@/lib/posthog/client';
+import { PostHogEvent } from '@/lib/posthog/events';
 import { RetrieveDialog } from '@/components/dashboard/RetrieveDialog';
 import { deriveStatus } from './status';
 import { BatchHeader, BatchHeaderRow } from './BatchHeader';
@@ -137,9 +139,16 @@ export function FileBrowser({ focusFileId }: FileBrowserProps) {
 
     const bulkRetrievalMutation = useMutation(
         trpc.files.requestBulkRetrieval.mutationOptions({
-            onSuccess() {
+            // `variables` rather than the selection state: the selection is
+            // cleared just below, and it can hold non-archived files the
+            // request already filtered out.
+            onSuccess(_data, variables) {
                 invalidateFileList();
                 setSelectedFiles([]);
+                captureEvent(PostHogEvent.RetrievalRequested, {
+                    fileCount: variables.fileIds.length,
+                    isBulk: true,
+                });
                 toast.success('Retrieval requests submitted');
             },
         })

--- a/apps/web/components/dashboard/header.tsx
+++ b/apps/web/components/dashboard/header.tsx
@@ -13,10 +13,23 @@ import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { signOut, useSession } from '@/lib/auth/client';
 import { cn } from '@/lib/cn';
 import { getNavItems } from '@/lib/dashboard/navigation';
-import { Archive, LogOut, Menu, Settings, User } from 'lucide-react';
+import {
+    isAnalyticsEnabled,
+    resetAnalytics,
+    showFeedbackSurvey,
+} from '@/lib/posthog/client';
+import {
+    Archive,
+    LogOut,
+    Menu,
+    MessageSquare,
+    Settings,
+    User,
+} from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 export function DashboardHeader() {
     const pathname = usePathname();
@@ -27,7 +40,16 @@ export function DashboardHeader() {
 
     async function handleSignOut() {
         await signOut();
+        // Before the redirect: unbinds the distinct id so anything the next
+        // visitor does on this browser isn't attributed to the user who left.
+        resetAnalytics();
         router.push('/');
+    }
+
+    function handleFeedback() {
+        showFeedbackSurvey(() =>
+            toast.error("Feedback form isn't available right now")
+        );
     }
 
     return (
@@ -111,6 +133,15 @@ export function DashboardHeader() {
                                 <Settings className="mr-2 h-4 w-4" />
                                 Settings
                             </DropdownMenuItem>
+                            {/* Hidden when analytics is off (local dev, CI,
+                                e2e) — the survey is served by PostHog, so
+                                without it this is a dead control. */}
+                            {isAnalyticsEnabled() && (
+                                <DropdownMenuItem onClick={handleFeedback}>
+                                    <MessageSquare className="mr-2 h-4 w-4" />
+                                    Send feedback
+                                </DropdownMenuItem>
+                            )}
                             <DropdownMenuSeparator />
                             <DropdownMenuItem onClick={handleSignOut}>
                                 <LogOut className="mr-2 h-4 w-4" />

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -33,6 +33,8 @@ import {
     isExpiredUrlError,
     isNetworkError,
     reportUploadFailure,
+    uploadEventProps,
+    type UploadEngine,
 } from '@/lib/upload/errors';
 import { captureEvent } from '@/lib/posthog/client';
 import { PostHogEvent } from '@/lib/posthog/events';
@@ -95,8 +97,6 @@ function randomId(): string {
     return Math.random().toString(36).substring(7);
 }
 
-type UploadEngine = 'single' | 'multipart';
-
 /**
  * `upload_started` counts *attempts*, not uploads: both engines are also the
  * entry point for retry and auto-resume-on-reconnect, so one file that drops
@@ -118,11 +118,7 @@ function trackUploadStarted(
     batchId: string | undefined
 ): void {
     captureEvent(PostHogEvent.UploadStarted, {
-        engine,
-        sizeBytes: uploadFile.size,
-        batchId,
-        clientUploadId: uploadFile.id,
-        fileId: uploadFile.fileId,
+        ...uploadEventProps(engine, { ...uploadFile, batchId }),
         // A row carrying either id has been through here before. Not the same
         // as "first attempt": an upload that dies before init assigns an id
         // re-enters as false, so dedupe on clientUploadId, not on this.
@@ -140,13 +136,10 @@ function trackUploadCompleted(
     fileId: string | undefined,
     batchId: string | undefined
 ): void {
-    captureEvent(PostHogEvent.UploadCompleted, {
-        engine,
-        fileId,
-        sizeBytes: uploadFile.size,
-        batchId,
-        clientUploadId: uploadFile.id,
-    });
+    captureEvent(
+        PostHogEvent.UploadCompleted,
+        uploadEventProps(engine, { ...uploadFile, fileId, batchId })
+    );
 }
 
 export function useUpload() {

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -100,10 +100,17 @@ type UploadEngine = 'single' | 'multipart';
 /**
  * `upload_started` counts *attempts*, not uploads: both engines are also the
  * entry point for retry and auto-resume-on-reconnect, so one file that drops
- * and comes back emits several. `isResume` is what a started→completed funnel
- * has to filter on, and keeping the repeats (rather than suppressing them)
- * leaves "how often does an upload need a second try" answerable. A row that
- * already carries an id has been through here before.
+ * and comes back emits several. Keeping the repeats (rather than suppressing
+ * them) is deliberate — suppression needs a "already emitted" flag persisted
+ * next to `completedParts`, and every way that flag can desync produces a
+ * *missing* start, which silently undercounts the top of the funnel. Extra
+ * events filter out at query time; absent ones don't come back.
+ *
+ * `clientUploadId` is what makes the attempts joinable, and it carries into
+ * `upload_completed`/`upload_failed` for the same reason. `fileId` can't do
+ * that job: the single engine mints a fresh one per attempt, so a retry looks
+ * like a different upload. Session-scoped, not global — a re-added row after
+ * reload gets a new one, which is the same boundary the join is useful across.
  */
 function trackUploadStarted(
     engine: UploadEngine,
@@ -114,7 +121,16 @@ function trackUploadStarted(
         engine,
         sizeBytes: uploadFile.size,
         batchId,
-        isResume: Boolean(uploadFile.uploadId ?? uploadFile.fileId),
+        clientUploadId: uploadFile.id,
+        fileId: uploadFile.fileId,
+        // A row carrying either id has been through here before. Not the same
+        // as "first attempt": an upload that dies before init assigns an id
+        // re-enters as false, so dedupe on clientUploadId, not on this.
+        isRetry: Boolean(uploadFile.uploadId ?? uploadFile.fileId),
+        // ...and only a multipart upload with a live S3 uploadId resumes from
+        // where it stopped. A single-engine retry restarts from byte zero, so
+        // counting it as a resume would flatter any bytes-saved read.
+        hasResumableState: Boolean(uploadFile.uploadId),
     });
 }
 
@@ -129,6 +145,7 @@ function trackUploadCompleted(
         fileId,
         sizeBytes: uploadFile.size,
         batchId,
+        clientUploadId: uploadFile.id,
     });
 }
 

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -34,6 +34,8 @@ import {
     isNetworkError,
     reportUploadFailure,
 } from '@/lib/upload/errors';
+import { captureEvent } from '@/lib/posthog/client';
+import { PostHogEvent } from '@/lib/posthog/events';
 
 const MULTIPART_THRESHOLD = 100 * 1024 * 1024; // 100MB
 const MAX_CONCURRENT_CHUNKS = 3;
@@ -91,6 +93,43 @@ interface InternalUploadFile extends UploadFile {
 
 function randomId(): string {
     return Math.random().toString(36).substring(7);
+}
+
+type UploadEngine = 'single' | 'multipart';
+
+/**
+ * `upload_started` counts *attempts*, not uploads: both engines are also the
+ * entry point for retry and auto-resume-on-reconnect, so one file that drops
+ * and comes back emits several. `isResume` is what a started→completed funnel
+ * has to filter on, and keeping the repeats (rather than suppressing them)
+ * leaves "how often does an upload need a second try" answerable. A row that
+ * already carries an id has been through here before.
+ */
+function trackUploadStarted(
+    engine: UploadEngine,
+    uploadFile: InternalUploadFile,
+    batchId: string | undefined
+): void {
+    captureEvent(PostHogEvent.UploadStarted, {
+        engine,
+        sizeBytes: uploadFile.size,
+        batchId,
+        isResume: Boolean(uploadFile.uploadId ?? uploadFile.fileId),
+    });
+}
+
+function trackUploadCompleted(
+    engine: UploadEngine,
+    uploadFile: InternalUploadFile,
+    fileId: string | undefined,
+    batchId: string | undefined
+): void {
+    captureEvent(PostHogEvent.UploadCompleted, {
+        engine,
+        fileId,
+        sizeBytes: uploadFile.size,
+        batchId,
+    });
 }
 
 export function useUpload() {
@@ -153,6 +192,7 @@ export function useUpload() {
                 status: 'uploading',
                 abortController,
             });
+            trackUploadStarted('single', uploadFile, sessionBatchId);
 
             // Carried outside the try so the failure report can include the
             // id once init has assigned it — the uploadFile closure predates
@@ -184,6 +224,12 @@ export function useUpload() {
                     status: 'complete',
                     progress: 100,
                 });
+                trackUploadCompleted(
+                    'single',
+                    uploadFile,
+                    fileId,
+                    sessionBatchId
+                );
                 await invalidateFileList();
             } catch (error) {
                 if (isAbortError(error)) {
@@ -227,6 +273,7 @@ export function useUpload() {
                 status: 'uploading',
                 abortController,
             });
+            trackUploadStarted('multipart', uploadFile, sessionBatchId);
 
             // Carried across the fresh-start / resume branches so the catch and
             // completion paths can act on whatever we managed to establish.
@@ -421,6 +468,12 @@ export function useUpload() {
                     status: 'complete',
                     progress: 100,
                 });
+                trackUploadCompleted(
+                    'multipart',
+                    uploadFile,
+                    fileId,
+                    sessionBatchId
+                );
                 await invalidateFileList();
             } catch (error) {
                 if (isAbortError(error)) {

--- a/apps/web/lib/env/schema.ts
+++ b/apps/web/lib/env/schema.ts
@@ -31,4 +31,12 @@ export const clientSchema = z.object({
     // (VERCEL server-side, NEXT_PUBLIC_VERCEL_ENV client-side) — so local
     // dev, CI, and e2e builds leave it unset. See instrumentation-client.ts.
     NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
+    // Same deployment gate as the Sentry DSN above, for the same reason. Not
+    // .url() — a PostHog project key is an opaque `phc_...` string.
+    NEXT_PUBLIC_POSTHOG_KEY: z.string().min(1).optional(),
+    // Ingestion host. Unset falls back to DEFAULT_POSTHOG_HOST (US cloud);
+    // set it to point at the EU region. lib/posthog/hosts.ts derives the
+    // asset and dashboard hosts from this by substring, which only holds for
+    // PostHog cloud — a self-hosted origin passes through unrewritten.
+    NEXT_PUBLIC_POSTHOG_HOST: z.string().url().optional(),
 });

--- a/apps/web/lib/posthog/client.ts
+++ b/apps/web/lib/posthog/client.ts
@@ -1,0 +1,124 @@
+'use client';
+
+import posthog, { DisplaySurveyType } from 'posthog-js';
+
+import {
+    DEFAULT_POSTHOG_HOST,
+    POSTHOG_INGEST_PATH,
+    resolveUiHost,
+} from './hosts';
+import type { PostHogEventName } from './events';
+
+/**
+ * Same double gate as instrumentation-client.ts: the key exists only in
+ * Vercel's production/preview env tiers (see ASYMMETRY_ALLOWLIST in
+ * scripts/check-vercel-env-parity.ts), and NEXT_PUBLIC_VERCEL_ENV — inlined on
+ * every deployment because the project auto-exposes system env vars;
+ * `process.env.VERCEL` isn't NEXT_PUBLIC_-prefixed so it can't gate here —
+ * keeps a stray .env.local key from turning PostHog on in local dev, CI, and
+ * the e2e production builds, which assert zero console errors.
+ *
+ * Raw process.env (not `@/lib/env`) is deliberate: the env proxy reads
+ * process.env[key] dynamically, which the bundler can't inline into browser
+ * code — only literal process.env.NEXT_PUBLIC_* expressions survive client
+ * bundling. The clientSchema entries still validate these; they just can't be
+ * the browser read site.
+ */
+const isEnabled = Boolean(
+    process.env.NEXT_PUBLIC_VERCEL_ENV && process.env.NEXT_PUBLIC_POSTHOG_KEY
+);
+
+let isInitialized = false;
+
+/** Whether analytics is live — gates UI that would otherwise be a dead control. */
+export function isAnalyticsEnabled(): boolean {
+    return isEnabled;
+}
+
+/** Idempotent: React strict mode double-invokes the mount effect. */
+export function initAnalytics(): void {
+    if (!isEnabled || isInitialized) return;
+    isInitialized = true;
+
+    const host = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST;
+
+    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+        // First-party proxy; next.config.ts rewrites this to `host`.
+        api_host: POSTHOG_INGEST_PATH,
+        ui_host: resolveUiHost(host),
+        // Opt into the current default set rather than the legacy ones. Most
+        // relevant here: capture_pageview becomes 'history_change', which is
+        // what makes client-side App Router navigations register as pageviews.
+        defaults: '2026-06-25',
+        autocapture: true,
+        // Backstop to Sentry (#327): PostHog sees anything that reaches
+        // window.onerror, and pins it to the replay it happened in.
+        capture_exceptions: true,
+        // All-session replay, not on-error sampling: at a 2-3 tester cohort
+        // every session is worth watching, and the interesting ones are the
+        // sessions where nothing threw and the tester just left.
+        disable_session_recording: false,
+        session_recording: {
+            // Same call as the Sentry replay config: replays exist to debug
+            // known alpha testers, so visibility beats redaction. The recorder
+            // masks password inputs regardless of this flag.
+            maskAllInputs: false,
+            maskTextSelector: null,
+        },
+        // No person profile for anonymous traffic — replays and events still
+        // record, they just don't mint a profile until identify().
+        person_profiles: 'identified_only',
+    });
+}
+
+/**
+ * Binds the session to the PostHog person. Called on every render that has a
+ * user, and cheap to repeat: the SDK short-circuits when the distinct id is
+ * already the one being identified.
+ */
+export function identifyUser(userId: string): void {
+    if (!isEnabled || !isInitialized) return;
+    posthog.identify(userId);
+}
+
+/** Unbinds the person on sign-out so the next user isn't merged into the last. */
+export function resetAnalytics(): void {
+    if (!isEnabled || !isInitialized) return;
+    posthog.reset();
+}
+
+export function captureEvent(
+    event: PostHogEventName,
+    properties?: Record<string, unknown>
+): void {
+    if (!isEnabled || !isInitialized) return;
+    posthog.capture(event, properties);
+}
+
+/**
+ * Opens the feedback survey configured in PostHog. Resolved at click time
+ * rather than hardcoding a survey id, so the survey can be rewritten (or
+ * swapped for a different one) in the PostHog UI without a deploy.
+ *
+ * `ignoreConditions`/`ignoreDelay` bypass the survey's own targeting: the user
+ * asked for it explicitly, so display rules meant for unprompted popups
+ * shouldn't suppress it.
+ */
+export function showFeedbackSurvey(onUnavailable: () => void): void {
+    if (!isEnabled || !isInitialized) {
+        onUnavailable();
+        return;
+    }
+    posthog.getActiveMatchingSurveys((surveys) => {
+        const survey = surveys[0];
+        if (!survey) {
+            onUnavailable();
+            return;
+        }
+        posthog.displaySurvey(survey.id, {
+            displayType: DisplaySurveyType.Popover,
+            ignoreConditions: true,
+            ignoreDelay: true,
+        });
+    });
+}

--- a/apps/web/lib/posthog/client.ts
+++ b/apps/web/lib/posthog/client.ts
@@ -7,6 +7,7 @@ import {
     POSTHOG_INGEST_PATH,
     resolveUiHost,
 } from './hosts';
+import { ANALYTICS_ENVIRONMENT_PROPERTY } from './events';
 import type { PostHogEventName } from './events';
 
 /**
@@ -68,6 +69,16 @@ export function initAnalytics(): void {
         // No person profile for anonymous traffic — replays and events still
         // record, they just don't mint a profile until identify().
         person_profiles: 'identified_only',
+    });
+
+    // Super property, so it rides every event from here on (including the
+    // autocaptured ones) and every replay is filterable by the tier it came
+    // from. Registered after init rather than via bootstrap so it also
+    // overwrites a stale value persisted by an earlier visit to a different
+    // tier in the same browser profile.
+    posthog.register({
+        [ANALYTICS_ENVIRONMENT_PROPERTY]:
+            process.env.NEXT_PUBLIC_VERCEL_ENV ?? 'unknown',
     });
 }
 

--- a/apps/web/lib/posthog/client.ts
+++ b/apps/web/lib/posthog/client.ts
@@ -100,16 +100,25 @@ export function captureEvent(
  * rather than hardcoding a survey id, so the survey can be rewritten (or
  * swapped for a different one) in the PostHog UI without a deploy.
  *
- * `ignoreConditions`/`ignoreDelay` bypass the survey's own targeting: the user
- * asked for it explicitly, so display rules meant for unprompted popups
- * shouldn't suppress it.
+ * `getSurveys`, not `getActiveMatchingSurveys`: "active matching" means the
+ * surveys the SDK would pop up on its own, and this one is the opposite of
+ * that. It drops `api`-type surveys (the only type that never auto-displays),
+ * and it honours the survey's internal "already seen" targeting flag — so a
+ * button backed by it would resolve once per person and toast "unavailable"
+ * forever after. `getSurveys` hits the same endpoint, which already returns
+ * only live surveys; it just skips the per-person matching that a
+ * user-initiated action shouldn't be subject to.
+ *
+ * `ignoreConditions`/`ignoreDelay` bypass the survey's own targeting for the
+ * same reason: the user asked for it explicitly, so display rules meant for
+ * unprompted popups shouldn't suppress it.
  */
 export function showFeedbackSurvey(onUnavailable: () => void): void {
     if (!isEnabled || !isInitialized) {
         onUnavailable();
         return;
     }
-    posthog.getActiveMatchingSurveys((surveys) => {
+    posthog.getSurveys((surveys) => {
         const survey = surveys[0];
         if (!survey) {
             onUnavailable();

--- a/apps/web/lib/posthog/client.ts
+++ b/apps/web/lib/posthog/client.ts
@@ -7,7 +7,7 @@ import {
     POSTHOG_INGEST_PATH,
     resolveUiHost,
 } from './hosts';
-import { ANALYTICS_ENVIRONMENT_PROPERTY } from './events';
+import { ANALYTICS_ENVIRONMENT_PROPERTY, FEEDBACK_SURVEY_NAME } from './events';
 import type { PostHogEventName } from './events';
 
 /**
@@ -107,9 +107,11 @@ export function captureEvent(
 }
 
 /**
- * Opens the feedback survey configured in PostHog. Resolved at click time
- * rather than hardcoding a survey id, so the survey can be rewritten (or
- * swapped for a different one) in the PostHog UI without a deploy.
+ * Opens the feedback survey configured in PostHog. Resolved by name at click
+ * time rather than hardcoding a survey id, so the survey can be rewritten in
+ * the PostHog UI without a deploy. By name and not by position: the lookup
+ * below returns every live survey in the project, so `surveys[0]` would hand
+ * this button to an unrelated campaign the day a second survey goes live.
  *
  * `getSurveys`, not `getActiveMatchingSurveys`: "active matching" means the
  * surveys the SDK would pop up on its own, and this one is the opposite of
@@ -130,7 +132,9 @@ export function showFeedbackSurvey(onUnavailable: () => void): void {
         return;
     }
     posthog.getSurveys((surveys) => {
-        const survey = surveys[0];
+        const survey = surveys.find(
+            (candidate) => candidate.name === FEEDBACK_SURVEY_NAME
+        );
         if (!survey) {
             onUnavailable();
             return;

--- a/apps/web/lib/posthog/events.ts
+++ b/apps/web/lib/posthog/events.ts
@@ -8,8 +8,11 @@ export const PostHogEvent = {
     /** Account created (client-confirmed, before the post-signup redirect). */
     SignedUp: 'signed_up',
     /**
-     * Bytes started moving browser→S3. Per attempt, not per upload — filter
-     * on `isResume` for a started→completed funnel.
+     * Bytes started moving browser→S3. Per attempt, not per upload — filter on
+     * `isRetry` for a started→completed funnel, and join attempts to their
+     * outcome on `clientUploadId`. Mirror this caveat into the event's
+     * description in PostHog data management: that's where analyses get built,
+     * and a note only in the source won't reach them.
      */
     UploadStarted: 'upload_started',
     /** Browser saw the upload through to confirm. */

--- a/apps/web/lib/posthog/events.ts
+++ b/apps/web/lib/posthog/events.ts
@@ -46,3 +46,15 @@ export type PostHogEventName = (typeof PostHogEvent)[keyof typeof PostHogEvent];
  * by default rather than making every analysis remember to filter.
  */
 export const ANALYTICS_ENVIRONMENT_PROPERTY = 'environment';
+
+/**
+ * Name of the survey behind the "Send feedback" menu item, matched at click
+ * time. The lookup returns every live survey in the project, so picking the
+ * first would quietly hand the button to an unrelated campaign the moment a
+ * second survey is switched on in the PostHog UI.
+ *
+ * This makes the name load-bearing: rewrite the survey's questions freely, but
+ * renaming it in PostHog disables the button (it falls back to the
+ * "unavailable" toast) until this constant follows.
+ */
+export const FEEDBACK_SURVEY_NAME = 'Alpha feedback';

--- a/apps/web/lib/posthog/events.ts
+++ b/apps/web/lib/posthog/events.ts
@@ -1,0 +1,29 @@
+/**
+ * Product event names, shared by the browser and the Node SDK so a rename
+ * can't split one funnel into two. Autocapture covers clicks and pageviews;
+ * these are the steps that either span a network round-trip or only the
+ * server can confirm, which autocapture can't see.
+ */
+export const PostHogEvent = {
+    /** Account created (client-confirmed, before the post-signup redirect). */
+    SignedUp: 'signed_up',
+    /**
+     * Bytes started moving browser→S3. Per attempt, not per upload — filter
+     * on `isResume` for a started→completed funnel.
+     */
+    UploadStarted: 'upload_started',
+    /** Browser saw the upload through to confirm. */
+    UploadCompleted: 'upload_completed',
+    /** Terminal upload failure — excludes pauses, aborts, and offline drops. */
+    UploadFailed: 'upload_failed',
+    /** Server flipped the file to `available` and counted its bytes. */
+    UploadConfirmed: 'upload_confirmed',
+    /** User asked for a Glacier restore (single file or bulk selection). */
+    RetrievalRequested: 'retrieval_requested',
+    /** S3 reported the restore complete — hours later, no session attached. */
+    RetrievalReady: 'retrieval_ready',
+    /** User opened a download URL. */
+    FileDownloaded: 'file_downloaded',
+} as const;
+
+export type PostHogEventName = (typeof PostHogEvent)[keyof typeof PostHogEvent];

--- a/apps/web/lib/posthog/events.ts
+++ b/apps/web/lib/posthog/events.ts
@@ -30,3 +30,19 @@ export const PostHogEvent = {
 } as const;
 
 export type PostHogEventName = (typeof PostHogEvent)[keyof typeof PostHogEvent];
+
+/**
+ * Property carrying the Vercel tier that emitted an event, shared for the same
+ * reason as the names above. Preview deploys report to the same project as
+ * production, so without this every funnel silently counts the deploys we poke
+ * at while reviewing a PR, and nothing distinguishes those from a real user.
+ *
+ * The value comes from a different env var on each side — the browser needs
+ * the literal `process.env.NEXT_PUBLIC_*` expression to survive bundling,
+ * while the server reads the unprefixed one — so only the key is shared.
+ *
+ * PostHog's "filter out internal and test users" toggle is configured against
+ * this property (project settings), which is what keeps insights on production
+ * by default rather than making every analysis remember to filter.
+ */
+export const ANALYTICS_ENVIRONMENT_PROPERTY = 'environment';

--- a/apps/web/lib/posthog/hosts.test.ts
+++ b/apps/web/lib/posthog/hosts.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_POSTHOG_HOST,
+    resolveAssetsHost,
+    resolveUiHost,
+} from './hosts';
+
+describe('resolveAssetsHost', () => {
+    it('points the default US host at its assets sibling', () => {
+        expect(resolveAssetsHost(DEFAULT_POSTHOG_HOST)).toBe(
+            'https://us-assets.i.posthog.com'
+        );
+    });
+
+    it('does the same for the EU region', () => {
+        expect(resolveAssetsHost('https://eu.i.posthog.com')).toBe(
+            'https://eu-assets.i.posthog.com'
+        );
+    });
+
+    it('leaves a self-hosted origin alone — it serves assets itself', () => {
+        expect(resolveAssetsHost('https://ph.example.com')).toBe(
+            'https://ph.example.com'
+        );
+    });
+});
+
+describe('resolveUiHost', () => {
+    it('drops the ingestion subdomain from the default US host', () => {
+        expect(resolveUiHost(DEFAULT_POSTHOG_HOST)).toBe(
+            'https://us.posthog.com'
+        );
+    });
+
+    it('does the same for the EU region', () => {
+        expect(resolveUiHost('https://eu.i.posthog.com')).toBe(
+            'https://eu.posthog.com'
+        );
+    });
+
+    it('leaves a self-hosted origin alone — dashboard and ingest share it', () => {
+        expect(resolveUiHost('https://ph.example.com')).toBe(
+            'https://ph.example.com'
+        );
+    });
+});

--- a/apps/web/lib/posthog/hosts.ts
+++ b/apps/web/lib/posthog/hosts.ts
@@ -1,0 +1,41 @@
+/**
+ * PostHog host resolution, shared by the browser SDK, the Node SDK, and the
+ * `/ingest` rewrite in next.config.ts. Kept dependency-free so next.config.ts
+ * can import it before any path aliases or bundler config exist.
+ */
+
+/** PostHog US cloud ingestion host — the default when the env var is unset. */
+export const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+
+/**
+ * Path the reverse proxy is mounted at. Browser traffic goes to a first-party
+ * path so adblock filter lists (which match on posthog.com) can't silently
+ * zero out session replay — a blocked tester would otherwise be
+ * indistinguishable from a tester who never showed up, which is the exact
+ * failure this integration exists to detect.
+ */
+export const POSTHOG_INGEST_PATH = '/ingest';
+
+/**
+ * Both helpers below rewrite a PostHog *cloud* ingestion host by substring.
+ * A host that doesn't match (a self-hosted instance) is returned unchanged,
+ * which is the right answer there: a self-hosted deployment serves assets and
+ * the dashboard off the one origin, so no rewrite is what's wanted.
+ */
+
+/**
+ * Static assets (the recorder, surveys, and toolbar bundles) are served from a
+ * sibling host, not the ingestion host: `us.i.posthog.com` →
+ * `us-assets.i.posthog.com`. Same shape for the EU region.
+ */
+export function resolveAssetsHost(host: string): string {
+    return host.replace('.i.posthog.com', '-assets.i.posthog.com');
+}
+
+/**
+ * The dashboard host, used for toolbar links only. Drops the ingestion
+ * subdomain: `us.i.posthog.com` → `us.posthog.com`.
+ */
+export function resolveUiHost(host: string): string {
+    return host.replace('.i.posthog.com', '.posthog.com');
+}

--- a/apps/web/lib/posthog/server.ts
+++ b/apps/web/lib/posthog/server.ts
@@ -1,0 +1,76 @@
+import { after } from 'next/server';
+import { PostHog } from 'posthog-node';
+
+import { DEFAULT_POSTHOG_HOST } from './hosts';
+import type { PostHogEventName } from './events';
+
+/**
+ * Server-side counterpart to lib/posthog/client.ts, for the two events the
+ * browser can't vouch for: an upload the server actually committed, and a
+ * Glacier restore that completes hours later in an SNS webhook with no session
+ * attached.
+ *
+ * Gating mirrors lib/sentry/init.ts rather than lib/stripe/client.ts: the key
+ * is optional (deployed Vercel tiers only), so an unconditional constructor
+ * would blow up in local dev, CI, and unit tests. `process.env.VERCEL` is fine
+ * here where instrumentation-client.ts needs NEXT_PUBLIC_VERCEL_ENV — this
+ * module never reaches the browser bundle.
+ *
+ * Raw process.env rather than `@/lib/env` for a different reason than the
+ * browser has: that module validates the whole client schema at import time,
+ * so pulling it into a service's dependency graph makes every unit test of
+ * that service require a full .env.local. The clientSchema entries still
+ * validate these two vars wherever the app does load `@/lib/env`.
+ */
+function createClient(): PostHog | null {
+    const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    if (!process.env.VERCEL || !key) return null;
+
+    return new PostHog(key, {
+        host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST,
+        // posthog-node batches, and a Vercel function can be frozen the
+        // instant it responds — without this the batch is dropped unsent.
+        // `after` keeps the invocation alive until the flush lands.
+        waitUntil: (promise) => {
+            try {
+                after(promise);
+            } catch {
+                // Outside a Next request scope (scripts, tests). Nothing to
+                // extend, so fall back to the SDK's own interval flush.
+            }
+        },
+    });
+}
+
+// Lazy so a build-time import doesn't open a client, and so tests that never
+// capture never construct one.
+let client: PostHog | null | undefined;
+
+function getClient(): PostHog | null {
+    if (client === undefined) client = createClient();
+    return client;
+}
+
+/**
+ * Fire-and-forget. Analytics is never allowed to fail a real request, so a
+ * broken client degrades to a log line.
+ *
+ * console rather than server/lib/logger for the same reason as the env read
+ * above: the logger imports `@/lib/env`, and dragging that into a service's
+ * dependency graph makes the service's unit tests demand a full .env.local.
+ * Vercel collects both the same way. lib/env/index.ts has the precedent.
+ */
+export function captureServerEvent(
+    userId: string,
+    event: PostHogEventName,
+    properties?: Record<string, unknown>
+): void {
+    const posthog = getClient();
+    if (!posthog) return;
+
+    try {
+        posthog.capture({ distinctId: userId, event, properties });
+    } catch (error) {
+        console.warn(`PostHog capture failed for "${event}":`, error);
+    }
+}

--- a/apps/web/lib/posthog/server.ts
+++ b/apps/web/lib/posthog/server.ts
@@ -1,6 +1,8 @@
 import { after } from 'next/server';
 import { PostHog } from 'posthog-node';
 
+import { resolveRuntimeEnvironment } from '@/lib/env/runtime';
+
 import { DEFAULT_POSTHOG_HOST } from './hosts';
 import { ANALYTICS_ENVIRONMENT_PROPERTY } from './events';
 import type { PostHogEventName } from './events';
@@ -17,11 +19,14 @@ import type { PostHogEventName } from './events';
  * here where instrumentation-client.ts needs NEXT_PUBLIC_VERCEL_ENV — this
  * module never reaches the browser bundle.
  *
- * Raw process.env rather than `@/lib/env` for a different reason than the
- * browser has: that module validates the whole client schema at import time,
- * so pulling it into a service's dependency graph makes every unit test of
- * that service require a full .env.local. The clientSchema entries still
- * validate these two vars wherever the app does load `@/lib/env`.
+ * Raw process.env for the two keys rather than `@/lib/env` for a different
+ * reason than the browser has: that module validates the whole client schema
+ * at import time, so pulling it into a service's dependency graph makes every
+ * unit test of that service require a full .env.local. The clientSchema
+ * entries still validate these two vars wherever the app does load
+ * `@/lib/env`. `@/lib/env/runtime` is exempt and safe to import — it has no
+ * imports of its own and reads process.env directly, so it drags no schema
+ * validation behind it.
  */
 function createClient(): PostHog | null {
     const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
@@ -73,13 +78,10 @@ export function captureServerEvent(
         posthog.capture({
             distinctId: userId,
             event,
-            // Unprefixed VERCEL_ENV: same reasoning as the gate above, this
-            // module never reaches the browser bundle. Spread first so a
-            // caller can't accidentally shadow the tier.
+            // Spread first so a caller can't accidentally shadow the tier.
             properties: {
                 ...properties,
-                [ANALYTICS_ENVIRONMENT_PROPERTY]:
-                    process.env.VERCEL_ENV ?? 'unknown',
+                [ANALYTICS_ENVIRONMENT_PROPERTY]: resolveRuntimeEnvironment(),
             },
         });
     } catch (error) {

--- a/apps/web/lib/posthog/server.ts
+++ b/apps/web/lib/posthog/server.ts
@@ -2,6 +2,7 @@ import { after } from 'next/server';
 import { PostHog } from 'posthog-node';
 
 import { DEFAULT_POSTHOG_HOST } from './hosts';
+import { ANALYTICS_ENVIRONMENT_PROPERTY } from './events';
 import type { PostHogEventName } from './events';
 
 /**
@@ -69,7 +70,18 @@ export function captureServerEvent(
     if (!posthog) return;
 
     try {
-        posthog.capture({ distinctId: userId, event, properties });
+        posthog.capture({
+            distinctId: userId,
+            event,
+            // Unprefixed VERCEL_ENV: same reasoning as the gate above, this
+            // module never reaches the browser bundle. Spread first so a
+            // caller can't accidentally shadow the tier.
+            properties: {
+                ...properties,
+                [ANALYTICS_ENVIRONMENT_PROPERTY]:
+                    process.env.VERCEL_ENV ?? 'unknown',
+            },
+        });
     } catch (error) {
         console.warn(`PostHog capture failed for "${event}":`, error);
     }

--- a/apps/web/lib/posthog/testing.ts
+++ b/apps/web/lib/posthog/testing.ts
@@ -1,0 +1,49 @@
+import { vi, type Mock } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMock = Mock<any>;
+
+export interface MockPostHogClient {
+    initAnalytics: AnyMock;
+    isAnalyticsEnabled: AnyMock;
+    identifyUser: AnyMock;
+    resetAnalytics: AnyMock;
+    captureEvent: AnyMock;
+    showFeedbackSurvey: AnyMock;
+}
+
+export interface MockPostHogServer {
+    captureServerEvent: AnyMock;
+}
+
+/**
+ * Vitest stub for `@/lib/posthog/client`. Wire it through `vi.hoisted` with a
+ * dynamic import (same pattern as `@/lib/sentry/testing`):
+ *
+ * ```ts
+ * const hoisted = await vi.hoisted(async () => {
+ *     const { createMockPostHogClient } = await import('@/lib/posthog/testing');
+ *     return { posthog: createMockPostHogClient() };
+ * });
+ * vi.mock('@/lib/posthog/client', () => hoisted.posthog);
+ * ```
+ *
+ * Worth mocking even though the real module already no-ops when analytics is
+ * disabled: without it a test proves nothing, because the assertion and the
+ * unconfigured no-op are indistinguishable.
+ */
+export function createMockPostHogClient(): MockPostHogClient {
+    return {
+        initAnalytics: vi.fn(),
+        isAnalyticsEnabled: vi.fn(() => false),
+        identifyUser: vi.fn(),
+        resetAnalytics: vi.fn(),
+        captureEvent: vi.fn(),
+        showFeedbackSurvey: vi.fn(),
+    };
+}
+
+/** Vitest stub for `@/lib/posthog/server`. Same wiring as the client stub. */
+export function createMockPostHogServer(): MockPostHogServer {
+    return { captureServerEvent: vi.fn() };
+}

--- a/apps/web/lib/upload/errors.test.ts
+++ b/apps/web/lib/upload/errors.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 const hoisted = await vi.hoisted(async () => {
     const { createMockSentry } = await import('@/lib/sentry/testing');
-    return { sentry: createMockSentry() };
+    const { createMockPostHogClient } = await import('@/lib/posthog/testing');
+    return { sentry: createMockSentry(), posthog: createMockPostHogClient() };
 });
 
 vi.mock('@sentry/nextjs', () => hoisted.sentry);
+vi.mock('@/lib/posthog/client', () => hoisted.posthog);
 
 import { UploadHttpError, UploadNetworkError } from '@/lib/http/xhr';
+import { PostHogEvent } from '@/lib/posthog/events';
 import { makeClientError } from '@/lib/trpc/test-fixtures';
 import {
     isExpiredUrlError,
@@ -56,6 +59,7 @@ describe('isAbortError', () => {
 describe('reportUploadFailure', () => {
     beforeEach(() => {
         hoisted.sentry.captureException.mockClear();
+        hoisted.posthog.captureEvent.mockClear();
     });
 
     const upload = {
@@ -93,5 +97,40 @@ describe('reportUploadFailure', () => {
         reportUploadFailure(error, 'single', upload);
 
         expect(hoisted.sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    // The two sinks disagree on scope deliberately — see the docblock on
+    // reportUploadFailure. These pin that difference down.
+    it('reports transport failures to PostHog as a lost upload', () => {
+        reportUploadFailure(new UploadHttpError(500), 'multipart', upload);
+
+        expect(hoisted.posthog.captureEvent).toHaveBeenCalledOnce();
+        expect(hoisted.posthog.captureEvent).toHaveBeenCalledWith(
+            PostHogEvent.UploadFailed,
+            {
+                engine: 'multipart',
+                fileId: 'f_1',
+                sizeBytes: 1024,
+                batchId: 'b_1',
+                isServerRejection: false,
+            }
+        );
+    });
+
+    it('reports tRPC failures to PostHog too, flagged as server rejections', () => {
+        const error = makeClientError({
+            code: 'PRECONDITION_FAILED',
+            domainCode: 'QUOTA_EXCEEDED',
+        });
+        reportUploadFailure(error, 'single', upload);
+
+        expect(hoisted.posthog.captureEvent).toHaveBeenCalledOnce();
+        expect(hoisted.posthog.captureEvent).toHaveBeenCalledWith(
+            PostHogEvent.UploadFailed,
+            expect.objectContaining({
+                engine: 'single',
+                isServerRejection: true,
+            })
+        );
     });
 });

--- a/apps/web/lib/upload/errors.test.ts
+++ b/apps/web/lib/upload/errors.test.ts
@@ -63,6 +63,7 @@ describe('reportUploadFailure', () => {
     });
 
     const upload = {
+        id: 'row_1',
         name: 'photo.raw',
         size: 1024,
         fileId: 'f_1',
@@ -112,6 +113,7 @@ describe('reportUploadFailure', () => {
                 fileId: 'f_1',
                 sizeBytes: 1024,
                 batchId: 'b_1',
+                clientUploadId: 'row_1',
                 isServerRejection: false,
             }
         );

--- a/apps/web/lib/upload/errors.ts
+++ b/apps/web/lib/upload/errors.ts
@@ -26,7 +26,10 @@ export function isAbortError(error: unknown): boolean {
     return error instanceof DOMException && error.name === 'AbortError';
 }
 
-/** The slice of an upload row a failure report needs. */
+/** Which upload path moved the bytes. */
+export type UploadEngine = 'single' | 'multipart';
+
+/** The slice of an upload row a failure report or upload event needs. */
 export interface UploadFailureInfo {
     /** Client row id — joins this failure to its `upload_started` attempt. */
     id: string;
@@ -34,6 +37,28 @@ export interface UploadFailureInfo {
     size: number;
     fileId?: string;
     batchId?: string;
+}
+
+/**
+ * The properties every upload event carries, so the three capture sites
+ * (started, completed, failed) can't drift apart. They have to agree: a
+ * started→completed funnel joins on `clientUploadId`, and one site renaming a
+ * field splits that funnel silently rather than failing.
+ *
+ * `engine` is separate from the row because a resumed multipart upload and the
+ * single-part attempt before it are the same row.
+ */
+export function uploadEventProps(
+    engine: UploadEngine,
+    upload: UploadFailureInfo
+): Record<string, unknown> {
+    return {
+        engine,
+        fileId: upload.fileId,
+        sizeBytes: upload.size,
+        batchId: upload.batchId,
+        clientUploadId: upload.id,
+    };
 }
 
 /**
@@ -53,15 +78,11 @@ export interface UploadFailureInfo {
  */
 export function reportUploadFailure(
     error: unknown,
-    engine: 'single' | 'multipart',
+    engine: UploadEngine,
     upload: UploadFailureInfo
 ): void {
     captureEvent(PostHogEvent.UploadFailed, {
-        engine,
-        fileId: upload.fileId,
-        sizeBytes: upload.size,
-        batchId: upload.batchId,
-        clientUploadId: upload.id,
+        ...uploadEventProps(engine, upload),
         // Distinguishes a server-side rejection (quota, auth) from a
         // browser→S3 transport failure without shipping the message.
         isServerRejection: error instanceof TRPCClientError,

--- a/apps/web/lib/upload/errors.ts
+++ b/apps/web/lib/upload/errors.ts
@@ -28,6 +28,8 @@ export function isAbortError(error: unknown): boolean {
 
 /** The slice of an upload row a failure report needs. */
 export interface UploadFailureInfo {
+    /** Client row id — joins this failure to its `upload_started` attempt. */
+    id: string;
     name: string;
     size: number;
     fileId?: string;
@@ -59,6 +61,7 @@ export function reportUploadFailure(
         fileId: upload.fileId,
         sizeBytes: upload.size,
         batchId: upload.batchId,
+        clientUploadId: upload.id,
         // Distinguishes a server-side rejection (quota, auth) from a
         // browser→S3 transport failure without shipping the message.
         isServerRejection: error instanceof TRPCClientError,

--- a/apps/web/lib/upload/errors.ts
+++ b/apps/web/lib/upload/errors.ts
@@ -2,6 +2,8 @@ import * as Sentry from '@sentry/nextjs';
 import { TRPCClientError } from '@trpc/client';
 
 import { UploadHttpError, UploadNetworkError } from '@/lib/http/xhr';
+import { captureEvent } from '@/lib/posthog/client';
+import { PostHogEvent } from '@/lib/posthog/events';
 
 /**
  * Classifies upload failures so the engine can react instead of giving up:
@@ -33,18 +35,35 @@ export interface UploadFailureInfo {
 }
 
 /**
- * Report a terminal upload failure to Sentry. tRPC mutation failures inside
- * the upload flow (init/confirm/sign-parts) already reach Sentry through the
- * MutationCache capture (lib/trpc/query-client.ts), which also filters
- * expected domain errors like quota-exceeded — skipping them here keeps
- * "captured once" true. What remains is exactly what the server never sees:
- * the browser→S3 presigned PUTs and local upload-store bookkeeping.
+ * Report a terminal upload failure. Callers have already filtered the
+ * non-failures (aborts, pauses, offline drops), so everything reaching here is
+ * an upload the user lost.
+ *
+ * The two sinks disagree on scope by design. PostHog wants every lost upload,
+ * quota rejections included — "tester hit the quota and stopped" is the
+ * funnel drop-off the analytics exist to surface. Sentry wants only the
+ * unexpected ones: tRPC mutation failures inside the upload flow
+ * (init/confirm/sign-parts) already reach Sentry through the MutationCache
+ * capture (lib/trpc/query-client.ts), which also filters expected domain
+ * errors like quota-exceeded, so skipping them here keeps "captured once"
+ * true. What remains for Sentry is exactly what the server never sees: the
+ * browser→S3 presigned PUTs and local upload-store bookkeeping.
  */
 export function reportUploadFailure(
     error: unknown,
     engine: 'single' | 'multipart',
     upload: UploadFailureInfo
 ): void {
+    captureEvent(PostHogEvent.UploadFailed, {
+        engine,
+        fileId: upload.fileId,
+        sizeBytes: upload.size,
+        batchId: upload.batchId,
+        // Distinguishes a server-side rejection (quota, auth) from a
+        // browser→S3 transport failure without shipping the message.
+        isServerRejection: error instanceof TRPCClientError,
+    });
+
     if (error instanceof TRPCClientError) return;
 
     Sentry.captureException(error, {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,12 +1,49 @@
 import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
 import path from 'node:path';
+import {
+    DEFAULT_POSTHOG_HOST,
+    POSTHOG_INGEST_PATH,
+    resolveAssetsHost,
+} from './lib/posthog/hosts';
+
+const posthogHost =
+    process.env.NEXT_PUBLIC_POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST;
 
 const nextConfig: NextConfig = {
     // Suppress verbose request logging in dev - we have our own tRPC logging
     logging: false,
     // @nexus/db exports raw TypeScript (JIT compilation, no build step)
     transpilePackages: ['@nexus/db'],
+    // PostHog's ingestion paths end in a slash (/e/, /s/). Next normalizes
+    // trailing slashes with a 308 *before* rewrites run, so without this the
+    // proxied requests below get redirected instead of proxied.
+    //
+    // This setting is app-wide, not scoped to /ingest: every route now serves
+    // `/some/page/` directly instead of redirecting it to `/some/page`. That
+    // costs the canonical-URL redirect on all pages, which is the price of
+    // the proxy below.
+    skipTrailingSlashRedirect: true,
+    // First-party reverse proxy for PostHog (see lib/posthog/hosts.ts for why).
+    //
+    // Rewrites forward the incoming headers, so these requests carry the
+    // better-auth session cookie to PostHog. Accepted deliberately: it's
+    // PostHog's own documented Next.js setup, they have no use for the cookie,
+    // and the alternative (a hand-rolled route-handler proxy that strips
+    // Cookie) is more moving parts than the exposure warrants. Revisit if the
+    // cohort ever grows past known testers.
+    async rewrites() {
+        return [
+            {
+                source: `${POSTHOG_INGEST_PATH}/static/:path*`,
+                destination: `${resolveAssetsHost(posthogHost)}/static/:path*`,
+            },
+            {
+                source: `${POSTHOG_INGEST_PATH}/:path*`,
+                destination: `${posthogHost}/:path*`,
+            },
+        ];
+    },
     // Pin the workspace root. Git worktrees carry their own pnpm-lock.yaml,
     // so Next's lockfile inference finds two candidates (worktree + primary
     // checkout), picks the wrong one, and warns on every build.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,6 +52,8 @@
         "next": "16.1.1",
         "next-themes": "^0.4.6",
         "pino": "^10.1.1",
+        "posthog-js": "^1.407.3",
+        "posthog-node": "^5.46.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "recharts": "^3.8.0",

--- a/apps/web/scripts/check-vercel-env-parity.ts
+++ b/apps/web/scripts/check-vercel-env-parity.ts
@@ -64,6 +64,17 @@ const ASYMMETRY_ALLOWLIST: Record<
         missingFrom: ['preview', 'development'],
         reason: 'n/a',
     },
+    // Same shape as Sentry: a key in the development tier reaches .env.local
+    // via env:pull and turns replay/autocapture on for local and e2e
+    // production builds, which assert zero console errors.
+    NEXT_PUBLIC_POSTHOG_KEY: {
+        missingFrom: ['development'],
+        reason: 'production+preview only by design',
+    },
+    NEXT_PUBLIC_POSTHOG_HOST: {
+        missingFrom: ['development'],
+        reason: 'production+preview only by design',
+    },
 };
 
 const DEFAULT_PROJECT_ID = 'prj_RuKjFko6iKwbyyIy55HYL5S5AabG';

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -1,4 +1,12 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+const hoisted = await vi.hoisted(async () => {
+    const { createMockPostHogServer } = await import('@/lib/posthog/testing');
+    return { posthog: createMockPostHogServer() };
+});
+
+vi.mock('@/lib/posthog/server', () => hoisted.posthog);
+
 import {
     createMockDb,
     type MockDb,
@@ -15,6 +23,7 @@ import {
     QuotaExceededError,
     InvalidStateError,
 } from '@/server/errors';
+import { PostHogEvent } from '@/lib/posthog/events';
 import { fileService, formatFallbackBatchName } from './files';
 import { PLAN_LIMITS } from './constants';
 
@@ -316,6 +325,46 @@ describe('files service', () => {
             expect(result.file).toEqual(availableFile);
             expect(mocks.update).not.toHaveBeenCalled();
             expect(mocks.onConflictDoUpdate).not.toHaveBeenCalled();
+        });
+
+        // The analytics event carries the same idempotency guarantee as the
+        // usage counter: a retried confirm must not inflate the funnel.
+        it('emits upload_confirmed once on the branch that flips status', async () => {
+            const uploadingFile = createFileFixture({
+                status: 'uploading',
+                size: 4096,
+            });
+            const availableFile = createFileFixture({
+                ...uploadingFile,
+                status: 'available',
+            });
+            mocks.files.findFirst.mockResolvedValue(uploadingFile);
+            mocks.returning
+                .mockResolvedValueOnce([availableFile])
+                .mockResolvedValueOnce([
+                    createStorageUsageFixture({ usedBytes: 4096 }),
+                ]);
+
+            await fileService.confirmUpload(db, TEST_USER_ID, uploadingFile.id);
+
+            expect(hoisted.posthog.captureServerEvent).toHaveBeenCalledOnce();
+            expect(hoisted.posthog.captureServerEvent).toHaveBeenCalledWith(
+                TEST_USER_ID,
+                PostHogEvent.UploadConfirmed,
+                expect.objectContaining({
+                    fileId: availableFile.id,
+                    sizeBytes: availableFile.size,
+                })
+            );
+        });
+
+        it('emits nothing on a duplicate confirm', async () => {
+            const availableFile = createFileFixture({ status: 'available' });
+            mocks.files.findFirst.mockResolvedValue(availableFile);
+
+            await fileService.confirmUpload(db, TEST_USER_ID, availableFile.id);
+
+            expect(hoisted.posthog.captureServerEvent).not.toHaveBeenCalled();
         });
 
         it('throws NotFoundError when file does not exist', async () => {

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -8,6 +8,8 @@ import {
 } from '@nexus/db/repo/uploadBatches';
 import { NotFoundError, InvalidStateError } from '@/server/errors';
 import { s3 } from '@/lib/storage';
+import { PostHogEvent } from '@/lib/posthog/events';
+import { captureServerEvent } from '@/lib/posthog/server';
 import { quotaService } from './quota';
 
 const PRESIGNED_URL_EXPIRY_SECONDS = 900; // 15 minutes
@@ -147,7 +149,7 @@ async function confirmUpload(
     userId: string,
     fileId: string
 ): Promise<ConfirmUploadResult> {
-    return db.transaction(async (tx) => {
+    const { file, isConfirmed } = await db.transaction(async (tx) => {
         const fileRepo = createFileRepo(tx);
         const usageRepo = createStorageUsageRepo(tx);
 
@@ -158,7 +160,7 @@ async function confirmUpload(
         // Idempotency: a duplicate confirm shouldn't double-count usage.
         // Only flip state and increment when the file is still uploading.
         if (file.status !== 'uploading') {
-            return { file };
+            return { file, isConfirmed: false };
         }
 
         const updated = await fileRepo.update(fileId, {
@@ -170,8 +172,21 @@ async function confirmUpload(
 
         await usageRepo.incrementUsage(userId, file.size);
 
-        return { file: updated };
+        return { file: updated, isConfirmed: true };
     });
+
+    // After the commit, and only on the branch that actually flipped state —
+    // a duplicate confirm must not double-count in the funnel either.
+    if (isConfirmed) {
+        captureServerEvent(userId, PostHogEvent.UploadConfirmed, {
+            fileId: file.id,
+            sizeBytes: file.size,
+            storageTier: file.storageTier,
+            batchId: file.batchId,
+        });
+    }
+
+    return { file };
 }
 
 async function initiateMultipartUpload(

--- a/apps/web/server/services/s3-restore.ts
+++ b/apps/web/server/services/s3-restore.ts
@@ -5,6 +5,8 @@ import { env } from '@/lib/env';
 import { emailService } from '@/server/services/email';
 import { logger } from '@/server/lib/logger';
 import type { S3EventRecord } from '@/lib/sns/types';
+import { PostHogEvent } from '@/lib/posthog/events';
+import { captureServerEvent } from '@/lib/posthog/server';
 import { resolveStorageTier } from '@/lib/storage/types';
 
 const log = logger.child({ service: 's3-restore' });
@@ -93,6 +95,20 @@ async function handleRestoreCompleted(
         { fileId: file.id, retrievalId: retrieval.id, expiresAt },
         'Retrieval marked as ready'
     );
+
+    // No session here — this is an SNS webhook firing hours after the request.
+    // file.userId is the only identity available, and it's the same value
+    // identify() binds in the browser, so the event lands on the right person.
+    captureServerEvent(file.userId, PostHogEvent.RetrievalReady, {
+        fileId: file.id,
+        retrievalId: retrieval.id,
+        storageTier: file.storageTier,
+        // How long the tester actually waited on Glacier — the number that
+        // decides whether retrieval is a usable feature or a dead end.
+        waitMs: retrieval.initiatedAt
+            ? now.getTime() - retrieval.initiatedAt.getTime()
+            : undefined,
+    });
 
     await sendReadyNotification(db, file, retrieval, expiresAt);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,12 @@ importers:
       pino:
         specifier: ^10.1.1
         version: 10.1.1
+      posthog-js:
+        specifier: ^1.407.3
+        version: 1.407.3
+      posthog-node:
+        specifier: ^5.46.1
+        version: 5.46.1(rxjs@7.8.2)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1870,6 +1876,15 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@posthog/browser-common@0.2.3':
+    resolution: {integrity: sha512-LJOUcBLLjFOqw6ZZsjrCuojliJHFU/GYeOV88T+lXyePXJQnxFzuAouDtwwHFHtoaaOjfQ0OvDMR7J468Nkomw==}
+
+  '@posthog/core@1.45.1':
+    resolution: {integrity: sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA==}
+
+  '@posthog/types@1.398.0':
+    resolution: {integrity: sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg==}
+
   '@react-email/body@0.3.0':
     resolution: {integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==}
     engines: {node: '>=20.0.0'}
@@ -2995,6 +3010,9 @@ packages:
   '@types/sns-validator@0.3.3':
     resolution: {integrity: sha512-v/3bN5dak8aDXn7bgTGu+1oGc+PQCP0qnfzUM6gzo7FnxiW4wpppkaIptPhRhJaiDItbUDK+YA4yDQuVs5Cq1Q==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -3630,6 +3648,9 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3785,6 +3806,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4236,6 +4260,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -5168,6 +5195,26 @@ packages:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
 
+  posthog-js@1.407.3:
+    resolution: {integrity: sha512-b9Kc7HVN6nh+xsh1JrcLYHv9bbYLwYUM9belJtNVUFZSJWWfFcZRJJP6L+KeanAeu2VxSFSpioVA39pjjolv4A==}
+
+  posthog-node@5.46.1:
+    resolution: {integrity: sha512-WjCqExq44pBdyg9MSsH6UAE0tNZ88p4aIuVFicgqhjf2Fbws6IhS4ioYUa4aBrbUPS9EDRXtBTtF5DpP1ml8Pw==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5218,6 +5265,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5957,6 +6007,9 @@ packages:
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -7632,6 +7685,17 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
+  '@posthog/browser-common@0.2.3':
+    dependencies:
+      '@posthog/core': 1.45.1
+      '@posthog/types': 1.398.0
+
+  '@posthog/core@1.45.1':
+    dependencies:
+      '@posthog/types': 1.398.0
+
+  '@posthog/types@1.398.0': {}
+
   '@react-email/body@0.3.0(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -8752,6 +8816,9 @@ snapshots:
 
   '@types/sns-validator@0.3.3': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
@@ -9374,6 +9441,8 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
+  core-js@3.49.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -9516,6 +9585,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -10107,6 +10180,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.4.9: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -10984,6 +11059,28 @@ snapshots:
 
   postgres@3.4.7: {}
 
+  posthog-js@1.407.3:
+    dependencies:
+      '@posthog/browser-common': 0.2.3
+      '@posthog/core': 1.45.1
+      '@posthog/types': 1.398.0
+      core-js: 3.49.0
+      dompurify: 3.4.12
+      fflate: 0.4.9
+      preact: 10.29.7
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  posthog-node@5.46.1(rxjs@7.8.2):
+    dependencies:
+      '@posthog/core': 1.45.1
+    optionalDependencies:
+      rxjs: 7.8.2
+
+  preact@10.29.7: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.1:
@@ -11026,6 +11123,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -11871,6 +11970,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
+  web-vitals@5.3.0: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
@@ -11898,7 +11999,7 @@ snapshots:
       minimizer-webpack-plugin: 5.6.1(lightningcss@1.30.2)(webpack@5.108.4(lightningcss@1.30.2))
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
+      tapable: 2.3.3
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Wires PostHog into the app: all-session replay, autocapture, eight explicit product events, `identify` by user id, exception autocapture, and a "Send feedback" entry in the dashboard user menu that opens PostHog's survey widget. At a 2-3 tester cohort a silent tester is indistinguishable from a failed one, and until now nothing in the app could tell them apart.

Closes #328

### Two deviations from the issue text, both deliberate

**Vercel tiers: production + preview, not all three.** The issue asked for all three tiers to keep the parity check green without an allowlist entry. That contradicts its own AC1 ("disabled in local dev"), and `scripts/check-vercel-env-parity.ts` already says why in the Sentry entry: a key in the development tier flows into `.env.local` via `env:pull` and turns the SDK on for local and e2e production builds, which assert zero console errors. Followed the Sentry precedent instead, with matching `ASYMMETRY_ALLOWLIST` entries.

**No wrapping provider.** `PostHogAnalytics` returns `null` and mounts beside `ClientErrorReporter`. posthog-js is a singleton, so a context provider would wrap the tree and carry nothing.

Several line references in the issue body were stale (the `useUpload.ts` and `FileBrowser.tsx` ones pointed at neighbouring code); the events went to the verified locations.

### The gate, verified rather than assumed

This is the trap #327 fixed, so it got checked against a real build instead of reasoned about. Building with the vars set inlines the key as a literal and folds `isAnalyticsEnabled` to `function(){return!0}`; building without them leaves `!!(process.env.NEXT_PUBLIC_VERCEL_ENV&&process.env.NEXT_PUBLIC_POSTHOG_KEY)` → falsy, and every capture/identify/reset short-circuits.

## Changes

- `lib/posthog/{client,server,events,hosts}.ts` — browser SDK wrapper, `posthog-node` singleton, shared event names, host derivation
- `components/PostHogAnalytics.tsx` — init + `identify`; mounted in `app/layout.tsx`
- `reset()` on sign-out lives in `header.tsx`'s `handleSignOut`, not an effect: `useSession` reports no user while loading, which an effect can't tell from a sign-out, so it would wipe the distinct id on every cold load
- Client events: signup, upload started/completed/failed, retrieval requested (single + bulk), file downloaded
- Server events via `posthog-node`: upload confirmed, retrieval ready. `confirmUpload` now returns an `isConfirmed` flag out of its transaction so the event fires after commit and only on the branch that flips status — a duplicate confirm must not inflate the funnel any more than it double-counts usage
- `upload_started` is tagged `isResume`: both engines are also the retry/auto-resume entry point, so one file that drops and reconnects emits several. Filter on it for a started→completed funnel; keeping the repeats leaves "how often does an upload need a second try" answerable
- Serverless flush: `posthog-node` batches and a Vercel function can freeze the moment it responds, so its `waitUntil` is fed Next's `after()` (guarded for non-request scopes)
- `/ingest` reverse proxy in `next.config.ts` so adblockers can't silently zero out replays. Two consequences documented at the call site: `skipTrailingSlashRedirect` is app-wide, not `/ingest`-scoped, and rewrites forward the session cookie to PostHog (PostHog's own documented setup; stripping it would mean a hand-rolled route-handler proxy)
- `lib/posthog/testing.ts` mirroring `lib/sentry/testing.ts`; tests for the host helpers and both failure sinks
- `lib/posthog/server.ts` reads raw `process.env` and uses `console.warn` rather than `@/lib/env` and `server/lib/logger` — both of those validate the client schema at import time, which would make every unit test of any service that touches analytics require a full `.env.local`

## Not done

**The Vercel env vars are not set.** `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` need adding to the production and preview tiers with the real project key. Until then the gate stays closed and nothing ships — this is inert on merge.

**The survey itself must be created in the PostHog UI.** The menu item resolves the active survey at click time rather than hardcoding an id, so no deploy is needed once one exists; with none configured it toasts "Feedback form isn't available right now". PostHog-side config is out of scope per the issue.

## Test Plan

- [x] `pnpm check` green
- [x] `pnpm -F web test:e2e:smoke` — 41/41
- [x] `pnpm -F web e2e:coverage --check` — 15/15 pages, 68/68 use-cases
- [x] Production build with the vars set inlines the key and opens the gate; without them the gate stays closed
- [ ] Set both env vars on the production + preview Vercel tiers, then confirm `check:vercel-env-parity` still passes
- [ ] Create a feedback survey in PostHog, then confirm "Send feedback" opens it on a deployed build
- [ ] After a real upload on a deploy: `upload_started` / `upload_completed` / `upload_confirmed` land on the identified person, and a session replay exists
