### PR TITLE
fix: bundle libcrypt.so.2 in exiftool layer, log fail-soft reasons (#350)

### DIFF
--- a/apps/worker/src/handlers/generateThumbnail.ts
+++ b/apps/worker/src/handlers/generateThumbnail.ts
@@ -155,9 +155,16 @@ async function extractRawPreview(
                 await writeFile(destPath, stdout);
                 return destPath;
             }
-        } catch {
+            console.warn(`exiftool ${tag}: empty extraction`);
+        } catch (error) {
             // exiftool exits non-zero on unreadable input; treat like an
-            // empty extraction and let the caller escalate.
+            // empty extraction and let the caller escalate — but never
+            // silently: the reason is unrecoverable after the job completes.
+            const e = error as NodeJS.ErrnoException & { stderr?: Buffer };
+            console.warn(
+                `exiftool ${tag} failed: ${e.code ?? ''} ${e.message}`,
+                e.stderr ? e.stderr.toString('utf8').slice(0, 500) : ''
+            );
         }
     }
     return null;
@@ -176,7 +183,12 @@ async function runFfmpeg(args: string[]): Promise<FfmpegResult> {
         await execFileAsync(FFMPEG, ['-y', '-hide_banner', ...args]);
         return { ok: true };
     } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'ENOENT') throw error;
+        const e = error as NodeJS.ErrnoException & { stderr?: string };
+        if (e.code === 'ENOENT') throw error;
+        console.warn(
+            `ffmpeg exited non-zero: ${e.message}`,
+            e.stderr ? e.stderr.slice(-500) : ''
+        );
         return { ok: false };
     }
 }
@@ -379,6 +391,9 @@ export async function generateThumbnail(
                 : await generateStill(file, kind, workDir);
 
         if (outcome.status !== 'ready') {
+            console.warn(
+                `thumbnail ${outcome.status}: file=${file.id} kind=${kind}`
+            );
             await fileRepo.update(file.id, { thumbnailStatus: outcome.status });
             return;
         }

--- a/infra/terraform/layers.tf
+++ b/infra/terraform/layers.tf
@@ -9,13 +9,17 @@
 # the workflow together (the apply fails fast if the object is missing).
 
 locals {
-  ffmpeg_layer_s3_key   = "layers/ffmpeg-${local.ffmpeg_version}-webp.zip"
-  exiftool_layer_s3_key = "layers/exiftool-${local.exiftool_version}-perl-${local.perl_version}.zip"
+  ffmpeg_layer_s3_key   = "layers/ffmpeg-${local.ffmpeg_version}-webp-r${local.ffmpeg_layer_revision}.zip"
+  exiftool_layer_s3_key = "layers/exiftool-${local.exiftool_version}-perl-${local.perl_version}-r${local.exiftool_layer_revision}.zip"
 
-  # Keep in lockstep with the pins in tooling/lambda-layers/*.sh.
-  ffmpeg_version   = "7.1"
-  perl_version     = "5.40.0"
-  exiftool_version = "13.55"
+  # Keep in lockstep with the pins in tooling/lambda-layers/*.sh. The
+  # revision bumps when layer content changes without a tool-version bump
+  # (a new s3 key is what makes this module publish a new layer version).
+  ffmpeg_version          = "7.1"
+  ffmpeg_layer_revision   = 1
+  perl_version            = "5.40.0"
+  exiftool_version        = "13.55"
+  exiftool_layer_revision = 2
 }
 
 resource "aws_s3_bucket" "lambda_artifacts" {

--- a/infra/terraform/scripts/upload-layers.sh
+++ b/infra/terraform/scripts/upload-layers.sh
@@ -17,13 +17,14 @@ ENV="$1"
 DIR="$2"
 case "$ENV" in dev | prod) ;; *) usage ;; esac
 
