### PR TITLE
feat: add /api/health route + scheduled uptime workflow (#333)

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,65 @@
+name: Uptime
+
+# HTTP pinger for the deployed app (#333, part of #326). The other scheduled
+# checks hit the DB or AWS directly from Actions, so a full app outage leaves
+# them all green — this one GETs /api/health on both environments over the
+# public internet. A failed run is the alert: GitHub emails the workflow
+# author on scheduled-run failure, and the notify step posts to Discord.
+#
+# Deliberately in-repo instead of a third-party pinger (no new external
+# services). If monitoring must ever survive an Actions outage, the
+# escalation path is an in-house AWS service via infra/ Terraform.
+
+on:
+    schedule:
+        # Nominal 15-minute cadence; Actions may delay scheduled runs under
+        # load, so treat detection latency as 15–30 min in practice.
+        - cron: '*/15 * * * *'
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    ping:
+        name: Ping /api/health (${{ matrix.env }})
+        runs-on: ubuntu-latest
+        strategy:
+            # An outage in one environment shouldn't hide the other's status.
+            fail-fast: false
+            matrix:
+                include:
+                    - env: prod
+                      url: https://nexus.thomasar.dev/api/health
+                    - env: dev
+                      url: https://dev.nexus.thomasar.dev/api/health
+        steps:
+            - name: GET ${{ matrix.url }}
+              run: |
+                  curl --fail-with-body --silent --show-error \
+                      --max-time 30 --retry 2 --retry-all-errors \
+                      "${{ matrix.url }}"
+
+            # Raw curl instead of lib/alerts on purpose: routing through the
+            # shared module needs checkout + Node + pnpm install, and an
+            # outage alert must not depend on the repo toolchain being
+            # healthy. Costs the styled embed the other alerts get. The
+            # unset-secret-degrades-to-a-no-op contract still matches
+            # s3-event-health.yml.
+            - name: Notify Discord
+              if: failure()
+              env:
+                  DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_ALERT_WEBHOOK_URL }}
+                  MESSAGE: >-
+                      🔴 **Uptime check failed** (${{ matrix.env }}):
+                      ${{ matrix.url }} —
+                      <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>
+              run: |
+                  if [ -z "$DISCORD_ALERT_WEBHOOK_URL" ]; then
+                      echo "DISCORD_ALERT_WEBHOOK_URL not configured — skipping Discord notification."
+                      exit 0
+                  fi
+                  jq -n --arg content "$MESSAGE" '{content: $content}' |
+                      curl --silent --show-error --max-time 15 \
+                          -H 'Content-Type: application/json' \
+                          -d @- "$DISCORD_ALERT_WEBHOOK_URL"

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const hoisted = await vi.hoisted(async () => {
+    const { createMockLogger } = await import('@/server/lib/logger/testing');
+    return { logger: createMockLogger(), execute: vi.fn() };
+});
+
+vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
+vi.mock('@/server/db', () => ({ db: { execute: hoisted.execute } }));
+
+// Import after mock setup
+import { GET } from './route';
+
+describe('GET /api/health', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns 200 with ok checks when the DB responds', async () => {
+        hoisted.execute.mockResolvedValueOnce([{ '?column?': 1 }]);
+
+        const response = await GET();
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            status: 'ok',
+            checks: { db: 'ok' },
+        });
+    });
+
+    it('returns 503 when the DB query throws', async () => {
+        hoisted.execute.mockRejectedValueOnce(
+            new Error('connect ECONNREFUSED')
+        );
+
+        const response = await GET();
+
+        expect(response.status).toBe(503);
+        expect(await response.json()).toEqual({
+            status: 'error',
+            checks: { db: 'down' },
+        });
+    });
+
+    it('keeps error details out of the response body', async () => {
+        hoisted.execute.mockRejectedValueOnce(
+            new Error('password authentication failed for user "app"')
+        );
+
+        const response = await GET();
+
+        const body = JSON.stringify(await response.json());
+        expect(body).not.toContain('password');
+        expect(body).not.toContain('authentication');
+    });
+});

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { sql } from 'drizzle-orm';
+import { db } from '@/server/db';
+import { logger } from '@/server/lib/logger';
+
+const log = logger.child({ handler: 'health' });
+
+// Every request must actually probe the DB — never a build-time snapshot.
+export const dynamic = 'force-dynamic';
+
+/**
+ * Unauthenticated liveness probe for the uptime workflow
+ * (`.github/workflows/uptime.yml`, #333). Reports whether the app can reach
+ * its database; response bodies stay generic so nothing about the failure
+ * (connection strings, driver errors) leaks to the public internet.
+ */
+export async function GET(): Promise<NextResponse> {
+    try {
+        await db.execute(sql`select 1`);
+        return NextResponse.json({ status: 'ok', checks: { db: 'ok' } });
+    } catch (err) {
+        // An unreachable DB is the expected failure this route exists to
+        // surface: log + 503, no Sentry capture, no in-app alert — during a
+        // real outage this route can't deliver either. The uptime workflow
+        // owns notification.
+        log.error({ err }, 'Health check failed');
+        return NextResponse.json(
+            { status: 'error', checks: { db: 'down' } },
+            { status: 503 }
+        );
+    }
+}

