### PR TITLE
fix: stop deployment-id vars from busting turbo cache for library builds

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,8 +10,14 @@
                 "!NEXT_PUBLIC_VERCEL_URL",
                 "!NEXT_PUBLIC_VERCEL_BRANCH_URL",
                 "!NEXT_PUBLIC_VERCEL_GIT_*",
+                "!NEXT_PUBLIC_VERCEL_DEPLOYMENT_ID",
                 "SENTRY_*"
             ]
+        },
+        "trpc-devtools#build": {
+            "dependsOn": ["^build"],
+            "outputs": ["dist/**"],
+            "env": ["!NEXT_PUBLIC_*", "!VERCEL_DEPLOYMENT_ID"]
         },
         "dev": {
             "dependsOn": ["^build"],


### PR DESCRIPTION
Follow-up to #346, which was necessary but not sufficient — prod builds still showed `0 cached`.

## What #346 missed

Two probe deployments (identical file trees, build command replaced with `turbo build --dry=json` + a dump of every hash input) isolated the remaining per-deployment inputs:

1. **`NEXT_PUBLIC_VERCEL_DEPLOYMENT_ID`** — injected by Vercel alongside `NEXT_DEPLOYMENT_ID` (absent from the system-env-vars docs), unique per deployment, matched by our `NEXT_PUBLIC_*` wildcard.
2. **`VERCEL_DEPLOYMENT_ID`** — added to *every* task's hash by turbo's Vercel-side inference (skew-protection guard), including non-Next packages like `trpc-devtools`.

## Fix

- Base `build` task: exclude `NEXT_PUBLIC_VERCEL_DEPLOYMENT_ID`.
- `trpc-devtools#build` override: exclude `VERCEL_DEPLOYMENT_ID` and inferred `NEXT_PUBLIC_*` too — its `dist/` consumes no env and contains no deployment id, so cross-deployment cache hits are safe. Negation overriding inference verified via dry-run.
- `@nexus/web` **keeps** the deployment id in its hash deliberately: prod HTML embeds `?dpl=<id>` in asset URLs, so its `.next` must not be restored across deployments. Web rebuilds every deploy by platform design.

## Expected

After one cache-repopulating deploy: `trpc-devtools:build: cache hit` on subsequent deploys, `@nexus/web:build` misses on new commits (source changed) and on same-source redeploys (deployment id — intended).

No-Issue: config-only follow-up to #346, diagnosed in-session