-shopt -s nullglob globstar
-zips=("$DIR"/**/*.zip)
-if [ ${#zips[@]} -eq 0 ]; then
+# find, not globstar: macOS ships bash 3.2, which has no globstar.
+found=0
+while IFS= read -r zip; do
+    found=1
+    aws s3 cp "$zip" "s3://nexus-lambda-artifacts-$ENV/layers/$(basename "$zip")"
+done < <(find "$DIR" -name '*.zip')
+
+if [ "$found" -eq 0 ]; then
     echo "no layer zips found under $DIR" >&2
     exit 1
 fi
-
-for zip in "${zips[@]}"; do
-    aws s3 cp "$zip" "s3://nexus-lambda-artifacts-$ENV/layers/$(basename "$zip")"
-done

--- a/tooling/lambda-layers/build-exiftool-layer.sh
+++ b/tooling/lambda-layers/build-exiftool-layer.sh
@@ -20,6 +20,10 @@ set -euo pipefail
 # 404s any pinned URL. CPAN archives every production release permanently.
 PERL_VERSION=5.40.0
 EXIFTOOL_VERSION=13.55
+# Bump when the layer CONTENT changes without a tool-version bump (the s3
+# key embeds it, and a new key is what makes Terraform publish a new layer
+# version). r2: bundled libcrypt.so.2.
+LAYER_REVISION=2
 
 PERL_SHA256=c740348f357396327a9795d3e8323bafd0fe8a5c7835fc1cbaba0cc8dfe7161f
 EXIFTOOL_SHA256=5f4c81d34ad406538c2871ad72dbfceb5d9b412b2f16cbbeb4d712d270846667
@@ -34,7 +38,7 @@ JOBS="$(nproc)"
 mkdir -p "$BUILD" "$ROOT/opt"
 
 dnf install -y --setopt=install_weak_deps=False \
-    gcc make tar gzip zip patch >/dev/null
+    gcc make tar gzip zip patch binutils >/dev/null
 
 fetch() { # <url> <sha256> <output>
     curl -fsSL --retry 3 -o "$3" "$1"
@@ -75,14 +79,46 @@ tar xf perl.tar.gz
 # Docs don't belong in a Lambda layer.
 find "$ROOT/opt/perl" -name '*.pod' -delete
 
+# The nodejs22.x Lambda runtime is a TRIMMED AL2023: perl's libcrypt.so.2
+# dependency exists in this full build container but not in the runtime,
+# where its absence makes perl exit 127 at the dynamic-linker stage. Bundle
+# it — /opt/lib is on the runtime's LD_LIBRARY_PATH.
+mkdir -p "$ROOT/opt/lib"
+cp -a /usr/lib64/libcrypt.so.2* "$ROOT/opt/lib/"
+
+# Guard the whole class of bug: every dynamic dependency of every ELF in
+# the layer must be present in the trimmed runtime (allowlist verified
+# against public.ecr.aws/lambda/nodejs:22) or bundled in lib/. The plain
+# smoke test below can't catch a miss — the build container resolves
+# system-wide what the runtime doesn't ship.
+RUNTIME_LIBS='libc.so.6 libm.so.6 libz.so.1'
+check_runtime_deps() { # <elf-file...>
+    local bin lib ok
+    for bin in "$@"; do
+        for lib in $(objdump -p "$bin" 2>/dev/null | awk '/NEEDED/{print $2}'); do
+            ok=false
+            case " $RUNTIME_LIBS " in *" $lib "*) ok=true ;; esac
+            [ -e "$ROOT/opt/lib/$lib" ] && ok=true
+            if [ "$ok" = false ]; then
+                echo "$bin needs $lib: absent from the Lambda runtime and not bundled in lib/" >&2
+                exit 1
+            fi
+        done
+    done
+}
+check_runtime_deps "$ROOT/opt/perl/bin/perl"
+while IFS= read -r so; do
+    check_runtime_deps "$so"
+done < <(find "$ROOT/opt/perl" -name '*.so')
+
 tar xf exiftool.tar.gz
 mkdir -p "$ROOT/opt/exiftool"
 cp "Image-ExifTool-$EXIFTOOL_VERSION/exiftool" "$ROOT/opt/exiftool/"
 cp -r "Image-ExifTool-$EXIFTOOL_VERSION/lib" "$ROOT/opt/exiftool/"
 
-# Smoke test with the staged interpreter — the build container is the same
-# AL2023 the Lambda runtime uses.
-version_output="$("$ROOT/opt/perl/bin/perl" "$ROOT/opt/exiftool/exiftool" -ver)"
+# Smoke test with the staged interpreter, resolving shared libs the way the
+# runtime will (bundled lib/ first).
+version_output="$(LD_LIBRARY_PATH="$ROOT/opt/lib" "$ROOT/opt/perl/bin/perl" "$ROOT/opt/exiftool/exiftool" -ver)"
 if [ "$version_output" != "$EXIFTOOL_VERSION" ]; then
     echo "exiftool smoke test failed: got '$version_output', want '$EXIFTOOL_VERSION'" >&2
     exit 1
@@ -94,9 +130,9 @@ if [ "$total_mb" -gt "$MAX_UNZIPPED_MB" ]; then
     exit 1
 fi
 
-ZIP="$OUT_DIR/exiftool-$EXIFTOOL_VERSION-perl-$PERL_VERSION.zip"
+ZIP="$OUT_DIR/exiftool-$EXIFTOOL_VERSION-perl-$PERL_VERSION-r$LAYER_REVISION.zip"
 rm -f "$ZIP"
-(cd "$ROOT/opt" && zip -qr9 --symlinks "$ZIP" perl exiftool)
+(cd "$ROOT/opt" && zip -qr9 --symlinks "$ZIP" perl exiftool lib)
 
 echo "built $ZIP (${total_mb}MB unzipped)"
 sha256sum "$ZIP"

--- a/tooling/lambda-layers/build-ffmpeg-layer.sh
+++ b/tooling/lambda-layers/build-ffmpeg-layer.sh
@@ -17,6 +17,10 @@ set -euo pipefail
 FFMPEG_VERSION=7.1
 LIBWEBP_VERSION=1.4.0
 OPENSSL_VERSION=3.5.7
+# Bump when the layer CONTENT changes without a tool-version bump (the s3
+# key embeds it, and a new key is what makes Terraform publish a new layer
+# version).
+LAYER_REVISION=1
 
 FFMPEG_SHA256=40973d44970dbc83ef302b0609f2e74982be2d85916dd2ee7472d30678a7abe6
 LIBWEBP_SHA256=61f873ec69e3be1b99535634340d5bde750b2e4447caa1db9f61be3fd49ab1e5
@@ -38,7 +42,7 @@ mkdir -p "$BUILD" "$DEPS"
 # budget can't afford.
 dnf install -y --setopt=install_weak_deps=False \
     gcc gcc-c++ make nasm perl pkgconf zlib-devel \
-    tar gzip xz bzip2 zip diffutils file >/dev/null
+    tar gzip xz bzip2 zip diffutils file binutils >/dev/null
 
 fetch() { # <url> <sha256> <output>
     curl -fsSL --retry 3 -o "$3" "$1"
@@ -119,13 +123,35 @@ strip "$BUILD/layer/bin/ffmpeg" "$BUILD/layer/bin/ffprobe"
 "$BUILD/layer/bin/ffmpeg" -hide_banner -protocols | grep -q https
 "$BUILD/layer/bin/ffprobe" -version >/dev/null
 
+# Every dynamic dependency must exist in the TRIMMED Lambda runtime
+# (allowlist verified against public.ecr.aws/lambda/nodejs:22) or be
+# bundled in the layer — the full build container resolves system-wide
+# what the runtime doesn't ship, so a plain smoke test can't catch a miss
+# (that's how the exiftool layer shipped without libcrypt.so.2).
+RUNTIME_LIBS='libc.so.6 libm.so.6 libz.so.1'
+check_runtime_deps() { # <elf-file...>
+    local bin lib ok
+    for bin in "$@"; do
+        for lib in $(objdump -p "$bin" 2>/dev/null | awk '/NEEDED/{print $2}'); do
+            ok=false
+            case " $RUNTIME_LIBS " in *" $lib "*) ok=true ;; esac
+            [ -e "$BUILD/layer/lib/$lib" ] && ok=true
+            if [ "$ok" = false ]; then
+                echo "$bin needs $lib: absent from the Lambda runtime and not bundled" >&2
+                exit 1
+            fi
+        done
+    done
+}
+check_runtime_deps "$BUILD/layer/bin/ffmpeg" "$BUILD/layer/bin/ffprobe"
+
 total_mb="$(du -sm "$BUILD/layer" | cut -f1)"
 if [ "$total_mb" -gt "$MAX_UNZIPPED_MB" ]; then
     echo "ffmpeg layer is ${total_mb}MB unzipped (cap ${MAX_UNZIPPED_MB}MB)" >&2
     exit 1
 fi
 
-ZIP="$OUT_DIR/ffmpeg-$FFMPEG_VERSION-webp.zip"
+ZIP="$OUT_DIR/ffmpeg-$FFMPEG_VERSION-webp-r$LAYER_REVISION.zip"
 rm -f "$ZIP"
 (cd "$BUILD/layer" && zip -qr9 "$ZIP" bin)
 


### PR DESCRIPTION
## Summary
The #350 rollout verification on dev found RAW thumbnails failing: the exiftool layer's perl exits 127 on the real Lambda because the nodejs22.x runtime is a trimmed AL2023 that does not ship `libcrypt.so.2` (perl links against it). The build container and CI smoke test run in full AL2023 where the lib resolves system-wide, so nothing caught it. Reproduced and fix verified in the actual runtime image (`public.ecr.aws/lambda/nodejs:22`): with the lib bundled, `exiftool -ver` returns 13.55 and JpgFromRaw extraction produces the full preview.

The failure was also invisible: the worker's fail-soft paths swallowed the exiftool/ffmpeg errors with zero logging, so the job completed as `failed` with no reason recorded anywhere.

No-Issue: rollout-blocking fix discovered while executing the #350 rollout.

## Changes
- `build-exiftool-layer.sh`: bundle `/usr/lib64/libcrypt.so.2*` into the layer's `lib/` (mounts at `/opt/lib`, which is on the runtime's `LD_LIBRARY_PATH`); smoke test now resolves libs the runtime way
- both layer scripts: `check_runtime_deps` guard — every NEEDED lib of every ELF must be in a runtime-verified allowlist (`libc/libm/libz`) or bundled, so this class of bug fails the build instead of cold start
- both layer scripts + `layers.tf`: `LAYER_REVISION` suffix in the zip name/s3 key, so content fixes without tool-version bumps make Terraform publish a new layer version (exiftool → r2, ffmpeg → r1)
- `generateThumbnail.ts`: fail-soft paths now log the swallowed reason (exiftool error + stderr, ffmpeg stderr tail, per-job outcome line)
- `upload-layers.sh`: replace `globstar` (bash 4+) with `find` — macOS ships bash 3.2

## Test Plan
- [x] `pnpm check` green
- [x] Runtime-image repro: unfixed layer fails exit 127 with `libcrypt.so.2 => not found`; patched layer extracts JpgFromRaw (1,175,901 bytes) in `public.ecr.aws/lambda/nodejs:22`
- [ ] Lambda-layers CI green on this PR
- [ ] Dev: upload r2/r1 zips, apply, redeploy worker, re-run NEF job → `thumbnail_status = ready`