### PR TITLE
fix: clean up abandoned single-part uploads (#330)

### DIFF
--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/client';
+import { toastContext } from '@/lib/trpc/error-link';
 import { useInvalidateFileList } from '@/lib/hooks/useInvalidateFileList';
 import { xhrPut } from '@/lib/http/xhr';
 import { retryAsync } from '@/lib/async/retry';
@@ -173,8 +174,18 @@ export function useUpload() {
             retry: CONFIRM_RETRIES,
         })
     );
+    // Both cleanup mutations fire and forget on a row the user already
+    // dismissed, so a failure has nothing to tell them — the nightly
+    // stale-`uploading` check is the backstop. Hence the shared skipToast.
     const multipartAbortMutation = useMutation(
-        trpc.files.multipart.abort.mutationOptions()
+        trpc.files.multipart.abort.mutationOptions({
+            trpc: toastContext({ skipToast: true }),
+        })
+    );
+    const abandonUploadMutation = useMutation(
+        trpc.files.abandonUpload.mutationOptions({
+            trpc: toastContext({ skipToast: true }),
+        })
     );
     const multipartListPartsMutation = useMutation(
         trpc.files.multipart.listParts.mutationOptions()
@@ -212,6 +223,16 @@ export function useUpload() {
             // init (mirrors the multipart engine).
             let fileId = uploadFile.fileId;
             try {
+                // Every restart of this engine (retry, or auto-resume after a
+                // network drop) mints a fresh fileId, row, and s3Key, so the
+                // attempt being replaced has to be released here or it strands
+                // as a hidden `uploading` row with billed bytes behind it
+                // (#330). Multipart is the opposite — it resumes the same
+                // uploadId — which is why this lives in the single engine.
+                if (fileId) {
+                    abandonUploadMutation.mutate({ fileId });
+                }
+
                 const init = await uploadMutation.mutateAsync({
                     name: file.name,
                     sizeBytes: file.size,
@@ -269,7 +290,13 @@ export function useUpload() {
                 });
             }
         },
-        [uploadMutation, confirmMutation, updateFile, invalidateFileList]
+        [
+            uploadMutation,
+            confirmMutation,
+            abandonUploadMutation,
+            updateFile,
+            invalidateFileList,
+        ]
     );
 
     const uploadMultipartFile = useCallback(
@@ -748,36 +775,55 @@ export function useUpload() {
         });
     }, []);
 
