### PR TITLE
fix: exclude per-deploy Vercel vars from turbo build hash

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,13 @@
         "build": {
             "dependsOn": ["^build"],
             "outputs": [".next/**", "dist/**"],
-            "env": ["NEXT_PUBLIC_*", "SENTRY_*"]
+            "env": [
+                "NEXT_PUBLIC_*",
+                "!NEXT_PUBLIC_VERCEL_URL",
+                "!NEXT_PUBLIC_VERCEL_BRANCH_URL",
+                "!NEXT_PUBLIC_VERCEL_GIT_*",
+                "SENTRY_*"
+            ]
         },
         "dev": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
## Problem

Turbo remote cache never hit on Vercel builds (prod and dev): every deployment logged `cache miss` / `Cached: 0 cached, 2 total`, including for `trpc-devtools` whose source hadn't changed.

Root cause: the `build` task hashes `NEXT_PUBLIC_*`, and the project auto-exposes Vercel system env vars, so the wildcard matches `NEXT_PUBLIC_VERCEL_URL` (unique per deployment) and `NEXT_PUBLIC_VERCEL_GIT_*` (per commit). The task hash changed on every single deploy. Verified in prod logs (three deploys within an hour, three different `trpc-devtools:build` hashes) and reproduced locally via `turbo build --dry=json` with differing `NEXT_PUBLIC_VERCEL_URL`.

## Fix

Exclude exactly the per-deploy vars from the hash. Verified by dry-run hash comparison:

- same code, different deploy URL / commit SHA → identical hash (cache hit)
- `NEXT_PUBLIC_VERCEL_ENV` prod vs preview → different hash (required: it's inlined into the client bundle for Sentry gating, and prod/preview share the team remote cache)
- `NEXT_PUBLIC_SENTRY_DSN` present vs absent → different hash

Named exclusions rather than `!NEXT_PUBLIC_VERCEL_*` + re-include: turbo applies exclusions order-independently, so a later re-include of `VERCEL_ENV` is silently swallowed (tested). Per Vercel docs, `URL`, `BRANCH_URL`, and `GIT_*` are the only per-deploy/per-commit vars in the `NEXT_PUBLIC_` family; the deployment ID is exposed as `NEXT_DEPLOYMENT_ID`, which the wildcard never matched.

## Expected after merge

First deploy repopulates the cache under new hashes (turbo.json is a global input, so everything misses once). From then on, `trpc-devtools:build` hits on unchanged commits and a redeploy of the same commit is FULL TURBO.

No-Issue: one-line config fix, diagnosed and verified in-session