### PR TITLE
chore: alarm on every DLQ and add an account budget (#334)

### DIFF
--- a/apps/web/app/api/webhooks/cloudwatch-alarm/route.ts
+++ b/apps/web/app/api/webhooks/cloudwatch-alarm/route.ts
@@ -28,8 +28,8 @@ interface CloudWatchAlarmMessage {
 }
 
 const SEVERITY_BY_STATE: Record<string, AlertSeverity> = {
-    // The only alarm today is jobs-DLQ depth: parked jobs mean the thumbnail
-    // pipeline is losing its Standard-tier window — page loudly.
+    // Alarms reach this topic only for unattended failures nothing else
+    // catches (alarms.tf), so any ALARM state pages loudly.
     ALARM: 'critical',
     OK: 'info',
     INSUFFICIENT_DATA: 'warning',

--- a/docs/guides/background-jobs.md
+++ b/docs/guides/background-jobs.md
@@ -28,7 +28,7 @@ One set per environment, in `us-east-1`, account `391615358272`, suffixed `-dev`
 | Resource              | Name pattern                                                                                |
 | --------------------- | ------------------------------------------------------------------------------------------- |
 | SQS Queue             | `nexus-jobs-<env>` (visibility timeout 720s, 3 retries → DLQ)                               |
-| SQS Dead Letter Queue | `nexus-jobs-dlq-<env>` (depth > 0 alarms → Discord, `alarms.tf`)                            |
+| SQS Dead Letter Queue | `nexus-jobs-dlq-<env>` (depth > 0 alarms → Discord, plus email in prod, `alarms.tf`)        |
 | Lambda Function       | `nexus-worker-<env>` (Node 22, 120s timeout, 1 GB, batch size 1, ffmpeg + exiftool layers)  |
 | Lambda Layers         | `nexus-ffmpeg-<env>`, `nexus-exiftool-<env>` (`layers.tf`; built by `lambda-layers.yml` CI) |
 | IAM Role (Lambda)     | `nexus-worker-role-<env>` (SQS consume, S3 CRUD, derived-bucket Put/Get, CloudWatch Logs)   |

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,11 +1,17 @@
 # Nexus Terraform
 
 Provisions one full Nexus AWS environment (S3 files bucket, SNS restore-events
-topic + webhook subscription, SQS jobs queues, worker Lambda, app IAM user),
-parameterized by `environment` and `region`. **Both environments are managed
-here and this is the source of truth**: prod since #53, dev since #127 (the
-hand-built dev resources were decommissioned and recreated from these files,
-which closed the main drift vector between environments).
+topic + webhook subscription, SQS jobs queues, worker Lambda, app IAM user,
+ops-alerts topic + DLQ-depth alarms), parameterized by `environment` and
+`region`. **Both environments are managed here and this is the source of
+truth**: prod since #53, dev since #127 (the hand-built dev resources were
+decommissioned and recreated from these files, which closed the main drift
+vector between environments).
+
+Two resources carry a `count` guard so they exist in the prod workspace only:
+the monthly cost budget (`budgets.tf`), which is account-global and would
+otherwise be fought over by both workspaces, and the alerts email subscription
+(`alarms.tf`), which dev deliberately skips.
 
 State lives in S3 (`nexus-terraform-state-391615358272`, us-east-1) with one
 workspace per environment. A guard resource fails the plan if the selected
@@ -96,6 +102,25 @@ production code.
     | `AWS_REGION`                                  | `aws_region` output        |
     | `SQS_QUEUE_URL`                               | `sqs_queue_url` output     |
     | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | access key from step 1     |
