### PR TITLE
chore: share one trial-length constant across seeds and fixtures (#360)

### DIFF
--- a/apps/web/server/services/constants.ts
+++ b/apps/web/server/services/constants.ts
@@ -1,11 +1,12 @@
-import { PLAN_LIMITS, type PlanTier } from '@nexus/db/plans';
+import {
+    PLAN_LIMITS,
+    TRIAL_DURATION_DAYS,
+    type PlanTier,
+} from '@nexus/db/plans';
 import type { Subscription } from '@nexus/db/repo/subscriptions';
 
-export { PLAN_LIMITS, type PlanTier };
+export { PLAN_LIMITS, TRIAL_DURATION_DAYS, type PlanTier };
 export type { CheckoutTier, BillingInterval } from '@/lib/stripe/types';
-
-/** Trial duration in days. */
-export const TRIAL_DURATION_DAYS = 30;
 
 /**
  * Default storage cap for sponsored (comped alpha-tester) subscriptions.

--- a/packages/db/src/plans.ts
+++ b/packages/db/src/plans.ts
@@ -9,3 +9,19 @@ export const PLAN_LIMITS: Record<PlanTier, number> = {
     max: 10 * 1024 ** 4, //    10 TB
     enterprise: 100 * 1024 ** 4, // 100 TB (custom; "20TB+" marketed)
 };
+
+/**
+ * Lives here rather than in `apps/web` so seeds and test-db helpers can reach
+ * it — they can't import from the app.
+ */
+export const TRIAL_DURATION_DAYS = 30;
+
+/**
+ * Trial expiry for a subscription starting at `from`. Fixed 24-hour days; the
+ * signup path uses date-fns `addDays`, which is calendar-aware, so the two can
+ * differ by an hour across a DST boundary. That's fine for seeds and fixtures,
+ * and `packages/db` has no date-fns dependency to share the calendar version.
+ */
+export function getTrialEnd(from: Date = new Date()): Date {
+    return new Date(from.getTime() + TRIAL_DURATION_DAYS * 86_400_000);
+}

--- a/packages/db/src/repositories/fixtures.ts
+++ b/packages/db/src/repositories/fixtures.ts
@@ -1,5 +1,5 @@
 import * as schema from '../schema';
-import { PLAN_LIMITS } from '../plans';
+import { PLAN_LIMITS, getTrialEnd } from '../plans';
 import type { File, NewFile } from './files';
 import type { Invite } from './invites';
 import type { Job, NewJob } from './jobs';
@@ -133,6 +133,10 @@ export function createNewJobFixture(overrides: Partial<NewJob> = {}): NewJob {
     };
 }
 