--- a/apps/web/e2e/smoke/health.spec.ts
+++ b/apps/web/e2e/smoke/health.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Health API', () => {
+    // Not a page and not a user-facing use-case, so no @page/@uc tag — the
+    // coverage manifest tracks UI surface only. This spec keeps the uptime
+    // workflow's probe target (`.github/workflows/uptime.yml`) honest.
+    test('GET /api/health reports ok', async ({ request }) => {
+        const response = await request.get('/api/health');
+
+        expect(response.status()).toBe(200);
+        expect(await response.json()).toEqual({
+            status: 'ok',
+            checks: { db: 'ok' },
+        });
+    });
+});

--- a/docs/infra/uptime-monitoring.md
+++ b/docs/infra/uptime-monitoring.md
@@ -1,0 +1,69 @@
+---
+title: Uptime Monitoring
+created: 2026-08-12
+updated: 2026-08-12
+status: active
+tags:
+    - infra
+    - monitoring
+    - observability
+aliases:
+    - Uptime Monitoring
+    - Health Check
+ai_summary: 'How the deployed app is uptime-monitored: /api/health + the scheduled Uptime workflow'
+---
+
+# Uptime Monitoring
+
+How the deployed app is monitored for availability. Created 2026-08-12 (#333, part of #326).
+
+## What exists
+
+| Piece                | Location                                 | Role                                                                              |
+| -------------------- | ---------------------------------------- | --------------------------------------------------------------------------------- |
+| Health endpoint      | `apps/web/app/api/health/route.ts`       | `GET /api/health` — 200 + `{ status, checks }` when the DB is reachable, 503 else |
+| Pinger               | `.github/workflows/uptime.yml`           | Scheduled GET against prod + dev every ~15 min; a failed run is the alert         |
+| Discord notification | `DISCORD_ALERT_WEBHOOK_URL` repo secret  | Posted by the workflow's `Notify Discord` step on failure                         |
+| Email notification   | GitHub's built-in workflow-failure email | Sent to the workflow author on scheduled-run failure                              |
+
+Monitored URLs:
+
+- prod: `https://nexus.thomasar.dev/api/health`
+- dev: `https://dev.nexus.thomasar.dev/api/health` (public since Vercel protection was disabled project-wide, #317/#320)
+
+## Why this shape
+
+The other scheduled checks ([[supabase-manual-setup|Supabase keepalive]], `s3-event-health.yml`) connect to the DB or AWS **directly from GitHub Actions** — a full app outage leaves all of them green. The Uptime workflow is the only check that goes through the deployed app over the public internet.
+
+No third-party pinger (UptimeRobot/BetterStack were considered and rejected — no new external services). The known trade-off: this monitor is blind if GitHub Actions itself is down, and scheduled runs can be delayed under load, so treat detection latency as 15–30 min.
+
+The workflow's Discord step is raw `curl`, not the shared `lib/alerts` module the other scheduled checks use — deliberately. Going through `lib/alerts` requires checkout + Node + pnpm install, and an outage alert must not depend on the repo toolchain being healthy. The cost is cosmetic: uptime alerts post as plain text instead of the styled embed every other alert gets.
+
+> [!important] Escalation path is in-house, not SaaS.
+> If monitoring must ever survive an Actions outage, build a small pinger in AWS via the existing `infra/` Terraform setup and the monorepo — do not add a third-party service.
+
+## The health endpoint
+
+`GET /api/health` is unauthenticated (the `proxy.ts` matcher only covers `/dashboard/*` and the auth pages) and `force-dynamic`. It runs `select 1` through the app's own drizzle connection (transaction pooler), so a green response means the deployed app can reach its database — not just that Vercel served a page.
+
+Response bodies are deliberately generic (`ok`/`down` per check, nothing else): the route is public, so no driver errors, hostnames, or timing details. A 503 is expected control flow — it logs via `logger` but does not report to Sentry or `lib/alerts`; during a real outage the app can't deliver either, which is the whole reason the pinger is external to the app.
+
+S3 is not checked here (kept DB-only for speed and fewer false 503s); tier drift and event-pipeline health have their own nightly workflow.
+
+## Changing the monitor
+
+Everything lives in `.github/workflows/uptime.yml`:
+
+- **Cadence**: the `cron` expression (nominal `*/15`).
+- **URLs / environments**: the job matrix.
+- **Timeout / retries**: the `curl` flags (`--max-time 30 --retry 2`) — transient blips retry before a run fails.
+- **Discord**: the `DISCORD_ALERT_WEBHOOK_URL` repo secret (shared with `s3-event-health.yml`); unset degrades to a no-op.
+- **Email**: GitHub notifies the workflow author when a scheduled run fails, per their GitHub notification settings — no config in-repo.
+- **Manual run**: `workflow_dispatch` (Actions tab → Uptime → Run workflow), or `gh workflow run uptime.yml`.
+
+During an outage the workflow alerts once per run per environment (no dedup/cooldown); at the current cadence that's up to ~4 Discord messages an hour per environment until resolved or the schedule is paused (Actions tab → Uptime → ⋯ → Disable workflow).
+
+## Related
+
+- [[supabase-manual-setup|Supabase Manual Setup]] — DB secrets the other scheduled checks depend on
+- [[aws-manual-setup|AWS Manual Setup]] — AWS-side manual configuration


### PR DESCRIPTION
## Summary

Adds the first check that actually issues an HTTP request to the deployed app. `GET /api/health` probes the DB through the app's own drizzle connection and returns 200/503; a new scheduled `Uptime` workflow GETs it on prod and dev every ~15 minutes, posting to Discord on failure (GitHub's built-in scheduled-workflow failure email covers the email channel). In-repo pinger by decision — no third-party uptime SaaS; the escalation path if Actions-independence is ever needed is an in-house AWS service via the existing Terraform setup (recorded in the issue and the new doc).

Closes #333

## Changes

- `apps/web/app/api/health/route.ts` — unauthenticated, `force-dynamic` GET; `select 1` via `db.execute`; minimal JSON (`ok`/`down` per check, no error details leaked); 503 logs but deliberately skips Sentry/`lib/alerts` (expected control flow, and during a real outage the app can't deliver either)
- `apps/web/app/api/health/route.test.ts` — vitest: 200 shape, 503 on DB failure, no-secret-leak regression guard
- `apps/web/e2e/smoke/health.spec.ts` — smoke spec hitting the live route; no `@page`/`@uc` tag (not a page or user-facing use-case, coverage check confirms green)
- `.github/workflows/uptime.yml` — `*/15` cron + `workflow_dispatch`, prod/dev matrix with `fail-fast: false`, curl with timeout/retries; Discord step is raw curl on purpose (no checkout/Node dependency for an outage alert — reviewed and documented; cost is a plain-text alert instead of the styled embed)
- `docs/infra/uptime-monitoring.md` — what exists, why this shape, how to change cadence/URLs/notifications

## Test Plan

- [x] `pnpm check` — 10/10 green (includes the new unit tests)
- [x] `pnpm -F web test:e2e:smoke` — 42/42, health spec exercises the real route against the dev server
- [x] `pnpm -F web e2e:coverage --check` — passes without a manifest entry
- [x] `actionlint .github/workflows/uptime.yml` — clean
- [ ] Post-merge: `gh workflow run uptime.yml` (scheduled workflows only run from the default branch) and confirm both matrix legs pass against the live environments
- [ ] Post-merge: temporarily point one matrix URL at a 404 (or run during a dev redeploy) if you want to see the Discord failure path fire
