### PR TITLE
fix: show Expired badge for pending invites past expiry (#336)

### DIFF
--- a/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/admin/invites/page.tsx
@@ -25,6 +25,7 @@ import {
     formatRelativeTime,
     formatRelativeTimeCompact,
 } from '@/lib/format';
+import { isInviteExpired } from '@/lib/invites';
 import { useTRPC } from '@/lib/trpc/client';
 import { SPONSORED_DEFAULT_STORAGE_LIMIT } from '@/server/services/constants';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -168,7 +169,7 @@ export default function AdminInvitesPage() {
                                         trailing={
                                             <>
                                                 <InviteStatusBadge
-                                                    status={invite.status}
+                                                    invite={invite}
                                                 />
                                                 {invite.status ===
                                                     'pending' && (
@@ -237,7 +238,7 @@ export default function AdminInvitesPage() {
                                             </TableCell>
                                             <TableCell>
                                                 <InviteStatusBadge
-                                                    status={invite.status}
+                                                    invite={invite}
                                                 />
                                             </TableCell>
                                             <TableCell className="text-muted-foreground">
@@ -454,36 +455,31 @@ function CreateInviteForm({ onCreated }: CreateInviteFormProps) {
     );
 }
 
-function InviteStatusBadge({ status }: { status: InviteStatus }) {
-    switch (status) {
-        case 'pending':
-            return (
-                <Badge
-                    variant="secondary"
-                    className="bg-blue-500/10 text-blue-600"
-                >
-                    Pending
-                </Badge>
-            );
-        case 'redeemed':
-            return (
-                <Badge
-                    variant="secondary"
-                    className="bg-green-500/10 text-green-600"
-                >
-                    Redeemed
-                </Badge>
-            );
-        case 'revoked':
-            return (
-                <Badge
-                    variant="secondary"
-                    className="bg-red-500/10 text-red-600"
-                >
-                    Revoked
-                </Badge>
-            );
-    }
+/* `expired` is derived, not a DB status — see `isInviteExpired`. Keying the
+   `Record` off the enum forces a new invite status to get a badge here rather
+   than falling through to an empty cell. */
+const INVITE_BADGES: Record<
+    InviteStatus | 'expired',
+    { label: string; className: string }
+> = {
+    pending: { label: 'Pending', className: 'bg-blue-500/10 text-blue-600' },
+    expired: { label: 'Expired', className: 'bg-amber-500/10 text-amber-600' },
+    redeemed: {
+        label: 'Redeemed',
+        className: 'bg-green-500/10 text-green-600',
+    },
+    revoked: { label: 'Revoked', className: 'bg-red-500/10 text-red-600' },
+};
+
+function InviteStatusBadge({ invite }: { invite: Invite }) {
+    const { label, className } =
+        INVITE_BADGES[isInviteExpired(invite) ? 'expired' : invite.status];
+
+    return (
+        <Badge variant="secondary" className={className}>
+            {label}
+        </Badge>
+    );
 }
 
 interface PendingInviteActionsProps {
@@ -495,7 +491,8 @@ interface PendingInviteActionsProps {
 }
 
 /* Copy-link + revoke for pending invites — shared by the table cell and the
-   stacked mobile rows. */
+   stacked mobile rows. Expired invites keep these actions: their DB status is
+   still `pending`, so revoke works and it's the only way to clear the row. */
 function PendingInviteActions({
     token,
     onRevoke,

--- a/apps/web/e2e/admin/invites.spec.ts
+++ b/apps/web/e2e/admin/invites.spec.ts
@@ -7,15 +7,22 @@ import {
     findUserByEmail,
     type Invite,
 } from '@nexus/db/test-db';
+import type { Page, Locator } from '@playwright/test';
 import { ADMIN_USER } from '../helpers/auth';
-import { waitForTableLoad } from '../helpers/table';
+import { statusCell, statusCells, waitForTableLoad } from '../helpers/table';
 
 const PAGE_URL = '/dashboard/admin/invites';
+
+/** The table row for a seeded invite, located by its unique recipient. */
+function inviteRow(page: Page, email: string): Locator {
+    return page.locator('tbody tr').filter({ hasText: email });
+}
 
 // Unique per run so a crashed previous run can't collide; cleaned in afterAll.
 const RUN_ID = `${Date.now()}-${process.pid}`;
 const SEEDED_EMAIL = `invite-seeded-${RUN_ID}@test.local`;
 const REVOKE_EMAIL = `invite-revoke-${RUN_ID}@test.local`;
+const EXPIRED_EMAIL = `invite-expired-${RUN_ID}@test.local`;
 const CREATED_EMAIL = `invite-created-${RUN_ID}@test.local`;
 
 // Admin project applies the admin storageState at the project level; align the
@@ -44,6 +51,12 @@ test.describe('admin invites', () => {
             }),
             insertInvite(db, { createdBy: admin.id, status: 'revoked' }),
             insertInvite(db, { createdBy: admin.id, email: REVOKE_EMAIL }),
+            // Still `pending` in the DB — expiry is derived in the UI (#336).
+            insertInvite(db, {
+                createdBy: admin.id,
+                email: EXPIRED_EMAIL,
+                expiresAt: new Date(Date.now() - 86_400_000),
+            }),
         ]);
     });
 
@@ -67,18 +80,34 @@ test.describe('admin invites', () => {
             await expect(headers.nth(3)).toHaveText('Created');
             await expect(headers.nth(4)).toHaveText('Expires');
 
-            const row = page
-                .locator('tbody tr')
-                .filter({ hasText: SEEDED_EMAIL });
+            const row = inviteRow(page, SEEDED_EMAIL);
             await expect(row.getByText('Pending')).toBeVisible();
             await expect(row.getByText('2 TB')).toBeVisible();
 
             // Invites without a per-tester override show the effective
             // sponsored default, marked as such.
-            const defaultRow = page
-                .locator('tbody tr')
-                .filter({ hasText: REVOKE_EMAIL });
+            const defaultRow = inviteRow(page, REVOKE_EMAIL);
             await expect(defaultRow.getByText('(default)')).toBeVisible();
+        }
+    );
+
+    test(
+        'a pending invite past its expiry reads Expired and stays revocable',
+        { tag: ['@page:/dashboard/admin/invites', '@uc:admin-invites-table'] },
+        async ({ page }) => {
+            await page.goto(PAGE_URL);
+            await waitForTableLoad(page, 'No invites found');
+
+            const row = inviteRow(page, EXPIRED_EMAIL);
+            // Scope to the status cell — the seeded email contains "expired",
+            // which a row-wide getByText would match too.
+            await expect(statusCell(row)).toHaveText('Expired');
+
+            // Expiry is derived, so the DB row is still pending — revoke is
+            // the only way to clear it and must stay available.
+            await expect(
+                row.getByRole('button', { name: 'Revoke invite' })
+            ).toBeVisible();
         }
     );
 
@@ -94,7 +123,7 @@ test.describe('admin invites', () => {
                 .click();
             await waitForTableLoad(page, 'No invites found');
 
-            const badges = page.locator('tbody td:nth-child(2)');
+            const badges = statusCells(page);
             const count = await badges.count();
             expect(count).toBeGreaterThan(0);
             for (let i = 0; i < count; i++) {
@@ -151,9 +180,7 @@ test.describe('admin invites', () => {
             ).toBeVisible();
 
             // The list invalidates on creation — the new invite appears.
-            await expect(
-                page.locator('tbody tr').filter({ hasText: CREATED_EMAIL })
-            ).toBeVisible();
+            await expect(inviteRow(page, CREATED_EMAIL)).toBeVisible();
         }
     );
 
@@ -164,9 +191,7 @@ test.describe('admin invites', () => {
             await page.goto(PAGE_URL);
             await waitForTableLoad(page, 'No invites found');
 
-            const row = page
-                .locator('tbody tr')
-                .filter({ hasText: REVOKE_EMAIL });
+            const row = inviteRow(page, REVOKE_EMAIL);
             await expect(row.getByText('Pending')).toBeVisible();
 
             await row.getByRole('button', { name: 'Revoke invite' }).click();

--- a/apps/web/e2e/admin/jobs.spec.ts
+++ b/apps/web/e2e/admin/jobs.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures';
 import type { Page } from '@playwright/test';
 import { USER_STATE_PATH } from '../helpers/auth';
-import { waitForTableLoad } from '../helpers/table';
+import { statusCells, waitForTableLoad } from '../helpers/table';
 import { waitForTrpcRequest } from '../helpers/trpc';
 import { countJobsByStatus, type Job } from '@nexus/db/test-db';
 import { seedJobs, cleanupJobs } from '../helpers/scenarios';
@@ -118,7 +118,7 @@ test.describe('dashboard with seeded data', () => {
                 .click();
             await waitForTableLoad(page, 'No jobs found');
 
-            const badges = page.locator('tbody td:nth-child(2)');
+            const badges = statusCells(page);
             const count = await badges.count();
             expect(count).toBeGreaterThan(0);
             for (let i = 0; i < count; i++) {

--- a/apps/web/e2e/helpers/table.ts
+++ b/apps/web/e2e/helpers/table.ts
@@ -11,6 +11,21 @@ export function fileName(page: Page, name: string): Locator {
     return page.getByText(name).filter({ visible: true }).first();
 }
 
+/* The admin data tables (invites, jobs) all put Status second. Kept in one
+   place so a column reorder breaks one selector, not assertions in three
+   specs. */
+const STATUS_COLUMN = 'td:nth-child(2)';
+
+/** The status cell of a single row (a `tr` locator). */
+export function statusCell(row: Locator): Locator {
+    return row.locator(STATUS_COLUMN);
+}
+
+/** Every status cell in the table — for asserting a filtered view. */
+export function statusCells(page: Page): Locator {
+    return page.locator(`tbody ${STATUS_COLUMN}`);
+}
+
 /**
  * Waits for a data-table page to finish loading: either the table itself or
  * the page's empty-state text, whichever renders first.

--- a/apps/web/lib/invites.test.ts
+++ b/apps/web/lib/invites.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { isInviteExpired } from './invites';
+
+const NOW = new Date('2026-08-12T12:00:00Z');
+const PAST = new Date('2026-08-11T12:00:00Z');
+const FUTURE = new Date('2026-08-13T12:00:00Z');
+
+describe('isInviteExpired', () => {
+    it('is true for a pending invite past its expiry', () => {
+        expect(
+            isInviteExpired({ status: 'pending', expiresAt: PAST }, NOW)
+        ).toBe(true);
+    });
+
+    it('is false for a pending invite that has not reached its expiry', () => {
+        expect(
+            isInviteExpired({ status: 'pending', expiresAt: FUTURE }, NOW)
+        ).toBe(false);
+    });
+
+    it('treats a null expiry as never expiring', () => {
+        expect(
+            isInviteExpired({ status: 'pending', expiresAt: null }, NOW)
+        ).toBe(false);
+    });
+
+    it('expires exactly at the boundary', () => {
+        expect(
+            isInviteExpired({ status: 'pending', expiresAt: NOW }, NOW)
+        ).toBe(true);
+    });
+
+    // Redeemed and revoked are terminal — an elapsed expiry must not relabel
+    // them, or the admin list would report a used invite as expired.
+    it('is false for non-pending invites regardless of expiry', () => {
+        expect(
+            isInviteExpired({ status: 'redeemed', expiresAt: PAST }, NOW)
+        ).toBe(false);
+        expect(
+            isInviteExpired({ status: 'revoked', expiresAt: PAST }, NOW)
+        ).toBe(false);
+    });
+});

--- a/apps/web/lib/invites.ts
+++ b/apps/web/lib/invites.ts
@@ -1,0 +1,22 @@
+import type { Invite } from '@nexus/db/repo/invites';
+
+/**
+ * Expiry is derived, never stored — an invite past its `expiresAt` keeps the
+ * `pending` DB status (there is no sweeper flipping it). Every surface that
+ * reports invite state has to apply this rule itself, so it lives here rather
+ * than being retyped: the redemption check, the trial-provisioning pre-check,
+ * and the admin list badge must all agree on when a link stops working.
+ *
+ * `null` means "never expires". The bound is inclusive: an invite is expired
+ * the instant it reaches `expiresAt`.
+ */
+export function isInviteExpired(
+    invite: Pick<Invite, 'status' | 'expiresAt'>,
+    now: Date = new Date()
+): boolean {
+    return (
+        invite.status === 'pending' &&
+        invite.expiresAt !== null &&
+        invite.expiresAt <= now
+    );
+}

--- a/apps/web/server/services/invites.ts
+++ b/apps/web/server/services/invites.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto';
 import type { DB } from '@nexus/db';
 import { createInviteRepo, type Invite } from '@nexus/db/repo/invites';
 import { env } from '@/lib/env';
+import { isInviteExpired } from '@/lib/invites';
 import { InvalidStateError, NotFoundError } from '@/server/errors';
 import { logger } from '@/server/lib/logger';
 import { emailService } from '@/server/services/email';
@@ -88,9 +89,7 @@ async function getInviteRedemption(
     const invite = await createInviteRepo(db).findByToken(token);
     if (!invite) return { status: 'invalid' };
     if (invite.status !== 'pending') return { status: invite.status };
-    if (invite.expiresAt && invite.expiresAt <= new Date()) {
-        return { status: 'expired' };
-    }
+    if (isInviteExpired(invite)) return { status: 'expired' };
     return { status: 'valid', email: invite.email };
 }
 

--- a/apps/web/server/services/subscriptions.ts
+++ b/apps/web/server/services/subscriptions.ts
@@ -8,6 +8,7 @@ import {
 } from '@nexus/db/repo/subscriptions';
 import { planTierEnum, subscriptionStatusEnum } from '@nexus/db/schema';
 import { env } from '@/lib/env';
+import { isInviteExpired } from '@/lib/invites';
 import { stripe, stripeClient } from '@/lib/stripe';
 import { NotFoundError, InvalidStateError } from '@/server/errors';
 import { logger } from '@/server/lib/logger';
@@ -286,7 +287,7 @@ async function tryProvisionSponsoredSubscription(
         );
         return false;
     }
-    if (invite.expiresAt && invite.expiresAt <= new Date()) {
+    if (isInviteExpired(invite)) {
         log.warn(
             {
                 userId: user.id,


### PR DESCRIPTION
## Summary

`InviteStatusBadge` switched only on the DB status, so an invite past its `expiresAt` still rendered "Pending" in the admin list — during the alpha that reads as "waiting on a tester" when the tester can never join. Expiry is now derived at render time, matching what the redemption flow already did server-side. No schema change: the DB status stays `pending`.

The rule itself moved into `apps/web/lib/invites.ts` as `isInviteExpired()`, because it was already hand-written in two services and this change would have made a third copy. The redemption check and the trial-provisioning pre-check now call it too, so the three surfaces cannot drift.

Closes #336

## Changes

- Add `isInviteExpired(invite, now?)` in `apps/web/lib/invites.ts` — `null` expiry means never, the bound is inclusive, and terminal statuses (`redeemed`/`revoked`) are never relabeled. Unit-tested.
- Derive `expired` in `InviteStatusBadge` and render it amber against Pending's blue; the four status branches collapse into an `INVITE_BADGES` record keyed on `InviteStatus | 'expired'`, following the `STATUS_BADGES` precedent in `subscriptionPlans.ts`.
- Replace the inline `expiresAt <= new Date()` checks in `server/services/invites.ts` and `server/services/subscriptions.ts` with the shared helper.
- Keep Revoke visible on expired rows: the DB row is still `pending`, `repo.revoke()` succeeds on it, and hiding the action would leave those rows with no way to clear them. Recorded in the `PendingInviteActions` docblock.
- E2E: seed a pending invite with a past `expiresAt` and assert it reads "Expired" and keeps its Revoke button. Extract an `inviteRow()` helper (five call sites) and `statusCell`/`statusCells` in `e2e/helpers/table.ts`, shared with `jobs.spec.ts`.

## Test Plan

- [ ] `pnpm check` — 10/10, including the new `lib/invites.test.ts` cases
- [ ] `pnpm -F web test:e2e:admin` — 21/21; the new case is `a pending invite past its expiry reads Expired and stays revocable`
- [ ] `pnpm -F web test:e2e:smoke` — 42/42
- [ ] `pnpm -F web e2e:coverage --check` — pages and use-cases still 100%
- [ ] Manually: create an invite with a 7-day expiry, backdate its `expiresAt` (`pnpm -F db db:studio`), reload `/dashboard/admin/invites` — the row reads Expired in amber and still offers Revoke; clicking it flips the badge to Revoked.

## Notes

The "Pending" status filter still returns rows that render "Expired", since the filter maps to DB status and there is no expired value to filter on. Consistent with the derived design and out of scope here, but worth a follow-up if the alpha list gets long enough to need it.

The mobile stacked-row badge gets `expiresAt` threaded through the same way, but only the desktop path is asserted — matching how the rest of this spec is written.