### PR TITLE
chore: guard the files bucket with prevent_destroy (#341)

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -9,7 +9,8 @@ which closed the main drift vector between environments).
 
 State lives in S3 (`nexus-terraform-state-391615358272`, us-east-1) with one
 workspace per environment. A guard resource fails the plan if the selected
-workspace doesn't match `var.environment`.
+workspace doesn't match `var.environment`, and `prevent_destroy` on the files
+bucket fails a whole-stack destroy (see [Destroy](#destroy)).
 
 ## Prerequisites
 
@@ -83,3 +84,26 @@ production code.
     | `AWS_REGION`                                  | `aws_region` output    |
     | `SQS_QUEUE_URL`                               | `sqs_queue_url` output |
     | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | access key from step 1 |
+
+## Destroy
+
+`aws_s3_bucket.files` carries `lifecycle { prevent_destroy = true }`, so
+`terraform destroy` on this stack fails at plan time, before any resource is
+removed. That one guard covers everything: the rest of the stack (SQS, SNS,
+Lambda, IAM) is reconstructible from these files, so losing it is an outage,
+not data loss.
+
+Decommissioning an environment for real means deleting the bucket contents and
+removing the guard in a commit first. Then:
+
+```bash
+terraform -chdir=infra/terraform workspace select dev    # or prod
+terraform -chdir=infra/terraform destroy -var-file=environments/dev.tfvars
+```
+
+- **`-chdir` over `cd`** — the target stack is named in the command itself, so
+  a destroy can't hit a different stack because the shell was left in another
+  directory.
+- **Never `-auto-approve`.** Read the `N to destroy` count in the plan header,
+  check that N and the listed resources match the stack you meant, then type
+  `yes`.

--- a/infra/terraform/s3.tf
+++ b/infra/terraform/s3.tf
@@ -2,6 +2,13 @@
 
 resource "aws_s3_bucket" "files" {
   bucket = "nexus-storage-files-${var.environment}"
+
+  # Customer archives live here and cannot be rebuilt from this config. The
+  # guard also fails a whole-stack destroy at plan time, before anything else
+  # in the stack is torn down.
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "files" {

--- a/infra/terraform/sqs.tf
+++ b/infra/terraform/sqs.tf
@@ -1,4 +1,8 @@
 # Background-jobs queues — spec: docs/guides/background-jobs.md
+#
+# Deliberately no prevent_destroy (unlike the files bucket): these buffer
+# in-flight messages rather than store data, and the bucket's guard already
+# fails a blanket destroy at plan time before any queue is reached.
 
 resource "aws_sqs_queue" "jobs_dlq" {
   name = "nexus-jobs-dlq-${var.environment}"


### PR DESCRIPTION
## Summary

The app stack had no structural backstop against a mistaken `terraform destroy` — safety depended entirely on operator care at the keyboard. This adds `prevent_destroy` to `aws_s3_bucket.files`, the one irreplaceable resource in the stack, which makes a whole-stack destroy fail at plan time before anything is torn down.

Closes #341

## Changes

- `s3.tf` — `lifecycle { prevent_destroy = true }` on `aws_s3_bucket.files`, with a comment on why it is that resource and not the others.
- `sqs.tf` — records the decision *not* to guard the job queues, so a future reader does not read the absence as an oversight. They buffer in-flight messages rather than store data, and the bucket guard already kills a blanket destroy before any queue is reached. The SNS webhook DLQ in `sns.tf` is untouched for the same reason.
- `README.md` — new `## Destroy` section with the safe pattern (`-chdir` instead of `cd`, never `-auto-approve`, read the `N to destroy` count before approving) plus a pointer to it from the state/guards paragraph. This also makes `docs/guides/background-jobs.md` honest: it already claimed the README documented an "apply/destroy flow", and until now there was no destroy section.

Left alone deliberately: the four S3 sub-resources (public-access block, lifecycle config, CORS, notification) carry no data and are cheap to recreate. A targeted `-target` destroy of one of those still works, which matches the issue’s intent — the guard is against a blanket destroy.

## Test Plan

- [x] `terraform plan -destroy` on the **dev** workspace exits 1: `Error: Instance cannot be destroyed — Resource aws_s3_bucket.files has lifecycle.prevent_destroy set`.
- [x] Same on the **prod** workspace, exits 1 with the same error.
- [x] A normal `terraform plan` on prod still reports `0 to destroy` and does not mark the bucket for replacement, so the guard does not block a legitimate apply.
- [x] `terraform fmt -check` clean, `terraform validate` passes, `pnpm check` green.

Note on the destroy-plan output: Terraform renders the proposed plan and *then* errors with a non-zero exit, so it never reaches an apply prompt and no resource is destroyed. It does not suppress the plan text.