### PR TITLE
feat: forgot-password reset flow (#335)

### DIFF
--- a/apps/web/app/(auth)/forgot-password/page.tsx
+++ b/apps/web/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { AuthPageShell } from '@/components/auth/auth-page-shell';
+import { ForgotPasswordForm } from '@/components/auth/forgot-password-form';
+
+export default function ForgotPasswordPage() {
+    return (
+        <AuthPageShell
+            title="Forgot your password?"
+            subtitle="Enter your email and we'll send a link to choose a new one"
+            footer={
+                <>
+                    Remembered it?{' '}
+                    <Link
+                        href="/sign-in"
+                        className="font-medium text-primary hover:underline"
+                    >
+                        Sign in
+                    </Link>
+                </>
+            }
+        >
+            <ForgotPasswordForm />
+        </AuthPageShell>
+    );
+}

--- a/apps/web/app/(auth)/invite/[token]/page.tsx
+++ b/apps/web/app/(auth)/invite/[token]/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import { Sparkles, MailQuestion } from 'lucide-react';
 import { cn } from '@/lib/cn';
+import { AuthNotice } from '@/components/auth/auth-notice';
+import { AuthPageShell } from '@/components/auth/auth-page-shell';
 import { SignUpForm } from '@/components/auth/sign-up-form';
 import { db } from '@/server/db';
 import {
@@ -25,25 +27,22 @@ export default async function InvitePage({ params }: InvitePageProps) {
     }
 
     return (
-        <div className="mx-auto w-full max-w-md">
-            <div className="mb-8 text-center">
+        <AuthPageShell
+            badge={
                 <span className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium tracking-wide text-primary uppercase">
                     <Sparkles className="size-3.5" />
                     Sponsored access
                 </span>
-                <h1 className="mb-2 text-2xl font-bold">
-                    You&apos;re invited to Nexus
-                </h1>
-                <p className="text-muted-foreground">
-                    Create your account and start archiving — storage is on us.
-                </p>
-            </div>
+            }
+            title="You're invited to Nexus"
+            subtitle="Create your account and start archiving — storage is on us."
+            footer={<SignInPrompt />}
+        >
             <SignUpForm
                 inviteToken={token}
                 lockedEmail={redemption.email ?? undefined}
             />
-            <SignInPrompt className="mt-6" />
-        </div>
+        </AuthPageShell>
     );
 }
 
@@ -76,14 +75,13 @@ function InviteUnavailable({
 }) {
     const copy = UNAVAILABLE_COPY[status];
     return (
-        <div className="mx-auto w-full max-w-md text-center">
-            <div className="mb-6 inline-flex size-12 items-center justify-center rounded-full bg-muted">
-                <MailQuestion className="size-6 text-muted-foreground" />
-            </div>
-            <h1 className="mb-2 text-2xl font-bold">{copy.title}</h1>
-            <p className="mb-8 text-muted-foreground">{copy.body}</p>
+        <AuthNotice
+            icon={<MailQuestion className="size-6 text-muted-foreground" />}
+            title={copy.title}
+            body={copy.body}
+        >
             <SignInPrompt />
-        </div>
+        </AuthNotice>
     );
 }
 

--- a/apps/web/app/(auth)/reset-password/page.tsx
+++ b/apps/web/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { KeyRound } from 'lucide-react';
+import { AuthNotice } from '@/components/auth/auth-notice';
+import { AuthPageShell } from '@/components/auth/auth-page-shell';
+import { ResetPasswordForm } from '@/components/auth/reset-password-form';
+import { RESET_PASSWORD_TOKEN_TTL_LABEL } from '@/lib/auth/constants';
+
+interface ResetPasswordPageProps {
+    searchParams: Promise<{ token?: string }>;
+}
+
+export default async function ResetPasswordPage({
+    searchParams,
+}: ResetPasswordPageProps) {
+    const { token } = await searchParams;
+
+    // A truncated or hand-typed link never reaches the API — say so here
+    // instead of rendering a form that can only fail.
+    if (!token) {
+        return (
+            <AuthNotice
+                icon={<KeyRound className="size-6 text-muted-foreground" />}
+                title="This reset link isn't usable"
+                body={`Check that the link matches the one you were emailed — it may have been truncated. Reset links also expire ${RESET_PASSWORD_TOKEN_TTL_LABEL} after they are sent.`}
+            >
+                <Link
+                    href="/forgot-password"
+                    className="font-medium text-primary hover:underline"
+                >
+                    Request a new link
+                </Link>
+            </AuthNotice>
+        );
+    }
+
+    return (
+        <AuthPageShell
+            title="Choose a new password"
+            subtitle="You'll use it the next time you sign in"
+        >
+            <ResetPasswordForm token={token} />
+        </AuthPageShell>
+    );
+}

--- a/apps/web/app/(auth)/sign-in/page.tsx
+++ b/apps/web/app/(auth)/sign-in/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { AuthPageShell } from '@/components/auth/auth-page-shell';
 import { SignInForm } from '@/components/auth/sign-in-form';
 import {
     DEFAULT_REDIRECT,
@@ -19,23 +20,22 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
             : `/sign-up?redirect=${encodeURIComponent(redirectTo)}`;
 
     return (
-        <div className="mx-auto w-full max-w-md">
-            <div className="mb-8 text-center">
-                <h1 className="mb-2 text-2xl font-bold">Welcome back</h1>
-                <p className="text-muted-foreground">
-                    Sign in to access your files
-                </p>
-            </div>
+        <AuthPageShell
+            title="Welcome back"
+            subtitle="Sign in to access your files"
+            footer={
+                <>
+                    Don&apos;t have an account?{' '}
+                    <Link
+                        href={signUpHref}
+                        className="font-medium text-primary hover:underline"
+                    >
+                        Sign up
+                    </Link>
+                </>
+            }
+        >
             <SignInForm redirectTo={redirectTo} />
-            <p className="mt-6 text-center text-sm text-muted-foreground">
-                Don&apos;t have an account?{' '}
-                <Link
-                    href={signUpHref}
-                    className="font-medium text-primary hover:underline"
-                >
-                    Sign up
-                </Link>
-            </p>
-        </div>
+        </AuthPageShell>
     );
 }

--- a/apps/web/app/(auth)/sign-up/page.tsx
+++ b/apps/web/app/(auth)/sign-up/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { Shield, DollarSign, Archive } from 'lucide-react';
+import { AuthPageShell } from '@/components/auth/auth-page-shell';
 import { SignUpForm } from '@/components/auth/sign-up-form';
 import {
     DEFAULT_REDIRECT,
@@ -20,37 +21,38 @@ export default async function SignUpPage({ searchParams }: SignUpPageProps) {
             : `/sign-in?redirect=${encodeURIComponent(redirectTo)}`;
 
     return (
-        <div className="mx-auto w-full max-w-md">
-            <div className="mb-8 text-center">
-                <h1 className="mb-2 text-2xl font-bold">Create your account</h1>
-                <p className="text-muted-foreground">
-                    Start storing your files securely for less
-                </p>
-            </div>
+        <AuthPageShell
+            title="Create your account"
+            subtitle="Start storing your files securely for less"
+            footer={
+                <>
+                    <p>
+                        Already have an account?{' '}
+                        <Link
+                            href={signInHref}
+                            className="font-medium text-primary hover:underline"
+                        >
+                            Sign in
+                        </Link>
+                    </p>
+                    <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-xs">
+                        <div className="flex items-center gap-1.5">
+                            <DollarSign className="size-3.5 text-primary" />
+                            <span>5 GB free</span>
+                        </div>
+                        <div className="flex items-center gap-1.5">
+                            <Shield className="size-3.5 text-primary" />
+                            <span>Encrypted</span>
+                        </div>
+                        <div className="flex items-center gap-1.5">
+                            <Archive className="size-3.5 text-primary" />
+                            <span>No credit card</span>
+                        </div>
+                    </div>
+                </>
+            }
+        >
             <SignUpForm redirectTo={redirectTo} />
-            <p className="mt-6 text-center text-sm text-muted-foreground">
-                Already have an account?{' '}
-                <Link
-                    href={signInHref}
-                    className="font-medium text-primary hover:underline"
-                >
-                    Sign in
-                </Link>
-            </p>
-            <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-xs text-muted-foreground">
-                <div className="flex items-center gap-1.5">
-                    <DollarSign className="size-3.5 text-primary" />
-                    <span>5 GB free</span>
-                </div>
-                <div className="flex items-center gap-1.5">
-                    <Shield className="size-3.5 text-primary" />
-                    <span>Encrypted</span>
-                </div>
-                <div className="flex items-center gap-1.5">
-                    <Archive className="size-3.5 text-primary" />
-                    <span>No credit card</span>
-                </div>
-            </div>
-        </div>
+        </AuthPageShell>
     );
 }

--- a/apps/web/app/api/webhooks/s3-restore/route.ts
+++ b/apps/web/app/api/webhooks/s3-restore/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { createWebhookRepo } from '@nexus/db/repo/webhooks';
 import { alerts } from '@/lib/alerts';
 import { isLocalDevelopment } from '@/lib/env/runtime';
+import { toErrorMessage } from '@/lib/errors';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { verifySnsMessage } from '@/lib/sns/webhooks';
@@ -151,8 +152,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             'Webhook processing failed'
         );
 
-        const errorMessage =
-            error instanceof Error ? error.message : String(error);
+        const errorMessage = toErrorMessage(error);
         await webhookRepo.update(webhookEvent.id, {
             status: 'failed',
             error: errorMessage,

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -3,6 +3,7 @@ import type Stripe from 'stripe';
 import { createWebhookRepo, type WebhookEvent } from '@nexus/db/repo/webhooks';
 import { alerts } from '@/lib/alerts';
 import { isLocalDevelopment } from '@/lib/env/runtime';
+import { toErrorMessage } from '@/lib/errors';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { stripe } from '@/lib/stripe';
@@ -156,8 +157,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             'Webhook processing failed'
         );
 
-        const errorMessage =
-            error instanceof Error ? error.message : String(error);
+        const errorMessage = toErrorMessage(error);
         await webhookRepo.update(webhookEvent.id, {
             status: 'failed',
             error: errorMessage,

--- a/apps/web/components/auth/auth-notice.tsx
+++ b/apps/web/components/auth/auth-notice.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+
+interface AuthNoticeProps {
+    /** Lucide icon element, rendered inside the muted bubble. */
+    icon: ReactNode;
+    title: string;
+    body: string;
+    /** Optional way forward — a sign-in prompt, a link to start over. */
+    children?: ReactNode;
+}
+
+/**
+ * Dead-end state for a link that can't be used: a bad invite, a reset link with
+ * no token. Explains what happened and offers the next step, instead of
+ * rendering a form that could only fail.
+ */
+export function AuthNotice({ icon, title, body, children }: AuthNoticeProps) {
+    return (
+        <div className="mx-auto w-full min-w-0 max-w-md text-center">
+            <div className="mb-6 inline-flex size-12 items-center justify-center rounded-full bg-muted">
+                {icon}
+            </div>
+            <h1 className="mb-2 text-2xl font-bold">{title}</h1>
+            <p className="mb-8 text-muted-foreground">{body}</p>
+            {children}
+        </div>
+    );
+}

--- a/apps/web/components/auth/auth-page-shell.tsx
+++ b/apps/web/components/auth/auth-page-shell.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+
+interface AuthPageShellProps {
+    title: string;
+    subtitle?: ReactNode;
+    /** Sits above the title — e.g. the invite page's "Sponsored access" pill. */
+    badge?: ReactNode;
+    /**
+     * Sits below the form in muted centered text — e.g. "Already have an
+     * account? Sign in". Pass only the content; the shell owns the spacing.
+     */
+    footer?: ReactNode;
+    children: ReactNode;
+}
+
+/**
+ * The frame every `(auth)` page shares: centered column, heading block, form,
+ * footer prompt. `min-w-0` matters — the column is a flex child of the auth
+ * layout, so without it a long unbreakable string (an echoed email address)
+ * would widen the page past a phone viewport instead of wrapping (#311).
+ */
+export function AuthPageShell({
+    title,
+    subtitle,
+    badge,
+    footer,
+    children,
+}: AuthPageShellProps) {
+    return (
+        <div className="mx-auto w-full min-w-0 max-w-md">
+            <div className="mb-8 text-center">
+                {badge}
+                <h1 className="mb-2 text-2xl font-bold">{title}</h1>
+                {subtitle && (
+                    <p className="text-muted-foreground">{subtitle}</p>
+                )}
+            </div>
+            {children}
+            {footer && (
+                <div className="mt-6 text-center text-sm text-muted-foreground">
+                    {footer}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/web/components/auth/forgot-password-form.tsx
+++ b/apps/web/components/auth/forgot-password-form.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import type React from 'react';
+
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { FormError, FormStatus } from '@/components/auth/form-feedback';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { requestPasswordReset } from '@/lib/auth/client';
+import { RESET_PASSWORD_TOKEN_TTL_LABEL } from '@/lib/auth/constants';
+
+export function ForgotPasswordForm() {
+    const [isLoading, setIsLoading] = useState(false);
+    const [email, setEmail] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [isRequested, setIsRequested] = useState(false);
+
+    async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        setError(null);
+        setIsLoading(true);
+
+        const result = await requestPasswordReset({ email });
+
+        setIsLoading(false);
+
+        if (result.error) {
+            setError(
+                result.error.message ??
+                    'Could not send the reset link. Try again in a moment.'
+            );
+            return;
+        }
+
+        setIsRequested(true);
+    }
+
+    // Deliberately says nothing about whether the address has an account —
+    // the endpoint answers identically either way, and so does this.
+    if (isRequested) {
+        return (
+            <FormStatus>
+                If an account exists for{' '}
+                <span className="font-medium wrap-anywhere text-foreground">
+                    {email}
+                </span>
+                , a reset link is on its way. The link expires in{' '}
+                {RESET_PASSWORD_TOKEN_TTL_LABEL}.
+            </FormStatus>
+        );
+    }
+
+    return (
+        <form onSubmit={onSubmit} className="space-y-4">
+            {error && <FormError>{error}</FormError>}
+            <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                    id="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    required
+                    disabled={isLoading}
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                />
+            </div>
+            <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Send reset link
+            </Button>
+        </form>
+    );
+}

--- a/apps/web/components/auth/form-feedback.tsx
+++ b/apps/web/components/auth/form-feedback.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react';
+
+interface FormFeedbackProps {
+    children: ReactNode;
+}
+
+/**
+ * Inline submission failure. `role="alert"` interrupts a screen reader, which
+ * is what a rejected submit warrants — e2e locators filter on the text because
+ * a production build also renders Next's empty route-announcer alert.
+ */
+export function FormError({ children }: FormFeedbackProps) {
+    return (
+        <div
+            role="alert"
+            className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+        >
+            {children}
+        </div>
+    );
+}
+
+/**
+ * The quieter counterpart: a submit that succeeded and left the user on the
+ * page. `role="status"` announces it without interrupting.
+ */
+export function FormStatus({ children }: FormFeedbackProps) {
+    return (
+        <div
+            role="status"
+            className="rounded-md bg-muted p-4 text-sm text-muted-foreground"
+        >
+            {children}
+        </div>
+    );
+}

--- a/apps/web/components/auth/reset-password-form.tsx
+++ b/apps/web/components/auth/reset-password-form.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import type React from 'react';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Loader2 } from 'lucide-react';
+import { FormError, FormStatus } from '@/components/auth/form-feedback';
+import { Button, buttonVariants } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { resetPassword, signOut } from '@/lib/auth/client';
+import { MIN_PASSWORD_LENGTH } from '@/lib/auth/constants';
+import { cn } from '@/lib/cn';
+
+interface ResetPasswordFormProps {
+    /** Token from the emailed link — validity is only known once submitted. */
+    token: string;
+}
+
+export function ResetPasswordForm({ token }: ResetPasswordFormProps) {
+    const [isLoading, setIsLoading] = useState(false);
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [isReset, setIsReset] = useState(false);
+
+    async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        setError(null);
+        setIsLoading(true);
+
+        const result = await resetPassword({ newPassword: password, token });
+
+        // The reset revoked every session server-side, but this browser may
+        // still hold the cookie of one — enough to fool the optimistic proxy
+        // guard into bouncing the user off /sign-in and into a dead dashboard.
+        // /sign-out clears the cookie whether or not a session backed it.
+        if (!result.error) {
+            await signOut();
+        }
+
+        setIsLoading(false);
+
+        if (result.error) {
+            // Covers the expired/already-used/tampered token cases, which
+            // better-auth returns as a 400 rather than anything that throws.
+            setError(
+                result.error.message ??
+                    'This reset link is no longer valid. Request a new one.'
+            );
+            return;
+        }
+
+        setIsReset(true);
+    }
+
+    if (isReset) {
+        return (
+            <div className="space-y-4">
+                <FormStatus>
+                    Your password has been changed. Any other devices signed
+                    into Nexus have been signed out.
+                </FormStatus>
+                <Link
+                    href="/sign-in"
+                    className={cn(buttonVariants(), 'w-full')}
+                >
+                    Sign in
+                </Link>
+            </div>
+        );
+    }
+
+    return (
+        <form onSubmit={onSubmit} className="space-y-4">
+            {error && (
+                <FormError>
+                    {error}{' '}
+                    <Link href="/forgot-password" className="underline">
+                        Request a new link
+                    </Link>
+                </FormError>
+            )}
+            <div className="space-y-2">
+                <Label htmlFor="password">New password</Label>
+                <Input
+                    id="password"
+                    type="password"
+                    placeholder={`At least ${MIN_PASSWORD_LENGTH} characters`}
+                    required
+                    minLength={MIN_PASSWORD_LENGTH}
+                    disabled={isLoading}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+            </div>
+            <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Set new password
+            </Button>
+        </form>
+    );
+}

--- a/apps/web/components/auth/sign-in-form.tsx
+++ b/apps/web/components/auth/sign-in-form.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { GoogleIcon } from '@/components/icons/google-icon';
+import { FormError } from '@/components/auth/form-feedback';
 import { OAuthDivider } from '@/components/auth/oauth-divider';
 import { signIn } from '@/lib/auth/client';
 import { DEFAULT_REDIRECT } from '@/lib/auth/sanitizeRedirect';
@@ -74,14 +75,7 @@ export function SignInForm({ redirectTo = DEFAULT_REDIRECT }: SignInFormProps) {
             <OAuthDivider />
 
             <form onSubmit={onSubmit} className="space-y-4">
-                {error && (
-                    <div
-                        role="alert"
-                        className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                    >
-                        {error}
-                    </div>
-                )}
+                {error && <FormError>{error}</FormError>}
                 <div className="space-y-2">
                     <Label htmlFor="email">Email</Label>
                     <Input
@@ -98,7 +92,7 @@ export function SignInForm({ redirectTo = DEFAULT_REDIRECT }: SignInFormProps) {
                     <div className="flex items-center justify-between">
                         <Label htmlFor="password">Password</Label>
                         <Link
-                            href="#"
+                            href="/forgot-password"
                             className="text-xs text-muted-foreground hover:text-primary"
                         >
                             Forgot password?

--- a/apps/web/components/auth/sign-up-form.tsx
+++ b/apps/web/components/auth/sign-up-form.tsx
@@ -11,8 +11,10 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { GoogleIcon } from '@/components/icons/google-icon';
+import { FormError } from '@/components/auth/form-feedback';
 import { OAuthDivider } from '@/components/auth/oauth-divider';
 import { signUp } from '@/lib/auth/client';
+import { MIN_PASSWORD_LENGTH } from '@/lib/auth/constants';
 import { DEFAULT_REDIRECT } from '@/lib/auth/sanitizeRedirect';
 import { captureEvent } from '@/lib/posthog/client';
 import { PostHogEvent } from '@/lib/posthog/events';
@@ -112,14 +114,7 @@ export function SignUpForm({
             )}
 
             <form onSubmit={onSubmit} className="space-y-4">
-                {error && (
-                    <div
-                        role="alert"
-                        className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
-                    >
-                        {error}
-                    </div>
-                )}
+                {error && <FormError>{error}</FormError>}
                 <div className="space-y-2">
                     <Label htmlFor="name">Name</Label>
                     <Input
@@ -161,8 +156,9 @@ export function SignUpForm({
                     <Input
                         id="password"
                         type="password"
-                        placeholder="Create a password"
+                        placeholder={`At least ${MIN_PASSWORD_LENGTH} characters`}
                         required
+                        minLength={MIN_PASSWORD_LENGTH}
                         disabled={isLoading}
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -62,6 +62,8 @@ export const PAGES: PageEntry[] = [
     { route: '/', title: 'Landing', auth: 'public' },
     { route: '/sign-in', title: 'Sign in', auth: 'public' },
     { route: '/sign-up', title: 'Sign up', auth: 'public' },
+    { route: '/forgot-password', title: 'Forgot password', auth: 'public' },
+    { route: '/reset-password', title: 'Reset password', auth: 'public' },
     { route: '/invite/[token]', title: 'Invite redemption', auth: 'public' },
     { route: '/dashboard', title: 'Dashboard overview', auth: 'user' },
     { route: '/dashboard/files', title: 'Files', auth: 'user' },
@@ -117,6 +119,32 @@ export const USE_CASES: UseCaseEntry[] = [
         title: 'Sign out from the user menu',
         area: 'auth',
         routes: ['/dashboard'],
+    },
+    {
+        id: 'password-reset-request',
+        title: 'Requesting a reset returns the same confirmation whether or not the account exists',
+        area: 'auth',
+        routes: ['/forgot-password'],
+    },
+    {
+        id: 'password-reset-complete',
+        title: 'A valid reset token sets a new password and the old sessions die',
+        area: 'auth',
+        routes: ['/reset-password'],
+    },
+    {
+        id: 'password-reset-invalid-token',
+        title: 'An invalid or missing reset token shows a clear error, not a crash',
+        area: 'auth',
+        routes: ['/reset-password'],
+    },
+    {
+        id: 'password-reset-email-delivery',
+        title: 'The reset email arrives via Resend with a working link',
+        area: 'auth',
+        routes: ['/forgot-password'],
+        excluded:
+            'Delivery is Resend-side; e2e runs against a placeholder API key, and no mail-capture harness exists. The token half is covered by password-reset-complete.',
     },
     {
         id: 'auth-guard-admin',

--- a/apps/web/e2e/helpers/auth.ts
+++ b/apps/web/e2e/helpers/auth.ts
@@ -1,4 +1,9 @@
-import { request as pwRequest, type APIRequestContext } from '@playwright/test';
+import {
+    expect,
+    request as pwRequest,
+    type APIRequestContext,
+    type Page,
+} from '@playwright/test';
 import type { Connection } from '@nexus/db/test-db';
 import {
     findUserByEmail,
@@ -34,6 +39,35 @@ export const REGULAR_USER: TestUser = {
 
 export const ADMIN_STATE_PATH = 'e2e/.auth/admin.json';
 export const USER_STATE_PATH = 'e2e/.auth/user.json';
+
+/**
+ * Builds a throwaway address for a spec that signs up its own user.
+ *
+ * The pid matters: `fullyParallel` spreads a file's tests across workers and
+ * runs `afterAll` in each of them. Workers spawn together, so `Date.now()`
+ * alone can collide across them — and then one worker's cleanup
+ * cascade-deletes another worker's user (and its session) mid-test.
+ */
+export function uniqueTestEmail(prefix: string): string {
+    return `${prefix}-${Date.now()}-${process.pid}@test.local`;
+}
+
+/**
+ * Signs up through the UI and waits for the dashboard. Use when the test needs
+ * a real browser session; `createUser` is the API back door for when it only
+ * needs the account to exist.
+ */
+export async function signUpViaUi(
+    page: Page,
+    testUser: TestUser
+): Promise<void> {
+    await page.goto('/sign-up');
+    await page.getByLabel('Name').fill(testUser.name);
+    await page.getByLabel('Email').fill(testUser.email);
+    await page.getByLabel('Password').fill(testUser.password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
+}
 
 /**
  * Create a user via the BetterAuth sign-up API (which also writes the `account`

--- a/apps/web/e2e/helpers/connection.ts
+++ b/apps/web/e2e/helpers/connection.ts
@@ -14,3 +14,20 @@ config({ path: '.env.local', quiet: true });
 export function createTestDb(): Connection {
     return createDb(process.env.DATABASE_URL!);
 }
+
+/**
+ * Runs `fn` against a short-lived connection and always closes it. The shape
+ * every unauthenticated spec needs — those run outside the fixture chain, so
+ * they can't use the worker-scoped `db` fixture and would otherwise repeat the
+ * connect/try/finally-end dance at every call site.
+ */
+export async function withTestDb<T>(
+    fn: (db: Connection) => Promise<T>
+): Promise<T> {
+    const db = createTestDb();
+    try {
+        return await fn(db);
+    } finally {
+        await db.$client.end({ timeout: 5 });
+    }
+}

--- a/apps/web/e2e/smoke/auth-flows.spec.ts
+++ b/apps/web/e2e/smoke/auth-flows.spec.ts
@@ -4,42 +4,27 @@
  * invalidate the shared `e2e/.auth/*.json` states used by other specs.
  */
 import { test, expect } from '@playwright/test';
-import { REGULAR_USER } from '../helpers/auth';
+import { REGULAR_USER, signUpViaUi, uniqueTestEmail } from '../helpers/auth';
 import { deleteUserByEmail } from '@nexus/db/test-db';
-import { createTestDb } from '../helpers/connection';
+import { withTestDb } from '../helpers/connection';
 
 // Unique per run so a crashed previous run can't collide; cleaned in afterAll.
-// The pid matters: fullyParallel spreads this file's tests across workers, and
-// afterAll runs in each of them. Workers spawn together, so Date.now() alone
-// can collide across workers — then another worker's afterAll cascade-deletes
-// this worker's signup user (and its session) mid-test.
-const SIGNUP_EMAIL = `signup-e2e-${Date.now()}-${process.pid}@test.local`;
-const SIGNUP_PASSWORD = 'signup-e2e-password-123';
+const SIGNUP_USER = {
+    email: uniqueTestEmail('signup-e2e'),
+    password: 'signup-e2e-password-123',
+    name: 'Signup E2E',
+};
 
 test.describe('auth flows', () => {
     test.afterAll(async () => {
-        // These tests run unauthenticated (outside the fixture chain), so use a
-        // direct connection rather than the worker `db` fixture.
-        const db = createTestDb();
-        try {
-            await deleteUserByEmail(db, SIGNUP_EMAIL);
-        } finally {
-            await db.$client.end({ timeout: 5 });
-        }
+        await withTestDb((db) => deleteUserByEmail(db, SIGNUP_USER.email));
     });
 
     test(
         'sign up with email lands on dashboard and provisions a trial',
         { tag: ['@page:/sign-up', '@uc:sign-up-email', '@uc:trial-on-signup'] },
         async ({ page }) => {
-            await page.goto('/sign-up');
-
-            await page.getByLabel('Name').fill('Signup E2E');
-            await page.getByLabel('Email').fill(SIGNUP_EMAIL);
-            await page.getByLabel('Password').fill(SIGNUP_PASSWORD);
-            await page.getByRole('button', { name: 'Create account' }).click();
-
-            await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
+            await signUpViaUi(page, SIGNUP_USER);
 
             // Trial starts at signup (not at plan selection): settings shows
             // a Trial badge and the Starter card is current.

--- a/apps/web/e2e/smoke/auth.spec.ts
+++ b/apps/web/e2e/smoke/auth.spec.ts
@@ -45,4 +45,45 @@ test.describe('Auth Pages', () => {
             expect(errors).toEqual([]);
         }
     );
+
+    test(
+        'forgot-password page renders without console errors',
+        { tag: ['@page:/forgot-password'] },
+        async ({ page }) => {
+            const errors = setupConsoleErrorTracking(page);
+
+            await page.goto('/forgot-password');
+
+            await expect(
+                page.getByRole('heading', { name: /forgot your password/i })
+            ).toBeVisible();
+            await expect(page.getByLabel(/email/i)).toBeVisible();
+            await expect(
+                page.getByRole('button', { name: /send reset link/i })
+            ).toBeVisible();
+
+            expect(errors).toEqual([]);
+        }
+    );
+
+    test(
+        'reset-password page renders the form for a token-bearing link',
+        { tag: ['@page:/reset-password'] },
+        async ({ page }) => {
+            const errors = setupConsoleErrorTracking(page);
+
+            // Validity is only checked on submit, so any token renders the form.
+            await page.goto('/reset-password?token=render-check');
+
+            await expect(
+                page.getByRole('heading', { name: /choose a new password/i })
+            ).toBeVisible();
+            await expect(page.getByLabel(/new password/i)).toBeVisible();
+            await expect(
+                page.getByRole('button', { name: /set new password/i })
+            ).toBeVisible();
+
+            expect(errors).toEqual([]);
+        }
+    );
 });

--- a/apps/web/e2e/smoke/invite.spec.ts
+++ b/apps/web/e2e/smoke/invite.spec.ts
@@ -11,15 +11,13 @@ import {
     deleteUserByEmail,
     type Invite,
 } from '@nexus/db/test-db';
-import { ADMIN_USER } from '../helpers/auth';
+import { ADMIN_USER, uniqueTestEmail } from '../helpers/auth';
 import { createTestDb } from '../helpers/connection';
 import { setupConsoleErrorTracking } from '../utils';
 
 // Unique per run so a crashed previous run can't collide; cleaned in afterAll.
-// The pid guards against cross-worker Date.now() collisions — see the note in
-// auth-flows.spec.ts (another worker's afterAll would delete this user).
-const SIGNUP_EMAIL = `sponsored-e2e-${Date.now()}-${process.pid}@test.local`;
-const BOUND_EMAIL = `invite-bound-e2e-${Date.now()}-${process.pid}@test.local`;
+const SIGNUP_EMAIL = uniqueTestEmail('sponsored-e2e');
+const BOUND_EMAIL = uniqueTestEmail('invite-bound-e2e');
 const SIGNUP_PASSWORD = 'sponsored-e2e-password-123';
 
 test.describe('invite redemption', () => {

--- a/apps/web/e2e/smoke/password-reset.spec.ts
+++ b/apps/web/e2e/smoke/password-reset.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Password reset, end to end minus the mailbox. The reset email itself never
+ * sends here (e2e runs against a placeholder Resend key), so the request half
+ * is exercised with an address that has no account — BetterAuth answers those
+ * neutrally without ever calling the send callback — and the completion half
+ * seeds the token straight into `verification`, which is what the emailed link
+ * would have carried.
+ *
+ * Runs unauthenticated (bare smoke project — no storageState) and creates its
+ * own user, so it can't invalidate the shared `e2e/.auth/*.json` states.
+ */
+import { test, expect } from '@playwright/test';
+import {
+    deletePasswordResetToken,
+    deleteUserByEmail,
+    findUserByEmail,
+    insertPasswordResetToken,
+} from '@nexus/db/test-db';
+import { RESET_PASSWORD_TOKEN_TTL_SECONDS } from '@/lib/auth/constants';
+import { signUpViaUi, uniqueTestEmail } from '../helpers/auth';
+import { withTestDb } from '../helpers/connection';
+
+const RESET_USER = {
+    email: uniqueTestEmail('reset-e2e'),
+    password: 'reset-e2e-original-123',
+    name: 'Reset E2E',
+};
+const NEW_PASSWORD = 'reset-e2e-changed-456';
+const RESET_TOKEN = `reset-e2e-token-${Date.now()}-${process.pid}`;
+
+test.describe('password reset', () => {
+    test.afterAll(async () => {
+        await withTestDb(async (db) => {
+            await deletePasswordResetToken(db, RESET_TOKEN);
+            await deleteUserByEmail(db, RESET_USER.email);
+        });
+    });
+
+    test(
+        'requesting a reset confirms without revealing whether the account exists',
+        { tag: ['@page:/forgot-password', '@uc:password-reset-request'] },
+        async ({ page }) => {
+            await page.goto('/forgot-password');
+
+            // No account for this address: the endpoint must still answer as
+            // if there were one.
+            const unknownEmail = uniqueTestEmail('no-such-user');
+            await page.getByLabel('Email').fill(unknownEmail);
+            await page.getByRole('button', { name: 'Send reset link' }).click();
+
+            await expect(page.getByRole('status')).toContainText(
+                /if an account exists/i,
+                { timeout: 10_000 }
+            );
+            await expect(page.getByRole('status')).toContainText(unknownEmail);
+        }
+    );
+
+    test(
+        'a valid token sets a new password, kills the old session, and the new password signs in',
+        { tag: ['@page:/reset-password', '@uc:password-reset-complete'] },
+        async ({ page }) => {
+            // Sign up through the UI so the account has a real credential to
+            // overwrite — and a live session for the reset to revoke.
+            await signUpViaUi(page, RESET_USER);
+
+            await withTestDb(async (db) => {
+                const user = await findUserByEmail(db, RESET_USER.email);
+                expect(user).toBeDefined();
+                await insertPasswordResetToken(db, {
+                    userId: user!.id,
+                    token: RESET_TOKEN,
+                    expiresAt: new Date(
+                        Date.now() + RESET_PASSWORD_TOKEN_TTL_SECONDS * 1000
+                    ),
+                });
+            });
+
+            await page.goto(`/reset-password?token=${RESET_TOKEN}`);
+            await page.getByLabel('New password').fill(NEW_PASSWORD);
+            await page
+                .getByRole('button', { name: 'Set new password' })
+                .click();
+
+            await expect(page.getByRole('status')).toContainText(
+                /password has been changed/i,
+                { timeout: 15_000 }
+            );
+
+            // Landing on /sign-in (not bounced to /dashboard) is the proof the
+            // revoked session's cookie was cleared along with it.
+            await page.getByRole('link', { name: 'Sign in' }).click();
+            await expect(page).toHaveURL(/\/sign-in/, { timeout: 10_000 });
+
+            await page.getByLabel('Email').fill(RESET_USER.email);
+            await page.getByLabel('Password').fill(NEW_PASSWORD);
+            await page.getByRole('button', { name: 'Sign in' }).click();
+
+            await expect(page).toHaveURL(/\/dashboard/, { timeout: 15_000 });
+        }
+    );
+
+    test(
+        'an unusable reset link explains itself instead of crashing',
+        { tag: ['@page:/reset-password', '@uc:password-reset-invalid-token'] },
+        async ({ page }) => {
+            // No token at all — caught before any API call.
+            await page.goto('/reset-password');
+            await expect(
+                page.getByRole('heading', { name: /isn.t usable/i })
+            ).toBeVisible();
+
+            // A token the server has never issued — caught on submit. Filter to
+            // the text-bearing alert: a production build also renders Next's
+            // empty role="alert" route announcer.
+            await page.goto('/reset-password?token=not-a-real-reset-token');
+            await page.getByLabel('New password').fill(NEW_PASSWORD);
+            await page
+                .getByRole('button', { name: 'Set new password' })
+                .click();
+
+            await expect(
+                page.getByRole('alert').filter({ hasText: /\S/ })
+            ).toBeVisible({ timeout: 10_000 });
+            await expect(page).toHaveURL(/\/reset-password/);
+        }
+    );
+});

--- a/apps/web/lib/auth/client.ts
+++ b/apps/web/lib/auth/client.ts
@@ -8,4 +8,11 @@ export const authClient = createAuthClient({
     plugins: [inferAdditionalFields<typeof auth>()],
 });
 
-export const { useSession, signIn, signUp, signOut } = authClient;
+export const {
+    useSession,
+    signIn,
+    signUp,
+    signOut,
+    requestPasswordReset,
+    resetPassword,
+} = authClient;

--- a/apps/web/lib/auth/constants.ts
+++ b/apps/web/lib/auth/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Auth values that have to agree across the BetterAuth config, the emails, the
+ * UI copy, and tests. Deliberately free of server imports so client components
+ * can read the same numbers the server enforces.
+ */
+
+/**
+ * Lifetime of a password-reset token. Drives BetterAuth's
+ * `resetPasswordTokenExpiresIn`, the expiry printed in the reset email, and the
+ * copy on the reset pages, so none of them can drift apart.
+ */
+export const RESET_PASSWORD_TOKEN_TTL_SECONDS = 60 * 60;
+
+/** The TTL above in the words the UI uses for it. */
+export const RESET_PASSWORD_TOKEN_TTL_LABEL = 'an hour';
+
+/** BetterAuth's server-side minimum for credential passwords. */
+export const MIN_PASSWORD_LENGTH = 8;

--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -1,7 +1,10 @@
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import * as schema from '@nexus/db/schema';
+import { RESET_PASSWORD_TOKEN_TTL_SECONDS } from '@/lib/auth/constants';
+import { env } from '@/lib/env';
 import { db } from '@/server/db';
+import { emailService } from '@/server/services/email';
 import { subscriptionService } from '@/server/services/subscriptions';
 import { logger } from '@/server/lib/logger';
 
@@ -29,6 +32,22 @@ export const auth = betterAuth({
     rateLimit,
     emailAndPassword: {
         enabled: true,
+        resetPasswordTokenExpiresIn: RESET_PASSWORD_TOKEN_TTL_SECONDS,
+        // A reset is the recovery path for an account that may be compromised,
+        // so every session created with the old password dies with it.
+        revokeSessionsOnPasswordReset: true,
+        // better-auth's own `url` points at its API, which only redirects to a
+        // real page when the request carried a `redirectTo`. Link straight at
+        // our page instead — same shape as the invite email.
+        sendResetPassword: async ({ user, token }) => {
+            await emailService.sendPasswordResetEmail({
+                to: user.email,
+                resetUrl: `${env.NEXT_PUBLIC_APP_URL}/reset-password?token=${token}`,
+                expiresAt: new Date(
+                    Date.now() + RESET_PASSWORD_TOKEN_TTL_SECONDS * 1000
+                ),
+            });
+        },
     },
     session: {
         expiresIn: 60 * 60 * 24 * 7, // 7 days

--- a/apps/web/lib/email/index.ts
+++ b/apps/web/lib/email/index.ts
@@ -26,4 +26,8 @@ export const email = {
     templates,
 } as const;
 
-export type { InviteEmailProps, RetrievalReadyEmailProps } from './templates';
+export type {
+    InviteEmailProps,
+    PasswordResetEmailProps,
+    RetrievalReadyEmailProps,
+} from './templates';

--- a/apps/web/lib/email/templates/index.ts
+++ b/apps/web/lib/email/templates/index.ts
@@ -1,4 +1,15 @@
+/**
+ * The transactional email library. Every template exports its component, its
+ * props, and a `*Subject()` function — subject and body live in one file so the
+ * whole message reads and tests as one unit, and a copy change can't drift
+ * between the inbox line and what's inside.
+ */
 export { InviteEmail, inviteSubject, type InviteEmailProps } from './invite';
+export {
+    PasswordResetEmail,
+    passwordResetSubject,
+    type PasswordResetEmailProps,
+} from './password-reset';
 export {
     RetrievalReadyEmail,
     retrievalReadySubject,

--- a/apps/web/lib/email/templates/password-reset.test.tsx
+++ b/apps/web/lib/email/templates/password-reset.test.tsx
@@ -1,0 +1,39 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { render } from '@react-email/components';
+import { PasswordResetEmail, passwordResetSubject } from './password-reset';
+
+describe('PasswordResetEmail', () => {
+    const resetUrl = 'https://test.example/reset-password?token=abc123token';
+
+    let html: string;
+    beforeAll(async () => {
+        html = await render(
+            <PasswordResetEmail
+                resetUrl={resetUrl}
+                expiresAt={new Date('2026-08-01T12:00:00Z')}
+            />
+        );
+    });
+
+    it('renders the reset link on the button and as fallback text', () => {
+        // Button href + plain-text fallback both carry the URL
+        expect(html).toContain(resetUrl);
+    });
+
+    it('tells a recipient who did not request it that they can ignore it', () => {
+        expect(html).toContain('ignore');
+    });
+
+    it('renders the expiry in UTC', () => {
+        expect(html).toContain('This link expires on');
+        expect(html).toContain('August 1, 2026 at 12:00 PM UTC');
+    });
+
+    it('renders to a full HTML document', () => {
+        expect(html).toContain('<!DOCTYPE html');
+    });
+
+    it('builds a subject line naming the reset', () => {
+        expect(passwordResetSubject()).toBe('Reset your Nexus password');
+    });
+});

--- a/apps/web/lib/email/templates/password-reset.tsx
+++ b/apps/web/lib/email/templates/password-reset.tsx
@@ -1,0 +1,51 @@
+import { Button, Heading, Section, Text } from '@react-email/components';
+import { EmailLayout } from './_layout';
+import { Callout, CalloutStrong } from './components/callout';
+import { ClockIcon } from './components/icons';
+import { LinkFallback } from './components/link-fallback';
+import { formatEmailDateTime } from './format';
+import { button, buttonSection, heading, intro, introStrong } from './styles';
+import { colors } from './theme';
+
+export interface PasswordResetEmailProps {
+    resetUrl: string;
+    /** When the link stops working — reset tokens are always time-boxed. */
+    expiresAt: Date;
+}
+
+/** Subject line — co-located with the component; see `templates/index.ts`. */
+export function passwordResetSubject(): string {
+    return 'Reset your Nexus password';
+}
+
+export function PasswordResetEmail({
+    resetUrl,
+    expiresAt,
+}: PasswordResetEmailProps) {
+    return (
+        <EmailLayout
+            preview="Choose a new password for your Nexus account"
+            footer={<LinkFallback url={resetUrl} />}
+        >
+            <Heading style={heading}>Reset your password</Heading>
+            <Text style={intro}>
+                Someone asked to reset the password for your{' '}
+                <strong style={introStrong}>Nexus</strong> account. Choose a new
+                one to get back to your files. If this wasn&apos;t you, ignore
+                this email — your password stays as it is.
+            </Text>
+
+            <Section style={buttonSection}>
+                <Button style={button} href={resetUrl}>
+                    Choose a new password
+                </Button>
+            </Section>
+
+            <Callout icon={<ClockIcon size={16} color={colors.primary} />}>
+                This link expires on{' '}
+                <CalloutStrong>{formatEmailDateTime(expiresAt)}</CalloutStrong>.
+                After that, request a new one from the sign-in page.
+            </Callout>
+        </EmailLayout>
+    );
+}

--- a/apps/web/lib/errors.ts
+++ b/apps/web/lib/errors.ts
@@ -1,0 +1,8 @@
+/**
+ * Narrows an unknown thrown value to a message string. Anything can be thrown,
+ * but the places that record failures — webhook `error` columns, alert context,
+ * retrieval `errorMessage` — all need a plain string.
+ */
+export function toErrorMessage(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -2,7 +2,10 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { getSessionCookie } from 'better-auth/cookies';
 import { sanitizeRedirect } from '@/lib/auth/sanitizeRedirect';
 
-const AUTH_ROUTES = ['/sign-in', '/sign-up'];
+// `/reset-password` is deliberately absent: a signed-in user who clicks the
+// reset link in their inbox must be able to complete it, not get bounced to a
+// dashboard whose session the reset is about to revoke.
+const AUTH_ROUTES = ['/sign-in', '/sign-up', '/forgot-password'];
 
 /**
  * Optimistic auth guard (UX layer only). It reads the session cookie's
@@ -35,5 +38,5 @@ export function proxy(req: NextRequest): NextResponse {
 }
 
 export const config = {
-    matcher: ['/dashboard/:path*', '/sign-in', '/sign-up'],
+    matcher: ['/dashboard/:path*', '/sign-in', '/sign-up', '/forgot-password'],
 };

--- a/apps/web/server/services/email.test.ts
+++ b/apps/web/server/services/email.test.ts
@@ -10,12 +10,14 @@ import { mockEmail } from '@/lib/email/testing';
 
 const hoisted = await vi.hoisted(async () => {
     const { createMockLogger } = await import('@/server/lib/logger/testing');
-    return { logger: createMockLogger() };
+    return { logger: createMockLogger(), alertsSend: vi.fn() };
 });
 
 vi.mock('@/lib/email', () => ({
     email: mockEmail,
 }));
+
+vi.mock('@/lib/alerts', () => ({ alerts: { send: hoisted.alertsSend } }));
 
 vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
 
@@ -113,6 +115,49 @@ describe('email service', () => {
             expect(hoisted.logger.warn).toHaveBeenCalledWith(
                 { to: 'tester@example.com', err: expect.any(Error) },
                 'Failed to send invite email'
+            );
+        });
+    });
+
+    describe('sendPasswordResetEmail', () => {
+        const resetOpts = {
+            to: 'tester@example.com',
+            resetUrl: 'https://test.example/reset-password?token=abc123token',
+            expiresAt: new Date('2026-08-01T12:00:00Z'),
+        };
+
+        it('sends to the account address with the reset subject', async () => {
+            await emailService.sendPasswordResetEmail(resetOpts);
+
+            expect(mockEmail.send).toHaveBeenCalledOnce();
+            const sent = mockEmail.send.mock.calls[0][0];
+            expect(sent.to).toBe('tester@example.com');
+            expect(sent.subject).toContain('Reset your Nexus password');
+            expect(sent.react).toBeDefined();
+        });
+
+        // The whole point of this function existing separately from the other
+        // two: a lost reset email locks the user out, so it must not swallow.
+        it('alerts and rethrows when the send fails', async () => {
+            mockEmail.send.mockRejectedValueOnce(new Error('Resend outage'));
+
+            await expect(
+                emailService.sendPasswordResetEmail(resetOpts)
+            ).rejects.toThrow('Resend outage');
+
+            expect(hoisted.logger.error).toHaveBeenCalledWith(
+                { to: 'tester@example.com', err: expect.any(Error) },
+                'Failed to send password reset email'
+            );
+            expect(hoisted.alertsSend).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    severity: 'critical',
+                    context: expect.objectContaining({
+                        source: 'auth',
+                        to: 'tester@example.com',
+                        error: 'Resend outage',
+                    }),
+                })
             );
         });
     });

--- a/apps/web/server/services/email.ts
+++ b/apps/web/server/services/email.ts
@@ -1,11 +1,14 @@
 import { createElement } from 'react';
 import type { DB } from '@nexus/db';
 import { createUserRepo } from '@nexus/db/repo/users';
+import { alerts } from '@/lib/alerts';
 import {
     email,
     type InviteEmailProps,
+    type PasswordResetEmailProps,
     type RetrievalReadyEmailProps,
 } from '@/lib/email';
+import { toErrorMessage } from '@/lib/errors';
 import { logger } from '@/server/lib/logger';
 
 const log = logger.child({ service: 'email' });
@@ -67,7 +70,42 @@ async function sendInviteEmail(opts: SendInviteEmailOptions): Promise<void> {
     }
 }
 
+export interface SendPasswordResetEmailOptions extends PasswordResetEmailProps {
+    /** Recipient — the account's own address, from better-auth's reset request. */
+    to: string;
+}
+
+// Deliberately NOT warn-and-swallow like the two above. A reset email is the
+// only way back into an account whose password is lost, so a swallowed failure
+// shows the user "check your email" for a message that will never arrive.
+// Alert the operator, then rethrow: better-auth awaits this callback, so the
+// throw surfaces as a failed /request-password-reset the user can see and retry.
+async function sendPasswordResetEmail(
+    opts: SendPasswordResetEmailOptions
+): Promise<void> {
+    const { to, ...props } = opts;
+
+    try {
+        await email.send({
+            to,
+            subject: email.templates.passwordResetSubject(),
+            react: createElement(email.templates.PasswordResetEmail, props),
+        });
+    } catch (err) {
+        log.error({ to, err }, 'Failed to send password reset email');
+        await alerts.send({
+            severity: 'critical',
+            title: 'Password reset email failed to send',
+            message:
+                'The reset link never reached the user — they stay locked out until this is fixed.',
+            context: { source: 'auth', to, error: toErrorMessage(err) },
+        });
+        throw err;
+    }
+}
+
 export const emailService = {
     sendInviteEmail,
+    sendPasswordResetEmail,
     sendRetrievalReadyEmail,
 } as const;

--- a/apps/web/server/services/retrieval.ts
+++ b/apps/web/server/services/retrieval.ts
@@ -7,6 +7,7 @@ import {
     type RetrievalRepo,
 } from '@nexus/db/repo/retrievals';
 import { createUploadBatchRepo } from '@nexus/db/repo/uploadBatches';
+import { toErrorMessage } from '@/lib/errors';
 import { NotFoundError, InvalidStateError } from '@/server/errors';
 import { logger } from '@/server/lib/logger';
 import { s3 } from '@/lib/storage';
@@ -217,10 +218,7 @@ async function restoreInserted(
                         'failed',
                         {
                             failedAt: new Date(),
-                            errorMessage:
-                                err instanceof Error
-                                    ? err.message
-                                    : String(err),
+                            errorMessage: toErrorMessage(err),
                         }
                     );
                 } catch (updateErr) {

--- a/packages/db/src/test-db/inserts.ts
+++ b/packages/db/src/test-db/inserts.ts
@@ -155,6 +155,35 @@ export async function insertInvite(
     return invite!;
 }
 
+export interface PasswordResetTokenOptions {
+    userId: string;
+    token: string;
+    /**
+     * Explicit on purpose: this package can't import the app's TTL constant,
+     * and a default here would be a second copy of it that silently goes stale.
+     */
+    expiresAt: Date;
+}
+
+/**
+ * Plants a password-reset token exactly as BetterAuth's
+ * `/request-password-reset` would (`verification.identifier` is prefixed,
+ * `value` holds the user id). E2E can't read the token out of the real email —
+ * the reset mail never sends against a placeholder Resend key — so specs seed
+ * it here and drive `/reset-password?token=` directly.
+ */
+export async function insertPasswordResetToken(
+    db: DB,
+    opts: PasswordResetTokenOptions
+): Promise<void> {
+    await db.insert(schema.verification).values({
+        id: crypto.randomUUID(),
+        identifier: `reset-password:${opts.token}`,
+        value: opts.userId,
+        expiresAt: opts.expiresAt,
+    });
+}
+
 export async function insertJob(
     db: DB,
     overrides: Partial<Job> = {}

--- a/packages/db/src/test-db/queries.ts
+++ b/packages/db/src/test-db/queries.ts
@@ -103,6 +103,22 @@ export async function deleteInviteByToken(
 }
 
 /**
+ * Clears a seeded password-reset token. `verification` has no FK to `user`, so
+ * deleting the user leaves the row behind — specs that seed a token clean it up
+ * here. Keyed on the token, not the user, so it can't take out the other row
+ * kinds that share the table (email verification, 2FA). A completed reset
+ * consumes its own row, making this a no-op.
+ */
+export async function deletePasswordResetToken(
+    db: DB,
+    token: string
+): Promise<void> {
+    await db
+        .delete(schema.verification)
+        .where(eq(schema.verification.identifier, `reset-password:${token}`));
+}
+
+/**
  * Upserts the user's subscription to a fresh trial. Used by global setup (the
  * shared e2e users are reused across runs and may pre-date the signup trial
  * hook) and as the `afterEach` reset for specs that flip to paid via


### PR DESCRIPTION
## Summary

Builds the password reset flow. "Forgot password?" was `href="#"`, so a tester
who forgot their password was silently locked out with no way back in — the
failure mode this epic exists to kill.

better-auth already shipped `/request-password-reset` and `/reset-password`;
they 400'd only because `emailAndPassword.sendResetPassword` was unset. Wiring
that callback activates both, so there's no new endpoint and no migration
(tokens live in the existing `verification` table).

Three decisions worth flagging:

- **The reset email throws on failure** instead of following the warn-and-swallow
  contract the other two senders use. A swallowed reset email shows "check your
  email" for a message that will never arrive, which is exactly the silent
  failure this issue is about. It alerts Discord at `critical`, then rethrows;
  better-auth awaits the callback, so the user sees a failed request they can
  retry. Trade-off: while Resend is down, a known address 500s and an unknown one
  still 200s — a short-lived account-enumeration oracle. Loud failure was worth
  more than neutrality under outage.
- **The email links straight at `/reset-password?token=`** rather than
  better-auth's own `url`, which routes through the API and only lands on a real
  page when the request carried a `redirectTo`. Same shape as the invite email.
- **`revokeSessionsOnPasswordReset: true`**, and the form calls `/sign-out`
  afterwards. Without that second step the browser keeps the dead session's
  cookie, which is enough to fool the optimistic proxy guard into bouncing the
  user off `/sign-in` into a dashboard whose session no longer exists.
  `/reset-password` is deliberately left out of `AUTH_ROUTES` for the same
  reason — a signed-in user must be able to finish a reset from their inbox.

Self-review surfaced 15 findings across three reviewers and all 15 are applied.
Ten were reuse findings about pre-existing duplication that this feature would
have deepened, so the shared pieces got extracted and the existing callers moved
onto them: `AuthPageShell` (5 pages), `FormError`/`FormStatus` (4 forms),
`AuthNotice` (2 pages), `toErrorMessage` (4 call sites), and three e2e helpers.

Closes #335

## Changes

- `lib/auth/server.ts`: `sendResetPassword`, `resetPasswordTokenExpiresIn`, `revokeSessionsOnPasswordReset`; `lib/auth/client.ts` re-exports `requestPasswordReset`/`resetPassword`
- `lib/auth/constants.ts`: TTL + `MIN_PASSWORD_LENGTH`, shared by the server config, the email, the UI copy, and tests so they can't drift
- `server/services/email.ts`: `sendPasswordResetEmail` — alerts then rethrows, unlike its warn-and-swallow siblings
- `lib/email/templates/password-reset.tsx` + unit test; convention docblock moved to `templates/index.ts`
- Pages `(auth)/forgot-password` and `(auth)/reset-password` (missing-token state included), forms in `components/auth/`, dead link repointed
- `proxy.ts`: `/forgot-password` added to `AUTH_ROUTES` and the matcher
- Extractions: `AuthPageShell`, `AuthNotice`, `FormError`/`FormStatus`, `lib/errors.ts`'s `toErrorMessage`; sign-in, sign-up, and invite pages/forms moved onto them
- `minLength` now enforced on the sign-up password field too, from the same constant
- E2E: `smoke/password-reset.spec.ts` (3 flows), 2 render tests, 4 manifest use-cases; `insertPasswordResetToken`/`deletePasswordResetToken` in `@nexus/db/test-db`; `uniqueTestEmail`, `signUpViaUi`, `withTestDb` helpers adopted by `auth-flows` and `invite` specs

## Test Plan

- [x] `pnpm check` — 10/10
- [x] `pnpm -F web typecheck` — app + e2e trees
- [x] `pnpm -F web e2e:coverage --check` — 17/17 pages, 72/72 use-cases
- [x] `pnpm -F web test:e2e` — 86/86 (full tier: auth pages and forms are cross-cutting)
- [x] Live send against dev: `POST /api/auth/request-password-reset` → 200, `verification` row written with a 1h expiry, emailed link renders the real form. Because the callback throws on failure, the 200 is itself proof Resend accepted the message.
- [x] Open the reset email in a real inbox and click through end to end (the one step no tier can reach — CI runs a placeholder Resend key, and `password-reset-email-delivery` is marked `excluded` in the manifest with that reason)
