### PR TITLE
chore: per-worktree e2e databases and automated worktree teardown

### DIFF
--- a/.claude/hooks/worktree-setup.sh
+++ b/.claude/hooks/worktree-setup.sh
@@ -42,10 +42,48 @@ if [ ! -d node_modules ]; then
     || echo "worktree-setup: install failed - run 'pnpm install' manually" >&2
 fi
 
+# .worktreeinclude normally copies the env files in, but a worktree created
+# before that existed (or by plain `git worktree add`) has none, and `pnpm check`
+# then fails in lib/env with "No client environment variables found".
+main_env="$(dirname "$(git rev-parse --git-common-dir)")/apps/web/.env.local"
+if [ ! -f apps/web/.env.local ] && [ -f "$main_env" ]; then
+  cp "$main_env" apps/web/.env.local
+  echo "worktree-setup: copied .env.local from the main checkout" >&2
+fi
+
 # Stable per-worktree dev port in 3001-4000, derived from the worktree name so
 # it stays the same across sessions. 3000 stays reserved for the main checkout.
 name=$(basename "$root")
 port=$(( 3001 + $(printf '%s' "$name" | cksum | cut -d' ' -f1) % 1000 ))
+
+# Per-worktree e2e database. Every worktree used to share one Supabase DB while
+# the e2e fixtures use fixed identities (admin-e2e@test.local, e2e-test-file-1
+# .txt), so two worktrees testing at once collided: sign-up 422s, duplicate-key
+# inserts, and strict-mode violations from the other run's rows. The app server
+# was already isolated per worktree by $port; this isolates the data too.
+#
+# Scoped to e2e on purpose. `pnpm dev` keeps pointing at the shared dev DB via
+# .env.local, which is where the real data lives - only playwright.config.ts
+# reads E2E_DATABASE_URL, and it falls back to DATABASE_URL when unset (CI).
+pg_bin=$(command -v createdb >/dev/null && dirname "$(command -v createdb)" || echo /opt/homebrew/opt/postgresql@17/bin)
+if [ -x "$pg_bin/createdb" ]; then
+  db="nexus_wt_$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '_' | cut -c1-50)"
+  e2e_url="postgres://$USER@localhost:5432/$db"
+  if ! "$pg_bin/psql" -lqt 2>/dev/null | cut -d'|' -f1 | grep -qw "$db"; then
+    if "$pg_bin/createdb" "$db" 2>/dev/null; then
+      echo "worktree-setup: created e2e database $db, migrating..." >&2
+      DATABASE_URL="$e2e_url" pnpm -F db db:migrate >&2 \
+        || echo "worktree-setup: migrate failed - run 'pnpm -F db db:migrate' manually" >&2
+    else
+      echo "worktree-setup: createdb $db failed - e2e will use the shared DB" >&2
+      e2e_url=''
+    fi
+  fi
+  [ -n "$e2e_url" ] && [ -n "${CLAUDE_ENV_FILE:-}" ] \
+    && printf 'E2E_DATABASE_URL=%s\nDB_ENV=local\n' "$e2e_url" >> "$CLAUDE_ENV_FILE"
+else
+  echo "worktree-setup: no local postgres (brew install postgresql@17) - e2e shares the dev DB" >&2
+fi
 
 # CLAUDE_ENV_FILE persists vars into this session's Bash tool calls. turbo
 # forwards everything (globalPassThroughEnv: ["*"]), so `pnpm dev` binds next dev
@@ -54,4 +92,4 @@ port=$(( 3001 + $(printf '%s' "$name" | cksum | cut -d' ' -f1) % 1000 ))
 [ -n "${CLAUDE_ENV_FILE:-}" ] && printf 'PORT=%s\n' "$port" >> "$CLAUDE_ENV_FILE"
 
 # A SessionStart hook's stdout is injected into Claude's context.
-echo "Worktree '$name' is dev-ready. PORT=$port is set for both 'pnpm dev' and e2e."
+echo "Worktree '$name' is dev-ready. PORT=$port is set for both 'pnpm dev' and e2e.${e2e_url:+ e2e uses its own database $db.}"

--- a/.claude/scripts/prune-worktrees.sh
+++ b/.claude/scripts/prune-worktrees.sh
@@ -171,15 +171,24 @@ for entry in "${prunable[@]}"; do
   IFS='|' read -r w branch pr_state <<< "$entry"
   if git worktree remove "$w"; then
     echo "removed $(basename "$w")"