+
+5. **Confirm the alerts email** (prod only) — the apply creates an email
+   subscription on `nexus-ops-alerts-prod` and reports success, but AWS leaves
+   it in `PendingConfirmation` until someone clicks the link in the "AWS
+   Notification - Subscription Confirmation" mail sent to `alert_email`. Until
+   then, alarms reach Discord only. Terraform does not diff on confirmation
+   status, so nothing later will remind you. Verify:
+
+    ```bash
+    aws sns list-subscriptions-by-topic --region us-east-1 \
+        --topic-arn arn:aws:sns:us-east-1:391615358272:nexus-ops-alerts-prod \
+        --query 'Subscriptions[?Protocol==`email`].SubscriptionArn'
+    ```
+
+    A confirmed subscription returns a real ARN; an unconfirmed one returns the
+    literal `"PendingConfirmation"`.
+
+    Budget notifications (`budgets.tf`) go to the same address directly, not
+    through SNS, so they need no confirmation step.
 
 ## Destroy
 

--- a/infra/terraform/alarms.tf
+++ b/infra/terraform/alarms.tf
@@ -40,14 +40,62 @@ resource "aws_sns_topic_subscription" "ops_alerts_webhook" {
   })
 }
 
-# Primary defense for the thumbnail pipeline (#350): a job that exhausts its
-# 3 SQS attempts parks in the jobs DLQ, and a redrive within ~24h still beats
-# the originals' Deep Archive transition. Depth > 0 means systemic breakage
-# (worker down, bad deploy) — page Discord immediately. ok_actions fires the
-# recovery notice once the DLQ is drained.
-resource "aws_cloudwatch_metric_alarm" "jobs_dlq_depth" {
-  alarm_name          = "nexus-jobs-dlq-depth-${var.environment}"
-  alarm_description   = "Background-jobs DLQ has parked messages; redrive within 24h to beat the Deep Archive transition (#350)"
+# Out-of-band path: the HTTPS subscription above cannot notify when the app
+# itself is what broke, which is exactly what the restore-DLQ alarm below
+# exists to catch. Dev stays Discord-only — its DLQs are the noisy ones (#263).
+# Terraform reports success while the subscription sits in "pending
+# confirmation"; the click is manual (README "After apply").
+resource "aws_sns_topic_subscription" "ops_alerts_email" {
+  count = var.environment == "prod" ? 1 : 0
+
+  topic_arn = aws_sns_topic.ops_alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# Every DLQ in the stack, alarmed on depth > 0. A parked message always means a
+# silent failure — nothing retries out of a DLQ on its own — so the threshold is
+# the floor rather than a tuned number, and ok_actions fires the recovery notice
+# once the queue drains.
+locals {
+  dlq_alarms = {
+    # Primary defense for the thumbnail pipeline (#350): a job that exhausts its
+    # 3 SQS attempts parks here, and a redrive within ~24h still beats the
+    # originals' Deep Archive transition. Depth > 0 means systemic breakage
+    # (worker down, bad deploy).
+    jobs = {
+      queue_name  = aws_sqs_queue.jobs_dlq.name
+      description = "Background-jobs DLQ has parked messages; redrive within 24h to beat the Deep Archive transition (#350)"
+    }
+
+    # The only detector for a dead restore-webhook rail. The route returns 200
+    # on its own bugs, so this DLQ fills only on true delivery failure (app
+    # down, TLS/DNS) — and in that case no webhook_events row is written
+    # either, so the nightly DB check stays green while restores silently stop
+    # completing.
+    s3-restore-events = {
+      queue_name  = aws_sqs_queue.s3_restore_events_dlq.name
+      description = "S3 restore-events webhook deliveries are failing outright; check that the app is serving /api/webhooks/s3-restore"
+    }
+
+    # Watches the alerting rail itself: if the Discord webhook endpoint is
+    # unreachable, the alarms above park here and nothing else notices. In prod
+    # the email subscription still delivers when the HTTPS endpoint is the
+    # broken part. In dev it is genuinely circular — the notification goes to a
+    # topic whose only subscriber is the dead endpoint — so the dev alarm is
+    # console-only, kept for parity rather than paging value.
+    ops-alerts = {
+      queue_name  = aws_sqs_queue.ops_alerts_dlq.name
+      description = "Alarm notifications are failing to reach Discord; check that the app is serving /api/webhooks/cloudwatch-alarm"
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "dlq_depth" {
+  for_each = local.dlq_alarms
+
+  alarm_name          = "nexus-${each.key}-dlq-depth-${var.environment}"
+  alarm_description   = each.value.description
   namespace           = "AWS/SQS"
   metric_name         = "ApproximateNumberOfMessagesVisible"
   statistic           = "Maximum"
@@ -58,9 +106,17 @@ resource "aws_cloudwatch_metric_alarm" "jobs_dlq_depth" {
   treat_missing_data  = "notBreaching"
 
   dimensions = {
-    QueueName = aws_sqs_queue.jobs_dlq.name
+    QueueName = each.value.queue_name
   }
 
   alarm_actions = [aws_sns_topic.ops_alerts.arn]
   ok_actions    = [aws_sns_topic.ops_alerts.arn]
+}
+
+# The jobs alarm shipped standalone in #350 and is already applied in both
+# workspaces. Re-keying it into the for_each above is a rename, not a
+# replacement — the alarm_name is unchanged.
+moved {
+  from = aws_cloudwatch_metric_alarm.jobs_dlq_depth
+  to   = aws_cloudwatch_metric_alarm.dlq_depth["jobs"]
 }

--- a/infra/terraform/budgets.tf
+++ b/infra/terraform/budgets.tf
@@ -1,0 +1,40 @@
+# Account-wide cost tripwire. Expedited Glacier restores are user-selectable
+# and uncapped beyond fileIds.max(100) per call (lib/storage/glacier.ts), so a
+# runaway retrieval is otherwise invisible until the bill arrives.
+#
+# Budgets are account-global, not regional or per-environment: created from the
+# prod workspace only, or the two workspaces would fight over one resource.
+#
+# Notifies var.alert_email directly rather than through aws_sns_topic.ops_alerts:
+# Budgets needs an explicit topic policy allowing budgets.amazonaws.com to
+# publish, and attaching aws_sns_topic_policy replaces the implicit default that
+# currently lets CloudWatch alarms publish — a silent way to break every alarm
+# in alarms.tf.
+resource "aws_budgets_budget" "monthly_cost" {
+  count = var.environment == "prod" ? 1 : 0
+
+  name              = "nexus-monthly-cost"
+  budget_type       = "COST"
+  limit_amount      = var.monthly_budget_usd
+  limit_unit        = "USD"
+  time_unit         = "MONTHLY"
+  time_period_start = "2026-08-01_00:00"
+
+  # Actual at 80% is the "something changed" nudge; forecast at 100% is the one
+  # that fires early enough in the month to still act on.
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.alert_email]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = [var.alert_email]
+  }
+}

--- a/infra/terraform/environments/dev.tfvars
+++ b/infra/terraform/environments/dev.tfvars
@@ -12,6 +12,9 @@ environment = "dev"
 region      = "us-east-1"
 app_domain  = "dev.nexus.thomasar.dev"
 
+# Inert here — dev alarms notify Discord only (see alarms.tf) — but required.
+alert_email = "thomasalmeidar@gmail.com"
+
 # The dev-branch deployment also carries a branch-scoped NEXT_PUBLIC_APP_URL
 # (Vercel Preview tier, git branch "dev") pointing at this same domain, so links
 # in dev-triggered emails (e.g. restore-completed) don't say localhost like

--- a/infra/terraform/environments/prod.tfvars
+++ b/infra/terraform/environments/prod.tfvars
@@ -7,6 +7,7 @@ environment          = "prod"
 region               = "us-east-1"
 app_domain           = "nexus.thomasar.dev"
 cors_allowed_origins = ["https://nexus.thomasar.dev"]
+alert_email          = "thomasalmeidar@gmail.com"
 
 # database_url is intentionally absent: pass via TF_VAR_database_url (the prod
 # Supabase transaction-pooler URL, port 6543). Never commit it.

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -23,6 +23,17 @@ variable "cors_allowed_origins" {
   type        = list(string)
 }
 
+variable "alert_email" {
+  description = "Ops contact for AWS-originated alerts (alarms.tf, budgets.tf); prod-only — see README 'After apply'."
+  type        = string
+}
+
+variable "monthly_budget_usd" {
+  description = "Monthly cap for the account-wide AWS budget (budgets.tf). Defaulted rather than set per environment because the budget is account-global. $20 is a tripwire above expected alpha spend, not a forecast — bump it if ordinary growth starts tripping it."
+  type        = number
+  default     = 20
+}
+
 variable "database_url" {
   description = "Supabase transaction-pooler URL (port 6543) injected into the worker Lambda. Pass via TF_VAR_database_url; never commit. Note: persisted in Terraform state."
   type        = string


### PR DESCRIPTION
## Summary

Closes the AWS→human notification gaps in #334. Note the issue body predates `alarms.tf`, which shipped in #352 (commit e931400) with the ops-alerts SNS topic, its Discord HTTPS subscription, and the jobs-DLQ alarm — so "Terraform has zero alarms and no notification path" is no longer true. What was actually missing: the other DLQs had no alarms, there was no path that survives the app being down, and there was no budget.

Three DLQs are now alarmed on `ApproximateNumberOfMessagesVisible > 0` in both envs, prod gets an email subscription alongside the Discord rail, and an account-global budget trips at $20/month.

Two decisions worth flagging:

- **The budget notifies email directly, not via SNS.** Routing it through `ops_alerts` needs an explicit topic policy for `budgets.amazonaws.com`, and attaching `aws_sns_topic_policy` replaces the implicit default policy that currently lets CloudWatch publish — a quiet way to break every alarm in the file.
- **The ops-alerts DLQ is alarmed too**, though the issue never saw that queue (it was created by the same PR that created the rail). If the Discord endpoint dies, alarms park there and nothing else notices. In prod the email subscription still delivers; in dev it is genuinely circular and the alarm is console-only, which the comment says outright.

Closes #334

## Changes

- `alarms.tf` — collapsed the jobs alarm and two new ones (`s3-restore-events`, `ops-alerts`) into a single `for_each` resource over `local.dlq_alarms`, with a `moved` block re-keying the already-applied jobs alarm. Alarm names are byte-identical to before, so this is a rename, not a replacement.
- `alarms.tf` — prod-only email subscription on `nexus-ops-alerts-prod`. Dev stays Discord-only; its DLQs are the noisy ones (#263).
- `budgets.tf` (new) — `nexus-monthly-cost`, account-global, `count`-guarded to the prod workspace. Actual ≥ 80% and forecasted ≥ 100% both notify `alert_email`.
- `variables.tf` — `alert_email` (set in both tfvars) and `monthly_budget_usd` (defaulted to 20; the budget is account-global, so there is nothing per-env to set).
- `README.md` — intro names the alarms and the two prod-only guarded resources; new "After apply" step 5 covers the email confirmation click and how to verify it.
- `route.ts`, `background-jobs.md` — comment and doc line that claimed jobs-DLQ was the only alarm.

## Test Plan

Nothing in CI touches `infra/**`, so the Terraform side is manual.

- [x] `terraform fmt -recursive` clean, `terraform validate` passes
- [x] `pnpm check` green (10/10)
- [ ] `terraform plan -var-file=environments/dev.tfvars` in the dev workspace shows: 1 moved (jobs alarm), 2 created (restore + ops-alerts alarms), 0 destroyed, no budget, no email subscription
- [ ] Apply dev, then repeat for prod — the prod plan should additionally show the budget and the email subscription
- [ ] Click the "AWS Notification - Subscription Confirmation" mail, then confirm the subscription ARN is no longer `PendingConfirmation` (command in README step 5)
- [ ] Sanity-check the alarms exist: `aws cloudwatch describe-alarms --alarm-name-prefix nexus- --region us-east-1 --query 'MetricAlarms[].AlarmName'`