-    const removeFile = useCallback((id: string) => {
-        const file = filesRef.current.find((f) => f.id === id);
-        file?.abortController?.abort(CANCEL);
-        setFiles((prev) => prev.filter((f) => f.id !== id));
-    }, []);
-
-    const clearFiles = useCallback(() => {
-        for (const file of filesRef.current) {
-            file.abortController?.abort(CANCEL);
-        }
-        setFiles([]);
-    }, []);
-
-    const cancelFile = useCallback(
-        (id: string) => {
-            const file = filesRef.current.find((f) => f.id === id);
-            file?.abortController?.abort(CANCEL);
-            // Abort the S3 multipart session and drop the persisted state so a
-            // cancelled upload doesn't linger as resumable.
-            if (file?.fileId && file?.uploadId) {
+    // Release whatever the server already minted for a row we're dropping: the
+    // S3 multipart session when there is one (plus its persisted state, so a
+    // cancelled upload doesn't linger as resumable), otherwise the plain object
+    // at the row's recorded key. A row that never reached the server has no
+    // fileId and nothing to release. Fire-and-forget — the row leaves the UI
+    // either way, and the nightly stale-upload check backs this up.
+    const abandonServerUpload = useCallback(
+        (file: InternalUploadFile | undefined) => {
+            // Skipping `complete` rows is an optimization, not the safety net:
+            // clear-all sweeps confirmed rows too, and there's no point asking
+            // the server to release an upload the UI already knows finished.
+            // Refusing to touch a confirmed file is the server's job, and
+            // `releaseUpload` does it for both engines.
+            if (!file?.fileId || file.status === 'complete') return;
+            if (file.uploadId) {
                 multipartAbortMutation.mutate({
                     fileId: file.fileId,
                     uploadId: file.uploadId,
                 });
                 void deleteUpload(file.fileId);
+                return;
             }
+            abandonUploadMutation.mutate({ fileId: file.fileId });
+        },
+        [multipartAbortMutation, abandonUploadMutation]
+    );
+
+    // Drop a row and release anything the server holds for it. Exposed under
+    // two names because the UI offers two affordances — Remove on a queued row,
+    // Cancel on one in flight — but there's a single operation behind them.
+    const dropRow = useCallback(
+        (id: string) => {
+            const file = filesRef.current.find((f) => f.id === id);
+            file?.abortController?.abort(CANCEL);
+            abandonServerUpload(file);
             setFiles((prev) => prev.filter((f) => f.id !== id));
         },
-        [multipartAbortMutation]
+        [abandonServerUpload]
     );
+    const removeFile = dropRow;
+    const cancelFile = dropRow;
+
+    const clearFiles = useCallback(() => {
+        for (const file of filesRef.current) {
+            file.abortController?.abort(CANCEL);
+            abandonServerUpload(file);
+        }
+        setFiles([]);
+    }, [abandonServerUpload]);
 
     const retryFile = useCallback(
         (id: string) => {

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -387,6 +387,12 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/upload'],
     },
     {
+        id: 'upload-cancel-cleanup',
+        title: 'Cancelling an in-flight upload strands no uploading row',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
         id: 'upload-multipart',
         title: 'Multipart upload for files >100MB',
         area: 'upload',

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -1,12 +1,17 @@
 /**
  * Upload queue interactions, run as a dedicated user (provisioned by the
- * `dedicatedUserConfig` fixture). All client-side — the one test that reaches
- * the server (`files.upload`) intercepts and aborts the mutation, so no DB rows
- * or S3 objects are created. The real end-to-end upload lives in the validate
+ * `dedicatedUserConfig` fixture). Mostly client-side: the retry test intercepts
+ * and aborts `files.upload`, so it creates nothing.
+ *
+ * The cancel-cleanup test is the exception — it lets `files.upload` through to
+ * get a real `uploading` row, which is the thing the cleanup has to find. It
+ * stalls the presigned PUT instead, so no bytes ever reach S3, and clears its
+ * rows on the way out. The real end-to-end upload still lives in the validate
  * tier (upload-batches-and-quota.spec.ts).
  */
 import { test, expect } from '../fixtures';
 import { type TestUser } from '../helpers/auth';
+import { deleteUserData } from '@nexus/db/test-db';
 import { interceptTrpcCalls } from '../helpers/trpc';
 import { seedResumableUpload } from '../helpers/uploadStore';
 
@@ -31,6 +36,14 @@ const FILE_B = {
 
 test.describe.configure({ mode: 'serial' });
 test.use({ dedicatedUserConfig: { user: UPLOAD_USER, statePath: STATE_PATH } });
+
+// Only the cancel-cleanup test writes rows, but the teardown belongs here
+// rather than at the end of that test body: it asserts on an exact status
+// array, so a failure that skipped cleanup would leave rows behind and fail
+// every later run of this serial spec for the wrong reason.
+test.afterEach(async ({ db, seedUserId }) => {
+    await deleteUserData(db, seedUserId);
+});
 
 test(
     'adding files builds the queue with names, sizes, and a remove control',
@@ -173,5 +186,41 @@ test(
         await expect(
             page.getByRole('button', { name: 'Retry upload' })
         ).toBeVisible({ timeout: 15_000 });
+    }
+);
+
+test(
+    'cancelling an in-flight upload strands no uploading row',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-cancel-cleanup'] },
+    async ({ page, db, seedUserId }) => {
+        // Stall the presigned PUT rather than failing it: the upload stays in
+        // flight (so Cancel is the live affordance) and no object is ever
+        // written. Deliberately never settled — teardown discards it.
+        await page.route(/amazonaws\.com/, () => {});
+
+        const readStatuses = async () =>
+            (
+                await db.query.files.findMany({
+                    where: (f, { eq }) => eq(f.userId, seedUserId),
+                })
+            ).map((f) => f.status);
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', [FILE_A]);
+        await page.getByRole('button', { name: 'Upload 1 file' }).click();
+
+        // Cancel only cleans up what `files.upload` already minted, so wait for
+        // the row before clicking — otherwise the test passes on a no-op.
+        await expect
+            .poll(readStatuses, { timeout: 15_000 })
+            .toEqual(['uploading']);
+
+        await page.getByRole('button', { name: 'Cancel upload' }).click();
+
+        // The whole point of #330: no row left hidden in `uploading`, where no
+        // list would ever show it and its S3 bytes would stay billed.
+        await expect
+            .poll(readStatuses, { timeout: 15_000 })
+            .toEqual(['deleted']);
     }
 );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,8 @@
         "backfill:storage-tier": "tsx --env-file=.env.local scripts/backfill-storage-tier.ts",
         "check:s3-event-health": "tsx --env-file=.env.local scripts/check-s3-event-health.ts",
         "check:stripe-config": "tsx --env-file=.env.local scripts/check-stripe-config.ts",
-        "check:vercel-env-parity": "tsx --env-file=.env.local scripts/check-vercel-env-parity.ts"
+        "check:vercel-env-parity": "tsx --env-file=.env.local scripts/check-vercel-env-parity.ts",
+        "reap:stale-uploads": "tsx --env-file=.env.local scripts/reap-stale-uploads.ts"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.975.0",

--- a/apps/web/scripts/check-s3-event-health.ts
+++ b/apps/web/scripts/check-s3-event-health.ts
@@ -7,6 +7,9 @@
  *     ObjectRestore:Post deliveries don't trip this)
  *   - any retrieval has sat in 'pending'/'in_progress' for over 48 hours
  *     (Deep Archive bulk restores complete within 48h — older is stuck)
+ *   - any file has sat in 'uploading' for over 24 hours (#330): the client
+ *     abandoned it without calling cleanup, so the row is invisible to every
+ *     list and whatever bytes reached S3 are billed but untracked
  *
  * Tier drift is covered separately by `backfill:storage-tier --check`; the
  * two together are the post-deploy watch for #278 (see #285).
@@ -25,6 +28,7 @@ import { and, count, eq, gte, inArray, lt } from 'drizzle-orm';
 import { alerts, getWorkflowRunUrl } from '@/lib/alerts';
 import { db } from '@/server/db';
 import { s3RestoreService } from '@/server/services/s3-restore';
+import { createFileRepo, STALE_UPLOAD_HOURS } from '@nexus/db/repo/files';
 import { retrievals, webhookEvents } from '@nexus/db/schema';
 
 const FAILED_WEBHOOK_WINDOW_DAYS = 7;
@@ -104,6 +108,24 @@ async function main(): Promise<void> {
     }
     if (stuckRetrievals.length > 0) hasFailure = true;
 
+    // Same query and threshold `reap:stale-uploads` acts on — this leg reports
+    // exactly what that script would clear.
+    const staleUploadsBefore = new Date(
+        Date.now() - STALE_UPLOAD_HOURS * 60 * 60 * 1000
+    );
+    const staleUploads =
+        await createFileRepo(db).findStaleUploads(staleUploadsBefore);
+
+    console.log(
+        `Uploads stuck >${STALE_UPLOAD_HOURS}h:                   ${staleUploads.length}`
+    );
+    for (const file of staleUploads) {
+        console.log(
+            `  ✗ ${file.createdAt.toISOString()}  ${file.size}B  file=${file.id} user=${file.userId} key=${file.s3Key}`
+        );
+    }
+    if (staleUploads.length > 0) hasFailure = true;
+
     if (since) {
         const [handled] = await db
             .select({ count: count() })
@@ -136,7 +158,7 @@ async function main(): Promise<void> {
         await alerts.send({
             severity: 'error',
             title: 'S3 event pipeline health check failed',
-            message: `${failedWebhooks.length} failed/unhandled SNS webhook event(s) in the last ${FAILED_WEBHOOK_WINDOW_DAYS}d; ${stuckRetrievals.length} retrieval(s) stuck >${STUCK_RETRIEVAL_HOURS}h.`,
+            message: `${failedWebhooks.length} failed/unhandled SNS webhook event(s) in the last ${FAILED_WEBHOOK_WINDOW_DAYS}d; ${stuckRetrievals.length} retrieval(s) stuck >${STUCK_RETRIEVAL_HOURS}h; ${staleUploads.length} upload(s) stuck >${STALE_UPLOAD_HOURS}h.`,
             context: {
                 source: 'check-s3-event-health',
                 ...(runUrl && { workflowRun: runUrl }),

--- a/apps/web/scripts/reap-stale-uploads.ts
+++ b/apps/web/scripts/reap-stale-uploads.ts
@@ -1,0 +1,84 @@
+/**
+ * Release uploads abandoned mid-flight: delete the object at each row's
+ * recorded key and close the row.
+ *
+ * The client cleans up after itself on cancel/clear/retry since #330, but rows
+ * stranded before that fix — and anything a browser that never came back
+ * leaves behind — need a sweep. An `uploading` row is hidden from every list
+ * and every usage total, so whatever bytes reached S3 are billed and invisible.
+ * The nightly `check:s3-event-health` flags them off the same query and
+ * threshold; this clears them.
+ *
+ * Nothing to decrement: usage increments at confirm, so an `uploading` row was
+ * never counted. DeleteObject is idempotent, so a row whose PUT never landed
+ * costs one no-op call.
+ *
+ * Idempotent: a re-run after a clean apply finds nothing.
+ *
+ * Usage:
+ *   pnpm -F web reap:stale-uploads          # dry run (default)
+ *   pnpm -F web reap:stale-uploads --apply  # delete objects + close rows
+ */
+
+import { db } from '@/server/db';
+import { fileService } from '@/server/services/files';
+import { createFileRepo, STALE_UPLOAD_HOURS } from '@nexus/db/repo/files';
+
+async function main(): Promise<void> {
+    const shouldApply = process.argv.includes('--apply');
+
+    const staleBefore = new Date(
+        Date.now() - STALE_UPLOAD_HOURS * 60 * 60 * 1000
+    );
+    const stale = await createFileRepo(db).findStaleUploads(staleBefore);
+
+    const totalBytes = stale.reduce((sum, f) => sum + f.size, 0);
+    console.log(`Uploads stuck >${STALE_UPLOAD_HOURS}h:  ${stale.length}`);
+    console.log(`Bytes claimed by them:  ${totalBytes}`);
+    for (const file of stale) {
+        console.log(
+            `  ~ ${file.createdAt.toISOString()}  ${file.size}B  file=${file.id} user=${file.userId} key=${file.s3Key}`
+        );
+    }
+
+    if (stale.length === 0) {
+        console.log('\nNothing to reap.');
+        return;
+    }
+
+    if (!shouldApply) {
+        console.log(
+            '\nDry run (default). Re-run with --apply to delete the objects and close the rows.'
+        );
+        return;
+    }
+
+    console.log('\nReaping…');
+    let ok = 0;
+    let failed = 0;
+    for (const file of stale) {
+        try {
+            // The same procedure the client calls on cancel, scoped to the
+            // row's own owner — one definition of "release an upload", and it
+            // carries the guard that refuses to touch a confirmed file.
+            await fileService.abandonUpload(db, file.userId, file.id);
+            console.log(`  ✓ ${file.s3Key}`);
+            ok += 1;
+        } catch (err) {
+            console.error(`  ✗ ${file.s3Key} —`, err);
+            failed += 1;
+        }
+    }
+
+    console.log(`\nDone. ${ok} reaped, ${failed} failed.`);
+    if (failed > 0) process.exitCode = 1;
+}
+
+main()
+    .catch((err) => {
+        console.error('Reap aborted:', err);
+        process.exitCode = 1;
+    })
+    // The pooled connection keeps the event loop alive; close it so the
+    // script exits instead of hanging after the summary prints.
+    .finally(() => db.$client.end());

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -874,6 +874,24 @@ describe('files service', () => {
             );
         });
 
+        // Clear-all sweeps completed rows too, so this has to be safe against a
+        // fileId whose upload already confirmed and was counted.
+        it('is a no-op on a file that already confirmed', async () => {
+            const availableFile = createFileFixture({ status: 'available' });
+            mocks.files.findFirst.mockResolvedValue(availableFile);
+            const abort = vi.spyOn(mockS3.multipart, 'abort');
+
+            await fileService.abortMultipartUpload(
+                db,
+                TEST_USER_ID,
+                availableFile.id,
+                'some-upload-id'
+            );
+
+            expect(abort).not.toHaveBeenCalled();
+            expect(mocks.update).not.toHaveBeenCalled();
+        });
+
         it('throws NotFoundError when file does not exist', async () => {
             mocks.files.findFirst.mockResolvedValue(undefined);
 
@@ -884,6 +902,86 @@ describe('files service', () => {
                     'nonexistent',
                     'some-upload-id'
                 )
+            ).rejects.toThrow(NotFoundError);
+        });
+    });
+
+    describe('abandonUpload', () => {
+        it('deletes the object at the recorded key and soft-deletes the row', async () => {
+            const uploadingFile = createFileFixture({ status: 'uploading' });
+            mocks.files.findFirst.mockResolvedValue(uploadingFile);
+            mocks.returning.mockResolvedValue([
+                { ...uploadingFile, status: 'deleted' },
+            ]);
+            const remove = vi.spyOn(mockS3.objects, 'remove');
+
+            await fileService.abandonUpload(db, TEST_USER_ID, uploadingFile.id);
+
+            // The row's own s3Key is the whole input — no uploadId involved,
+            // which is what lets this serve single-part uploads.
+            expect(remove).toHaveBeenCalledWith(uploadingFile.s3Key);
+            expect(mocks.set).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    status: 'deleted',
+                    deletedAt: expect.any(Date),
+                })
+            );
+        });
+
+        // An abandoned upload was never counted (usage increments at confirm),
+        // so releasing it must not move the counter.
+        it('does not touch storage usage', async () => {
+            const uploadingFile = createFileFixture({ status: 'uploading' });
+            mocks.files.findFirst.mockResolvedValue(uploadingFile);
+            mocks.returning.mockResolvedValue([
+                { ...uploadingFile, status: 'deleted' },
+            ]);
+
+            await fileService.abandonUpload(db, TEST_USER_ID, uploadingFile.id);
+
+            // Only the file row's update — no usage decrement or upsert.
+            expect(mocks.update).toHaveBeenCalledTimes(1);
+            expect(mocks.onConflictDoUpdate).not.toHaveBeenCalled();
+        });
+
+        // The dangerous race: a cancel click landing just after the confirm it
+        // raced must not delete the bytes of a file the user now owns.
+        it('is a no-op on a file that already confirmed', async () => {
+            const availableFile = createFileFixture({ status: 'available' });
+            mocks.files.findFirst.mockResolvedValue(availableFile);
+            const remove = vi.spyOn(mockS3.objects, 'remove');
+
+            await fileService.abandonUpload(db, TEST_USER_ID, availableFile.id);
+
+            expect(remove).not.toHaveBeenCalled();
+            expect(mocks.update).not.toHaveBeenCalled();
+        });
+
+        it('is idempotent — a second abandon deletes nothing', async () => {
+            const deletedFile = createFileFixture({ status: 'deleted' });
+            mocks.files.findFirst.mockResolvedValue(deletedFile);
+            const remove = vi.spyOn(mockS3.objects, 'remove');
+
+            await fileService.abandonUpload(db, TEST_USER_ID, deletedFile.id);
+
+            expect(remove).not.toHaveBeenCalled();
+            expect(mocks.update).not.toHaveBeenCalled();
+        });
+
+        it('throws NotFoundError when file does not exist', async () => {
+            mocks.files.findFirst.mockResolvedValue(undefined);
+
+            await expect(
+                fileService.abandonUpload(db, TEST_USER_ID, 'nonexistent')
+            ).rejects.toThrow(NotFoundError);
+        });
+
+        it('throws NotFoundError when file belongs to a different user', async () => {
+            // findByUserAndId scopes by both ids, so a wrong user returns undefined
+            mocks.files.findFirst.mockResolvedValue(undefined);
+
+            await expect(
+                fileService.abandonUpload(db, 'different-user', 'some-file-id')
             ).rejects.toThrow(NotFoundError);
         });
     });

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -390,26 +390,59 @@ async function signMultipartParts(
     return { parts, expiresAt };
 }
 
-async function abortMultipartUpload(
+/**
+ * Give up on an upload: hand its S3 side to `release`, then close the row.
+ * The two engines differ only in that release step, so the parts that must not
+ * drift between them live here.
+ *
+ * The status guard is the load-bearing line. A row past `uploading` has
+ * confirmed and been counted, so releasing it would delete the bytes of a
+ * file the user now owns while leaving its usage incremented — and a cancel
+ * click really can land just after the confirm it raced. Doing nothing there
+ * also makes a repeated release idempotent.
+ *
+ * No usage decrement anywhere: an upload that never confirmed was never
+ * counted (`confirmUpload` is what increments).
+ */
+async function releaseUpload(
     db: DB,
     userId: string,
     fileId: string,
-    uploadId: string
+    release: (file: File) => Promise<void>
 ): Promise<void> {
     const fileRepo = createFileRepo(db);
     const file = await fileRepo.findByUserAndId(userId, fileId);
     if (!file) {
         throw new NotFoundError('File', fileId);
     }
+    if (file.status !== 'uploading') return;
 
-    await s3.multipart.abort(file.s3Key, uploadId);
+    await release(file);
 
-    // Aborted uploads never made it to `available`, so usage was never
-    // incremented — no decrement needed here.
-    await fileRepo.update(fileId, {
-        status: 'deleted',
-        deletedAt: new Date(),
-    });
+    await fileRepo.softDelete(fileId);
+}
+
+function abortMultipartUpload(
+    db: DB,
+    userId: string,
+    fileId: string,
+    uploadId: string
+): Promise<void> {
+    return releaseUpload(db, userId, fileId, (file) =>
+        s3.multipart.abort(file.s3Key, uploadId)
+    );
+}
+
+// Release an upload the client gave up on — cancelled, cleared, or replaced by
+// a retry. Takes no uploadId, unlike `abortMultipartUpload`: `initiateUpload`
+// records `s3Key` on the row at insert, which is all a DeleteObject needs, so
+// this serves the single-part engine (which never mints an uploadId) too.
+// Without it a cancelled single-part upload leaves an `uploading` row that no
+// list ever shows and bytes in S3 that nothing accounts for (#330).
+function abandonUpload(db: DB, userId: string, fileId: string): Promise<void> {
+    return releaseUpload(db, userId, fileId, (file) =>
+        s3.objects.remove(file.s3Key)
+    );
 }
 
 const THUMBNAIL_URL_EXPIRY_SECONDS = 3600; // 1 hour
@@ -506,6 +539,7 @@ export const fileService = {
     listMultipartParts,
     signMultipartParts,
     abortMultipartUpload,
+    abandonUpload,
     deleteUserFile,
     getThumbnailUrls,
 } as const;

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -116,6 +116,17 @@ export const filesRouter = router({
             );
         }),
 
+    // Top-level, not under `multipart`: it serves both engines.
+    abandonUpload: protectedProcedure
+        .input(z.object({ fileId: z.string().uuid() }))
+        .mutation(({ ctx, input }) => {
+            return fileService.abandonUpload(
+                ctx.db,
+                ctx.session.user.id,
+                input.fileId
+            );
+        }),
+
     delete: protectedProcedure
         .input(z.object({ id: z.string().uuid() }))
         .mutation(({ ctx, input }) => {

--- a/packages/db/src/repositories/files.ts
+++ b/packages/db/src/repositories/files.ts
@@ -8,6 +8,7 @@ import {
     inArray,
     ne,
     gte,
+    lt,
     ilike,
 } from 'drizzle-orm';
 import type { DB } from '../connection';
@@ -161,6 +162,35 @@ function findByUserAndBatch(
  */
 export const HIDDEN_STATUSES: (typeof schema.files.status.enumValues)[number][] =
     ['uploading', 'deleted'];
+
+/**
+ * How long a row may sit in `uploading` before it counts as abandoned. Far
+ * past both presigned expiries (15 min single-part, 1 h per multipart part),
+ * but loose enough that a multipart upload resumed across sessions isn't
+ * called stale mid-flight.
+ *
+ * Shared by the nightly check that flags these and the script that reaps them
+ * (#330) — one threshold, so the two can't drift apart.
+ */
+export const STALE_UPLOAD_HOURS = 24;
+
+/**
+ * Uploads nothing is going to finish: still `uploading` well past any
+ * presigned URL's life. `HIDDEN_STATUSES` keeps them out of every list and
+ * every usage total, so they strand invisibly with their S3 bytes billed —
+ * which is exactly why they need sweeping (#330).
+ *
+ * Filters on `createdAt`, not `updatedAt`: nothing touches an abandoned row
+ * after the insert, so the two are equal anyway.
+ */
+function findStaleUploads(db: DB, olderThan: Date): Promise<File[]> {
+    return db.query.files.findMany({
+        where: and(
+            eq(schema.files.status, 'uploading'),
+            lt(schema.files.createdAt, olderThan)
+        ),
+    });
+}
 
 // Escape LIKE/ILIKE wildcards so a search for "100%" or "foo_bar" is treated
 // as a literal substring, not a pattern. Postgres' default escape char is `\`.
@@ -541,6 +571,7 @@ export const createFileRepo = createRepository({
     findByUserGroupedByBatch,
     countByUser,
     countStatusesByUser,
+    findStaleUploads,
     sumStorageByUser,
     insert,
     update,


### PR DESCRIPTION
## Summary

Cancelling or abandoning a single-part upload left an `uploading` row that no
list ever shows, plus whatever bytes had already reached S3. `cancelFile` only
called server cleanup when `file.uploadId` was set, and only multipart sets it.

The fix is a cleanup procedure keyed on `fileId` alone. `initiateUpload` records
`s3Key` on the row at insert, which is all a `DeleteObject` needs, so the
single-part engine can release its own uploads without ever minting an
`uploadId`. Both engines now go through one `releaseUpload` helper, so the guard
that refuses to touch a confirmed file has a single definition.

Retry cleanup went inside `uploadSingleFile` rather than `retryFile`, because
that is where the replacement `fileId` is actually minted — which also covers
auto-resume after a network drop, a path with the identical leak.

Closes #330

## Changes

- `fileService.abandonUpload` + the `files.abandonUpload` procedure: owner-scoped,
  deletes the object at the recorded key, flips the row to `deleted`, no usage
  decrement (an upload that never confirmed was never counted).
- `releaseUpload` extracted; `abortMultipartUpload` now sits on top of it and
  uses the repo's existing `softDelete`.
- Client: one `abandonServerUpload` helper wired into cancel, remove, and
  clear-all; single-part restarts release the attempt they replace.
- Nightly `check:s3-event-health` gains a stale-`uploading` leg at 24h, folded
  into the existing `alerts.send`. No workflow change needed — the leg is
  DB-only, so it works on both matrix legs.
- `STALE_UPLOAD_HOURS` + `findStaleUploads` live in the files repository, shared
  by the check and the reap script so the two can't drift.
- New `pnpm -F web reap:stale-uploads` (dry run by default) for rows stranded
  before this fix.
- Coverage: 6 service unit tests and a flows-tier e2e that cancels a real
  in-flight upload and asserts the row goes `uploading` -> `deleted`.

## Beyond the acceptance criteria

Both approved during the work:

- **The reap script and the dev sweep.** The new leg found 35 stranded rows on
  dev going back to 2026-01-29, claiming 1.55 GB (mostly one abandoned 1.5 GB
  .dmg). Already reaped — dev now reports zero, so the nightly won't go red on
  its first run. **Prod has not been swept**: no prod DB URL locally, and local
  AWS credentials are dev-scoped, so a sweep from here would delete against the
  wrong bucket. The nightly's prod leg will report whether anything is there.
- **A status guard on `abortMultipartUpload`.** It previously had none, so
  calling it with a confirmed file's id would soft-delete the row while leaving
  its bytes in the usage total. Not reachable before this change, but wiring
  clear-all would have reached it.

## Known residuals

Neither is introduced here; both are caught by the nightly leg.

- Cancelling during the `files.upload` round-trip (before the row's `fileId`
  comes back) has nothing to release yet.
- A `DeleteObject` can in principle lose the race with a PUT already in flight.

## Test Plan

- [x] `pnpm check` — 10/10
- [x] `pnpm -F web test:e2e:flows` — 23/23 (includes the new cancel-cleanup spec)
- [x] `pnpm -F web test:e2e:smoke` — 47/47
- [x] `pnpm -F web e2e:coverage --check` — 17/17 pages, 73/73 use-cases
- [x] `pnpm -F web check:s3-event-health` against dev — found 35, now reports 0
- [x] `pnpm -F web reap:stale-uploads --apply` against dev — 35 reaped, 0 failed
- [ ] After merge, confirm the first nightly run is green on both dev and prod