+/**
+ * Defaults to a fresh trial, matching the schema default and what the signup
+ * path writes. Tests that need a paid subscription pass `status` explicitly.
+ */
 export function createSubscriptionFixture(
     overrides: Partial<Subscription> = {}
 ): Subscription {
@@ -143,12 +147,12 @@ export function createSubscriptionFixture(
         stripeCustomerId: TEST_STRIPE_CUSTOMER_ID,
         stripeSubscriptionId: null,
         planTier: 'starter',
-        status: 'active',
+        status: 'trialing',
         storageLimit: PLAN_LIMITS.starter,
         currentPeriodStart: null,
         currentPeriodEnd: null,
         cancelAtPeriodEnd: false,
-        trialEnd: null,
+        trialEnd: getTrialEnd(now),
         createdAt: now,
         updatedAt: now,
         ...overrides,

--- a/packages/db/src/seed/constants.ts
+++ b/packages/db/src/seed/constants.ts
@@ -1,5 +1,5 @@
 import type { Connection, DB } from '../connection';
-export { PLAN_LIMITS, type PlanTier } from '../plans';
+export { PLAN_LIMITS, getTrialEnd, type PlanTier } from '../plans';
 
 // Seed ID prefixes
 // All seeded entities use these prefixes so cleanup can target them

--- a/packages/db/src/seed/scenarios.ts
+++ b/packages/db/src/seed/scenarios.ts
@@ -11,7 +11,7 @@ import {
     buildStorageUsage,
     buildRetrievals,
 } from './builders';
-import { PLAN_LIMITS, withTransaction } from './constants';
+import { PLAN_LIMITS, getTrialEnd, withTransaction } from './constants';
 
 // Scenario registry
 
@@ -94,7 +94,7 @@ async function emptyUser(db: DB): Promise<SeedResult> {
     const sub = await buildSubscription(db, user.id, {
         planTier: 'starter',
         status: 'trialing',
-        trialEnd: new Date(Date.now() + 14 * 86_400_000),
+        trialEnd: getTrialEnd(),
     });
     const usage = await buildStorageUsage(db, user.id);
 

--- a/packages/db/src/test-db/queries.ts
+++ b/packages/db/src/test-db/queries.ts
@@ -10,7 +10,7 @@ import { eq, count } from 'drizzle-orm';
 import type { DB } from '../connection';
 import * as schema from '../schema';
 import { createSubscriptionFixture, type User } from '../repositories/fixtures';
-import { PLAN_LIMITS, type PlanTier } from '../plans';
+import { PLAN_LIMITS, getTrialEnd, type PlanTier } from '../plans';
 
 export async function findUserByEmail(
     db: DB,
@@ -123,7 +123,7 @@ export async function ensureTrialSubscription(
         currentPeriodStart: null,
         currentPeriodEnd: null,
         cancelAtPeriodEnd: false,
-        trialEnd: new Date(Date.now() + 30 * 86_400_000),
+        trialEnd: getTrialEnd(),
     });
     await db
         .insert(schema.subscriptions)


### PR DESCRIPTION
## Summary

Three fixture layers each retyped prod's subscription rules and two had drifted. `TRIAL_DURATION_DAYS` lived in `apps/web/server/services/constants.ts`, which `packages/db` can't import (the dependency runs the other way), so the seed scenario invented a 14-day trial and the test-db helper hardcoded its own 30.

The constant now lives in `packages/db/src/plans.ts` next to `PLAN_LIMITS`, reachable from every layer via the existing `@nexus/db/plans` subpath export. `apps/web` re-exports it from `server/services/constants.ts` under the same name, so no app call site changed. A small `getTrialEnd()` helper replaces the three copies of `Date.now() + N * 86_400_000`.

Separately, `createSubscriptionFixture` defaulted to `status: 'active'`, `trialEnd: null` while both the schema default and the signup path produce `trialing` with a real `trialEnd`. It now defaults to a fresh trial. All 13 call sites in `subscriptions.test.ts` pass — the ones modelling paid subscriptions already set `status` explicitly, and none of the four relying on the default asserts on status.

The signup path keeps its date-fns `addDays`, which is calendar-aware; the db-side helper uses fixed 24-hour days. They can differ by an hour across a DST boundary, which is documented on the helper and fine for seeds and fixtures. Unifying them would change prod behavior, so it's deliberately out of this chore.

Closes #360

## Changes

- Add `TRIAL_DURATION_DAYS` and `getTrialEnd()` to `packages/db/src/plans.ts`; re-export through `seed/constants.ts`
- `apps/web/server/services/constants.ts` imports and re-exports the constant instead of defining its own
- Fix the 14-day trial in the `emptyUser` seed scenario and the hardcoded 30 in `ensureTrialSubscription`
- `createSubscriptionFixture` defaults to `status: 'trialing'` with a real `trialEnd`, matching the schema default and signup

## Self-review notes

Four findings were raised and deliberately skipped:

- Collapsing `ensureTrialSubscription`'s overrides now that they match the fixture defaults. Its docblock says it forces every column back so a crash can't leak paid state into the next run; inheriting the fixture default reintroduces exactly the coupling this issue removes.
- `seed/builders.ts:179` still has a silent `status ?? 'active'` default. Same class of drift, but it's a fourth layer the issue doesn't name and changing it changes what `pnpm seed` produces. Follow-up.
- Pointing the prod signup path at `getTrialEnd()`. That swaps calendar-aware arithmetic for fixed 24h days in live signup.
- Extracting a shared `daysFromNow` for the six `n * 86_400_000` sites repo-wide. New module, five unrelated call sites.

## Test Plan

- [ ] `pnpm check` green (lint + build + unit tests, including the 13 `createSubscriptionFixture` call sites in `subscriptions.test.ts`)
- [ ] `pnpm -F db seed --scenario emptyUser` produces a subscription with `trial_end` ~30 days out, not 14
- [ ] E2E global setup still yields a trialing subscription via `ensureTrialSubscription`
