### PR TITLE
chore: make uptime workflow failures readable at a glance

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -34,11 +34,49 @@ jobs:
                     - env: dev
                       url: https://dev.nexus.thomasar.dev/api/health
         steps:
+            # Hand-rolled retry loop instead of curl --retry: --retry logs
+            # only bare "curl: (22)" lines and dumps the full error page,
+            # which made the first real failure unreadable. The loop gives
+            # one line per attempt (status + latency), a truncated body only
+            # on final failure, and an ::error annotation + step summary so
+            # the run page says what broke without opening logs.
             - name: GET ${{ matrix.url }}
+              env:
+                  URL: ${{ matrix.url }}
+                  ENV_NAME: ${{ matrix.env }}
               run: |
-                  curl --fail-with-body --silent --show-error \
-                      --max-time 30 --retry 2 --retry-all-errors \
-                      "${{ matrix.url }}"
+                  attempts=3
+                  status=000
+                  touch body.txt
+                  for i in $(seq 1 "$attempts"); do
+                      started=$(date +%s%3N)
+                      status=$(curl --silent --show-error --output body.txt \
+                          --write-out '%{http_code}' --max-time 30 "$URL" || true)
+                      status=${status:-000}
+                      took=$(( $(date +%s%3N) - started ))
+                      if [ "$status" = "200" ]; then
+                          echo "attempt $i/$attempts: HTTP 200 in ${took}ms — $(cat body.txt)"
+                          exit 0
+                      fi
+                      if [ "$status" = "000" ]; then
+                          echo "attempt $i/$attempts: no HTTP response (timeout/DNS/connection) after ${took}ms"
+                      else
+                          echo "attempt $i/$attempts: HTTP $status in ${took}ms"
+                      fi
+                      if [ "$i" -lt "$attempts" ]; then sleep 10; fi
+                  done
+                  echo "last response body (truncated to 300 bytes):"
+                  head -c 300 body.txt; echo
+                  echo "::error title=Uptime check failed ($ENV_NAME)::GET $URL → HTTP $status on all $attempts attempts"
+                  {
+                      echo "### ❌ $ENV_NAME: \`GET $URL\` → HTTP $status ($attempts attempts)"
+                      echo
+                      echo '```'
+                      head -c 300 body.txt
+                      echo
+                      echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
+                  exit 1
 
             # Raw curl instead of lib/alerts on purpose: routing through the
             # shared module needs checkout + Node + pnpm install, and an

--- a/docs/infra/uptime-monitoring.md
+++ b/docs/infra/uptime-monitoring.md
@@ -56,7 +56,7 @@ Everything lives in `.github/workflows/uptime.yml`:
 
 - **Cadence**: the `cron` expression (nominal `*/15`).
 - **URLs / environments**: the job matrix.
-- **Timeout / retries**: the `curl` flags (`--max-time 30 --retry 2`) — transient blips retry before a run fails.
+- **Timeout / retries**: the retry loop in the `GET` step (3 attempts, `--max-time 30` each, 10s apart) — transient blips retry before a run fails. Each attempt logs one line (HTTP status + latency); a failed run also gets an `::error` annotation and a step summary on the run page.
 - **Discord**: the `DISCORD_ALERT_WEBHOOK_URL` repo secret (shared with `s3-event-health.yml`); unset degrades to a no-op.
 - **Email**: GitHub notifies the workflow author when a scheduled run fails, per their GitHub notification settings — no config in-repo.
 - **Manual run**: `workflow_dispatch` (Actions tab → Uptime → Run workflow), or `gh workflow run uptime.yml`.


### PR DESCRIPTION
## Summary

The first real Uptime failure (run 31612312216) was unreadable: three bare `curl: (22)` lines, a 26KB one-line dump of Vercel's 404 HTML, and `exit code 22` — no status code, no timeout-vs-HTTP distinction, no per-attempt context. This replaces `curl --retry` with a hand-rolled loop that reports what happened, still pure bash/curl (no toolchain dependency).

No-Issue: DX polish on #333's workflow, surfaced by its first real failure.

## Changes

- `.github/workflows/uptime.yml` — retry loop (3 attempts, 10s apart, `--max-time 30` each): one log line per attempt with HTTP status + latency (curl `%{time_total}`), explicit "no HTTP response (timeout/DNS/connection)" wording for curl-level failures, response body truncated to 300 bytes and only shown on final failure, `::error` annotation so the run page states the failure without opening logs, and a step-summary block
- `docs/infra/uptime-monitoring.md` — updated the "Timeout / retries" bullet to match

## Test Plan

- [x] `actionlint` clean (includes shellcheck on the run block)
- [x] Step body extracted and run locally against live endpoints: dev `/api/health` (200 path) and prod's current 404 — per-attempt lines, truncated body, annotation, and summary all render as intended
- [x] `pnpm check` green
- [ ] After merge: next failed run shows readable output + annotation + summary