-    # Its e2e database goes with it - same name derivation as worktree-setup.sh.
+    # Its e2e database goes with it. The name derivation must match
+    # worktree-setup.sh exactly, including `printf '%s'` - piping `basename`
+    # feeds tr a trailing newline, which `tr -c 'a-z0-9' '_'` turns into a
+    # trailing underscore, and the drop then silently misses the real database.
     pg_bin=$(command -v dropdb >/dev/null && dirname "$(command -v dropdb)" || echo /opt/homebrew/opt/postgresql@17/bin)
-    db="nexus_wt_$(basename "$w" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '_' | cut -c1-50)"
+    db="nexus_wt_$(printf '%s' "$(basename "$w")" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '_' | cut -c1-50)"
     [ -x "$pg_bin/dropdb" ] && "$pg_bin/dropdb" --if-exists "$db" 2>/dev/null \
       && echo "  dropped database $db"
     # Squash-merged branches never look merged to `git branch -d`, so -D is the
     # only option - gated on the PR state, which is the authoritative signal.
-    if [ "$pr_state" = MERGED ] && [ "$branch" != main ]; then
-      git branch -D "$branch" >/dev/null 2>&1 && echo "  deleted branch $branch"
+    # Everything else gets the safe `-d`, which refuses anything unmerged and so
+    # only ever clears branches with nothing on them.
+    if [ "$branch" != main ] && [ "$branch" != '(detached)' ]; then
+      if [ "$pr_state" = MERGED ]; then
+        git branch -D "$branch" >/dev/null 2>&1 && echo "  deleted branch $branch"
+      else
+        git branch -d "$branch" >/dev/null 2>&1 && echo "  deleted empty branch $branch"
+      fi
     fi
   else
     echo "SKIPPED $(basename "$w") - git refused the removal" >&2

--- a/.claude/scripts/prune-worktrees.sh
+++ b/.claude/scripts/prune-worktrees.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Teardown counterpart to .claude/hooks/worktree-setup.sh: report which linked
+# worktrees are safe to remove, and (with --apply) remove them.
+#
+# A worktree is prunable only when all four hold:
+#   1. clean      - no uncommitted or untracked changes
+#   2. pushed     - no commits the remote hasn't seen
+#   3. done       - its PR is MERGED, or it has no commits beyond origin/main
+#   4. idle       - no Claude session activity for the applicable window
+#
+# The idle window is split because "merged" and "quiet" mean different things.
+# A merged PR says the work landed, so the only thing left to protect is a live
+# session doing post-merge validation - hours, not days. A worktree with no
+# merged PR might be paused work, so it gets the long window. At ~10 new
+# worktrees a day, each carrying its own ~1GB node_modules, the difference is
+# roughly 11GB of live checkouts instead of 22GB.
+#
+# Sessions are NOT stored in the worktree; they live in
+# ~/.claude/projects/<slugged-path>/ and survive removal. What removal costs is
+# the `claude --resume` listing for that path (the transcripts stay readable,
+# and recreating the same path brings the listing back). The idle check exists
+# so an active worktree is never pruned mid-session, not to protect history.
+#
+# Dry run by default. Removal uses plain `git worktree remove` (no --force), so
+# git itself is the last line of defence if this script's checks are ever wrong.
+set -uo pipefail
+
+apply=0
+fetch=1
+merged_idle_hours=12
+idle_hours=48
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply)              apply=1 ;;
+    --no-fetch)           fetch=0 ;;
+    --merged-idle-hours)  merged_idle_hours=${2:?--merged-idle-hours needs a value}; shift ;;
+    --idle-hours)         idle_hours=${2:?--idle-hours needs a value}; shift ;;
+    -h|--help)
+      sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+command -v gh >/dev/null || { echo "prune-worktrees: gh CLI is required" >&2; exit 1; }
+
+# launchd invokes this with cwd=/, so the repo is located from the script's own
+# path (<checkout>/.claude/scripts/) rather than the working directory. A copy
+# inside a linked worktree still resolves to the same shared .git.
+invoked_from=$PWD
+cd "$(dirname "$0")/../.." 2>/dev/null || { echo "prune-worktrees: cannot locate checkout" >&2; exit 1; }
+git rev-parse --git-common-dir >/dev/null 2>&1 || { echo "prune-worktrees: not a git repo" >&2; exit 1; }
+main_root=$(cd "$(dirname "$(git rev-parse --git-common-dir)")" && pwd)
+cd "$main_root" || exit 1
+
+# Only set when invoked from inside a worktree - that one is never pruned out
+# from under the caller. Empty under launchd, where no worktree is "current".
+root=$(cd "$invoked_from" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+
+[ "$fetch" = 1 ] && git fetch --quiet --prune origin 2>/dev/null
+
+# Claude keys a project dir by the worktree's absolute path with /, . and _ all
+# collapsed to '-'. Newest transcript mtime in that dir is the session clock.
+session_age_hours() {
+  local slug dir newest now
+  slug=$(printf '%s' "$1" | tr '/._' '---')
+  dir="$HOME/.claude/projects/$slug"
+  [ -d "$dir" ] || { echo 99999; return; }
+  newest=$(find "$dir" -name '*.jsonl' -exec stat -f %m {} + 2>/dev/null | sort -rn | head -1)
+  [ -n "$newest" ] || { echo 99999; return; }
+  now=$(date +%s)
+  echo $(( (now - newest) / 3600 ))
+}
+
+prunable=()
+# Under launchd every run appends to one log, so stamp non-tty output. A
+# terminal already has the context and doesn't need the banner.
+[ -t 1 ] || printf '=== %s ===\n' "$(date '+%F %T')"
+printf '%-38s %-40s %s\n' WORKTREE BRANCH VERDICT
+
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *) wt=${line#worktree } ;;
+    locked*)     [ -n "${wt:-}" ] && locked[${#prunable[@]}]=1; wt_locked=1 ;;
+    '')
+      # end of a porcelain record - evaluate the worktree we just read
+      [ -n "${wt:-}" ] || continue
+      w=$wt; wt=''; was_locked=${wt_locked:-0}; wt_locked=0
+
+      [ "$w" = "$main_root" ] && continue
+      name=$(basename "$w")
+      branch=$(git -C "$w" symbolic-ref --quiet --short HEAD 2>/dev/null || echo '(detached)')
+
+      verdict=''; reason=''; window=0; pr_state=''
+      if [ "$was_locked" = 1 ]; then
+        verdict='keep - locked'
+      elif [ "$w" = "$root" ]; then
+        verdict='keep - current worktree'
+      elif [ -n "$(git -C "$w" status --porcelain 2>/dev/null)" ]; then
+        verdict="keep - uncommitted changes ($(git -C "$w" status --porcelain | wc -l | tr -d ' ') files)"
+      fi
+
+      # Only meaningful while the remote branch still exists. `gh pr merge
+      # --delete-branch` removes it, and `git fetch --prune` then drops the
+      # remote-tracking ref - so a merged worktree legitimately has no upstream,
+      # and the PR state below is what settles it.
+      if [ -z "$verdict" ] && git -C "$w" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+        unpushed=$(git -C "$w" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
+        [ "$unpushed" != 0 ] && verdict="keep - $unpushed unpushed commit(s)"
+      fi
+
+      if [ -z "$verdict" ]; then
+        ahead=$(git -C "$w" rev-list --count origin/main..HEAD 2>/dev/null || echo 0)
+        # mergedAt comes back as UTC while git dates carry a local offset, so
+        # jq's fromdate normalises both sides to epoch seconds before compare.
+        pr=$(gh pr list --head "$branch" --state all --limit 1 --json number,state,mergedAt \
+               --jq '.[0] | "\(.number) \(.state) \(if .mergedAt then (.mergedAt|fromdate) else 0 end)"' 2>/dev/null)
+        read -r pr_num pr_state merged_ct <<< "$pr"
+        case "$pr_state" in
+          MERGED)
+            # Squash-merged commits never land in main verbatim, so "ahead of
+            # main" says nothing here. What would be unrecoverable is a commit
+            # made after the merge, once the remote branch is gone - the one
+            # case worth refusing.
+            head_ct=$(git -C "$w" log -1 --format=%ct HEAD 2>/dev/null || echo 0)
+            if [ "${merged_ct:-0}" != 0 ] && [ "$head_ct" -gt "$merged_ct" ]; then
+              verdict="keep - commit after PR #$pr_num merged"
+            else
+              reason="PR #$pr_num merged"; window=$merged_idle_hours
+            fi ;;
+          OPEN)   verdict="keep - PR #$pr_num still open" ;;
+          CLOSED) verdict="keep - PR #$pr_num closed unmerged" ;;
+          *)      if [ "$ahead" = 0 ]; then reason='no PR, no commits past main'; window=$idle_hours
+                  else verdict="keep - $ahead commit(s), no PR"; fi ;;
+        esac
+      fi
+
+      if [ -z "$verdict" ]; then
+        idle=$(session_age_hours "$w")
+        if [ "$idle" -lt "$window" ]; then
+          verdict="keep - session activity ${idle}h ago (needs ${window}h)"
+        else
+          # One append for every PRUNE verdict - a reported line that never
+          # reaches the array would make --apply quietly do less than it said.
+          if [ "$idle" -ge 99999 ]; then age='no sessions recorded'
+          else age="idle ${idle}h"; fi
+          verdict="PRUNE - $reason, $age"
+          prunable+=("$w|$branch|$pr_state")
+        fi
+      fi
+
+      printf '%-38s %-40s %s\n' "$name" "$branch" "$verdict"
+      ;;
+  esac
+done < <(git worktree list --porcelain; echo)
+
+echo
+if [ ${#prunable[@]} -eq 0 ]; then
+  echo "Nothing to prune."
+  exit 0
+fi
+
+if [ "$apply" = 0 ]; then
+  echo "${#prunable[@]} worktree(s) prunable. Re-run with --apply to remove them."
+  exit 0
+fi
+
+for entry in "${prunable[@]}"; do
+  IFS='|' read -r w branch pr_state <<< "$entry"
+  if git worktree remove "$w"; then
+    echo "removed $(basename "$w")"
+    # Its e2e database goes with it - same name derivation as worktree-setup.sh.
+    pg_bin=$(command -v dropdb >/dev/null && dirname "$(command -v dropdb)" || echo /opt/homebrew/opt/postgresql@17/bin)
+    db="nexus_wt_$(basename "$w" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '_' | cut -c1-50)"
+    [ -x "$pg_bin/dropdb" ] && "$pg_bin/dropdb" --if-exists "$db" 2>/dev/null \
+      && echo "  dropped database $db"
+    # Squash-merged branches never look merged to `git branch -d`, so -D is the
+    # only option - gated on the PR state, which is the authoritative signal.
+    if [ "$pr_state" = MERGED ] && [ "$branch" != main ]; then
+      git branch -D "$branch" >/dev/null 2>&1 && echo "  deleted branch $branch"
+    fi
+  else
+    echo "SKIPPED $(basename "$w") - git refused the removal" >&2
+  fi
+done
+
+git worktree prune

--- a/apps/web/e2e/global.setup.ts
+++ b/apps/web/e2e/global.setup.ts
@@ -8,8 +8,24 @@ import {
     promoteToAdmin,
     authenticateAndSaveState,
 } from './helpers/auth';
-import { findUserByEmail, ensureTrialSubscription } from '@nexus/db/test-db';
+import {
+    findUserByEmail,
+    ensureTrialSubscription,
+    deleteUserData,
+} from '@nexus/db/test-db';
 import { createTestDb } from './helpers/connection';
+
+/**
+ * Clear the shared users' domain data at the start of a run, so leftovers from
+ * the previous run can't produce strict-mode violations ("resolved to 3
+ * elements") in specs that assert on a filename.
+ *
+ * Only when this worktree has its own database (E2E_DATABASE_URL, see
+ * .claude/hooks/worktree-setup.sh). On the shared dev DB a wipe would delete
+ * rows out from under another worktree's in-flight run — the exact failure this
+ * whole change exists to remove.
+ */
+const OWNS_DB = !!process.env.E2E_DATABASE_URL;
 
 // The setup project runs outside the fixture chain, so it owns its own
 // connection (created + disposed per setup test) rather than the worker `db`
@@ -26,6 +42,7 @@ setup('create and authenticate admin user', async ({ request }) => {
                 `admin user not found after createUser: ${ADMIN_USER.email}`
             );
         }
+        if (OWNS_DB) await deleteUserData(db, user.id);
         await ensureTrialSubscription(db, user.id);
         await authenticateAndSaveState(request, ADMIN_USER, ADMIN_STATE_PATH);
     } finally {
@@ -43,6 +60,7 @@ setup('create and authenticate regular user', async ({ request }) => {
                 `regular user not found after createUser: ${REGULAR_USER.email}`
             );
         }
+        if (OWNS_DB) await deleteUserData(db, user.id);
         await ensureTrialSubscription(db, user.id);
         await authenticateAndSaveState(request, REGULAR_USER, USER_STATE_PATH);
     } finally {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,6 +6,16 @@ import { WEBSERVER_LOG } from './e2e/helpers/webserver-log';
 
 const BASE_URL = E2E_BASE_URL;
 
+// Per-worktree e2e database, set by .claude/hooks/worktree-setup.sh. Assigning
+// it here — before any test module or the webServer child loads — is what makes
+// it stick everywhere: e2e/helpers/connection.ts reads process.env.DATABASE_URL,
+// and dotenv/Next both refuse to override a variable that is already set, so
+// .env.local's shared Supabase URL loses to this. Unset (CI, main checkout) is
+// the old behaviour: everything keeps using DATABASE_URL as before.
+if (process.env.E2E_DATABASE_URL) {
+    process.env.DATABASE_URL = process.env.E2E_DATABASE_URL;
+}
+
 const adminChrome = {
     ...devices['Desktop Chrome'],
     storageState: 'e2e/.auth/admin.json',
@@ -157,7 +167,15 @@ export default defineConfig({
         // S3_DERIVED_BUCKET is synthetic: presigning is local HMAC (no AWS
         // round-trip), and the thumbnails spec fulfills this bucket's image
         // requests via page.route — no real derived bucket needed in e2e.
-        env: { E2E: '1', S3_DERIVED_BUCKET: 'e2e-derived-bucket' },
+        // DATABASE_URL is passed explicitly rather than relying on inheritance,
+        // so the server is provably on the same database the fixtures seed.
+        env: {
+            E2E: '1',
+            S3_DERIVED_BUCKET: 'e2e-derived-bucket',
+            ...(process.env.DATABASE_URL
+                ? { DATABASE_URL: process.env.DATABASE_URL }
+                : {}),
+        },
         stdout: 'pipe',
         stderr: 'pipe',
     },


### PR DESCRIPTION
Every worktree shared one Supabase dev DB (byte-identical `DATABASE_URL`) while the e2e fixtures use fixed identities (`admin-e2e@test.local`, `e2e-test-file-1.txt`). Two worktrees testing at once collided: sign-up 422s, duplicate-key inserts, and `strict mode violation: ... resolved to 3 elements` from the other run's rows. Across 19 sessions on Aug 12–13 that produced 20 failing-spec occurrences over 72 playwright invocations, mostly reruns. The app server was already isolated per worktree by `$PORT`; the data was not.

## Changes

- `worktree-setup.sh` creates and migrates `nexus_wt_<name>` in local postgres, exports `E2E_DATABASE_URL` + `DB_ENV`, and copies a missing `.env.local` from the main checkout (that omission was failing `pnpm check` in `lib/env`)
- `playwright.config.ts` assigns it over `DATABASE_URL` before any test module or the webServer child loads, and passes it explicitly to `webServer.env`
- `global.setup.ts` clears the shared users' data per run, gated on the worktree owning its DB — on the shared DB that wipe would break another run
- `.claude/scripts/prune-worktrees.sh`: teardown gate (clean + pushed + merged + idle, split idle window) that drops the database and branch with the worktree

Scoped to e2e deliberately: `pnpm dev` still points at the shared dev DB. Unset `E2E_DATABASE_URL` (CI) is the existing behaviour.

## Verification

- `pnpm check` green
- smoke 47/47 against the local DB, ~25s vs 33–45s against Supabase
- two worktrees running smoke simultaneously: 47/47 and 47/47, which had never passed before
- teardown verified end to end on throwaway worktrees: worktree removed, database dropped, branch deleted

Requires `brew install postgresql@17` locally; without it the hook warns and e2e falls back to the shared DB.

No-Issue: tooling fix found while auditing session health across worktrees