### PR TITLE
fix: recover stranded webhook events and retry transient failures (#331)

### DIFF
--- a/apps/web/app/api/webhooks/s3-restore/route.test.ts
+++ b/apps/web/app/api/webhooks/s3-restore/route.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createWebhookEventFixture } from '@nexus/db/testing';
+
+const hoisted = await vi.hoisted(async () => {
+    const { createMockLogger } = await import('@/server/lib/logger/testing');
+    const { createMockDb } = await import('@nexus/db/testing');
+    return {
+        logger: createMockLogger(),
+        mockDb: createMockDb(),
+        dispatch: vi.fn(),
+        alertsSend: vi.fn(),
+        verifySnsMessage: vi.fn(),
+    };
+});
+
+vi.mock('@/server/lib/logger', () => ({ logger: hoisted.logger }));
+
+vi.mock('@/lib/alerts', () => ({
+    alerts: { send: hoisted.alertsSend },
+}));
+
+vi.mock('@/lib/sns/webhooks', () => ({
+    verifySnsMessage: hoisted.verifySnsMessage,
+}));
+
+// The route imports `db` directly, not through a factory. We point it at the
+// shared mock db so test setup can drive it via `mocks.webhookEvents.findFirst`.
+vi.mock('@/server/db', () => ({ db: hoisted.mockDb.db }));
+
+vi.mock('@/server/services/s3-restore', () => ({
+    s3RestoreService: {
+        dispatch: hoisted.dispatch,
+        expectedUnhandledEvents: new Set(['ObjectRestore:Post']),
+    },
+}));
+
+import { POST } from './route';
+
+const dispatch = hoisted.dispatch;
+const mocks = hoisted.mockDb.mocks;
+
+const MESSAGE_ID = 'sns-msg-123';
+const EVENT_NAME = 'ObjectRestore:Completed';
+
+function makeNotification(eventName = EVENT_NAME): Record<string, unknown> {
+    return {
+        Type: 'Notification',
+        MessageId: MESSAGE_ID,
+        TopicArn: 'arn:aws:sns:us-east-1:123456789:nexus-s3-events-test',
+        Message: JSON.stringify({
+            Records: [
+                {
+                    eventName,
+                    s3: {
+                        bucket: { name: 'nexus-storage-files-dev' },
+                        object: { key: 'users/u1/file.cr2' },
+                    },
+                },
+            ],
+        }),
+    };
+}
+
+function makeRequest(body: object): NextRequest {
+    return new NextRequest('http://localhost/api/webhooks/s3-restore', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+function snsEventFixture(status: 'received' | 'processed' | 'failed') {
+    return createWebhookEventFixture({
+        source: 'sns',
+        externalId: MESSAGE_ID,
+        eventType: EVENT_NAME,
+        status,
+    });
+}
+
+describe('POST /api/webhooks/s3-restore', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Local dev bypasses signature verification, which keeps these tests
+        // about dispatch and recovery rather than SNS crypto.
+        vi.stubEnv('NODE_ENV', 'development');
+        // Reset shared mock state since vi.clearAllMocks does not reset
+        // mockResolvedValue defaults set in createMockDb (e.g. returning -> []).
+        mocks.returning.mockResolvedValue([snsEventFixture('received')]);
+        mocks.webhookEvents.findFirst.mockResolvedValue(undefined);
+        dispatch.mockResolvedValue(true);
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+    });
+
+    describe('idempotency', () => {
+        it('skips dispatch when the event was already processed', async () => {
+            mocks.webhookEvents.findFirst.mockResolvedValue(
+                snsEventFixture('processed')
+            );
+
+            const response = await POST(makeRequest(makeNotification()));
+
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({
+                received: true,
+                duplicate: true,
+            });
+            expect(dispatch).not.toHaveBeenCalled();
+            expect(mocks.insert).not.toHaveBeenCalled();
+        });
+
+        it('re-drives a row a prior crash stranded at received', async () => {
+            // The strand this issue is about: the route inserts at 'received'
+            // and only moves the row after dispatch, so a crash in between
+            // used to make the event permanently undeliverable (#331).
+            mocks.webhookEvents.findFirst.mockResolvedValue(
+                snsEventFixture('received')
+            );
+
+            const response = await POST(makeRequest(makeNotification()));
+
+            expect(response.status).toBe(200);
+            expect(dispatch).toHaveBeenCalled();
+            expect(mocks.insert).not.toHaveBeenCalled();
+            expect(mocks.set).toHaveBeenCalledWith({ status: 'processed' });
+        });
+
+        it('re-drives a row a prior attempt marked failed', async () => {
+            mocks.webhookEvents.findFirst.mockResolvedValue(
+                snsEventFixture('failed')
+            );
+
+            const response = await POST(makeRequest(makeNotification()));
+
+            expect(response.status).toBe(200);
+            expect(dispatch).toHaveBeenCalled();
+            expect(mocks.set).toHaveBeenCalledWith({ status: 'processed' });
+        });
+
+        it('treats Postgres unique-violation on insert as a duplicate', async () => {
+            // Concurrent redelivery: the find() race lost, the insert hits the
+            // unique index. Production code should swallow code 23505 only.
+            mocks.returning.mockRejectedValue(
+                Object.assign(
+                    new Error('duplicate key value violates unique constraint'),
+                    { code: '23505' }
+                )
+            );
+
+            const response = await POST(makeRequest(makeNotification()));
+
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toEqual({
+                received: true,
+                duplicate: true,
+            });
+            expect(dispatch).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('dispatch outcome', () => {
+        it('marks the event failed and returns 200 on a business error', async () => {
+            dispatch.mockRejectedValue(new Error('downstream exploded'));
+
+            const response = await POST(makeRequest(makeNotification()));
+
+            // A retry would hit the same bug, so the provider is told to stop.
+            expect(response.status).toBe(200);
+            expect(mocks.set).toHaveBeenCalledWith({
+                status: 'failed',
+                error: 'downstream exploded',
+            });
+            expect(hoisted.alertsSend).toHaveBeenCalledWith(
+                expect.objectContaining({ severity: 'error' })
+            );
+        });
+
+        it('rethrows transient infra failures so SNS redelivers', async () => {
+            // Marking the row 'failed' would need the same database that just
+            // went away, and nothing re-drives a failed row on its own — so
+            // this becomes a 5xx and the row stays visible at 'received'.
+            dispatch.mockRejectedValue(
+                Object.assign(new Error('connection refused'), {
+                    code: 'ECONNREFUSED',
+                })
+            );
+
+            await expect(POST(makeRequest(makeNotification()))).rejects.toThrow(
+                'connection refused'
+            );
+            expect(mocks.set).not.toHaveBeenCalled();
+            expect(hoisted.alertsSend).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('subscription confirmation', () => {
+        const confirmation = {
+            Type: 'SubscriptionConfirmation',
+            MessageId: 'sns-confirm-1',
+            TopicArn: 'arn:aws:sns:us-east-1:123456789:nexus-s3-events-test',
+            SubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=Confirm',
+        };
+
+        it('alerts when the SubscribeURL cannot be reached', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockRejectedValue(new Error('network down'))
+            );
+
+            const response = await POST(makeRequest(confirmation));
+
+            expect(response.status).toBe(200);
+            expect(hoisted.alertsSend).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    severity: 'error',
+                    title: 'SNS subscription confirmation failed',
+                    context: expect.objectContaining({
+                        source: 'sns',
+                        topicArn: confirmation.TopicArn,
+                        error: 'network down',
+                    }),
+                })
+            );
+        });
+
+        it('alerts when the SubscribeURL answers with an error status', async () => {
+            // `fetch` resolves on a 4xx/5xx, so without an explicit check this
+            // logged as confirmed while the topic stayed unsubscribed.
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue(new Response('nope', { status: 403 }))
+            );
+
+            await POST(makeRequest(confirmation));
+
+            expect(hoisted.alertsSend).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    severity: 'error',
+                    title: 'SNS subscription confirmation failed',
+                })
+            );
+        });
+
+        it('does not alert when confirmation succeeds', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
+            );
+
+            await POST(makeRequest(confirmation));
+
+            expect(hoisted.alertsSend).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/web/app/api/webhooks/s3-restore/route.ts
+++ b/apps/web/app/api/webhooks/s3-restore/route.ts
@@ -2,7 +2,11 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { createWebhookRepo } from '@nexus/db/repo/webhooks';
 import { alerts } from '@/lib/alerts';
 import { isLocalDevelopment } from '@/lib/env/runtime';
-import { toErrorMessage } from '@/lib/errors';
+import { isTransientInfraError, toErrorMessage } from '@/lib/errors';
+import {
+    recordWebhookFailure,
+    resolveWebhookEvent,
+} from '@/lib/webhooks/events';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { verifySnsMessage } from '@/lib/sns/webhooks';
@@ -56,16 +60,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const notification = body as unknown as SnsNotification;
     const webhookRepo = createWebhookRepo(db);
 
-    const existing = await webhookRepo.find('sns', notification.MessageId);
-
-    if (existing) {
-        log.debug(
-            { messageId: notification.MessageId, duplicate: true },
-            'Duplicate webhook event skipped'
-        );
-        return NextResponse.json({ received: true, duplicate: true });
-    }
-
     let s3Event: S3EventNotification;
     try {
         s3Event = JSON.parse(notification.Message) as S3EventNotification;
@@ -79,12 +73,36 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const eventType = s3Event.Records?.[0]?.eventName ?? 'unknown';
 
-    const webhookEvent = await webhookRepo.insert({
+    const lookup = await resolveWebhookEvent(webhookRepo, {
         source: 'sns',
         externalId: notification.MessageId,
         eventType,
         payload: body,
     });
+
+    if (lookup.outcome === 'duplicate') {
+        log.debug(
+            {
+                messageId: notification.MessageId,
+                duplicate: true,
+                reason: lookup.reason,
+            },
+            'Duplicate webhook event skipped'
+        );
+        return NextResponse.json({ received: true, duplicate: true });
+    }
+
+    if (lookup.outcome === 'retry') {
+        log.info(
+            {
+                messageId: notification.MessageId,
+                prevStatus: lookup.event.status,
+            },
+            'Retrying webhook event'
+        );
+    }
+
+    const webhookEvent = lookup.event;
 
     const start = Date.now();
     log.info(
@@ -152,14 +170,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             'Webhook processing failed'
         );
 
-        const errorMessage = toErrorMessage(error);
-        await webhookRepo.update(webhookEvent.id, {
-            status: 'failed',
-            error: errorMessage,
-        });
+        // Rethrow so the 5xx makes SNS redeliver — see `isTransientInfraError`
+        // for why nothing is written first (#331).
+        if (isTransientInfraError(error)) throw error;
 
-        await alerts.send({
-            severity: 'error',
+        await recordWebhookFailure(webhookRepo, webhookEvent.id, error, {
             title: 'S3 webhook processing failed',
             message:
                 'Handler threw while processing an SNS webhook; the event row is marked failed.',
@@ -167,7 +182,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
                 source: 'sns',
                 eventType,
                 externalId: notification.MessageId,
-                error: errorMessage,
             },
         });
 
@@ -181,13 +195,35 @@ async function handleSubscriptionConfirmation(
     log.info({ topicArn: message.TopicArn }, 'Confirming SNS subscription');
 
     try {
-        await fetch(message.SubscribeURL);
+        const response = await fetch(message.SubscribeURL);
+        // `fetch` only rejects on a network failure, so an SNS-side 4xx/5xx
+        // would otherwise log as confirmed while the topic stays unsubscribed.
+        if (!response.ok) {
+            throw new Error(
+                `SubscribeURL returned ${response.status} ${response.statusText}`
+            );
+        }
         log.info({ topicArn: message.TopicArn }, 'SNS subscription confirmed');
     } catch (err) {
+        // An unconfirmed subscription delivers nothing at all, so this is
+        // louder than a log line: every restore notification is lost until
+        // someone re-triggers confirmation (#331).
         log.error(
             { err, topicArn: message.TopicArn },
             'Failed to confirm SNS subscription'
         );
+
+        await alerts.send({
+            severity: 'error',
+            title: 'SNS subscription confirmation failed',
+            message:
+                'Could not confirm an SNS subscription; the topic will not deliver events to this endpoint until it is confirmed.',
+            context: {
+                source: 'sns',
+                topicArn: message.TopicArn,
+                error: toErrorMessage(err),
+            },
+        });
     }
 
     return NextResponse.json({ received: true });

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -334,7 +334,8 @@ describe('POST /api/webhooks/stripe', () => {
 
             const response = await POST(makeRequest(sampleEvent));
 
-            // Failed events still return 200 — see #201 for the retry-loss tradeoff
+            // Business errors still return 200: a retry hits the same bug.
+            // Only the transient class rethrows (#331).
             expect(response.status).toBe(200);
             await expect(response.json()).resolves.toEqual({ received: true });
             expect(mocks.set).toHaveBeenCalledWith({
@@ -362,6 +363,40 @@ describe('POST /api/webhooks/stripe', () => {
                 status: 'failed',
                 error: 'plain string failure',
             });
+        });
+
+        it('rethrows transient infra failures so Stripe retries', async () => {
+            // The database went away mid-dispatch. Marking the row 'failed'
+            // would need that same database, and nothing re-drives a failed
+            // row on its own — so this becomes a 5xx and Stripe retries.
+            dispatchWebhookEvent.mockRejectedValue(
+                Object.assign(new Error('connection refused'), {
+                    code: 'ECONNREFUSED',
+                })
+            );
+
+            await expect(POST(makeRequest(sampleEvent))).rejects.toThrow(
+                'connection refused'
+            );
+            expect(mocks.set).not.toHaveBeenCalled();
+            expect(hoisted.alertsSend).not.toHaveBeenCalled();
+        });
+
+        it('unwraps a transient cause from a fetch wrapper', async () => {
+            // undici reports a refused connection as `TypeError: fetch failed`
+            // with the real code one level down.
+            dispatchWebhookEvent.mockRejectedValue(
+                new TypeError('fetch failed', {
+                    cause: Object.assign(new Error('socket hang up'), {
+                        code: 'ECONNRESET',
+                    }),
+                })
+            );
+
+            await expect(POST(makeRequest(sampleEvent))).rejects.toThrow(
+                'fetch failed'
+            );
+            expect(mocks.set).not.toHaveBeenCalled();
         });
     });
 });

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,26 +1,19 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import type Stripe from 'stripe';
-import { createWebhookRepo, type WebhookEvent } from '@nexus/db/repo/webhooks';
+import { createWebhookRepo } from '@nexus/db/repo/webhooks';
 import { alerts } from '@/lib/alerts';
 import { isLocalDevelopment } from '@/lib/env/runtime';
-import { toErrorMessage } from '@/lib/errors';
+import { isTransientInfraError } from '@/lib/errors';
+import {
+    recordWebhookFailure,
+    resolveWebhookEvent,
+} from '@/lib/webhooks/events';
 import { db } from '@/server/db';
 import { logger } from '@/server/lib/logger';
 import { stripe } from '@/lib/stripe';
 import { subscriptionService } from '@/server/services/subscriptions';
 
 const log = logger.child({ handler: 'stripe-webhook' });
-
-const POSTGRES_UNIQUE_VIOLATION = '23505';
-
-function isUniqueViolation(err: unknown): boolean {
-    return (
-        typeof err === 'object' &&
-        err !== null &&
-        'code' in err &&
-        (err as { code: unknown }).code === POSTGRES_UNIQUE_VIOLATION
-    );
-}
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
     let rawBody: string;
@@ -65,47 +58,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const webhookRepo = createWebhookRepo(db);
 
-    // Stripe may redeliver events during outages, or retry after a prior
-    // failure. Only `processed` short-circuits — `failed` and `received` rows
-    // fall through so the dispatch can re-run and recover.
-    const existing = await webhookRepo.find('stripe', event.id);
-    if (existing?.status === 'processed') {
-        log.debug({ eventId: event.id }, 'Webhook already processed, skipping');
+    const lookup = await resolveWebhookEvent(webhookRepo, {
+        source: 'stripe',
+        externalId: event.id,
+        eventType: event.type,
+        payload: event as unknown as Record<string, unknown>,
+    });
+
+    if (lookup.outcome === 'duplicate') {
+        log.debug(
+            { eventId: event.id, duplicate: true, reason: lookup.reason },
+            'Duplicate webhook event skipped'
+        );
         return NextResponse.json({ received: true, duplicate: true });
     }
 
-    let webhookEvent: WebhookEvent;
-    if (existing) {
-        webhookEvent = existing;
+    if (lookup.outcome === 'retry') {
         log.info(
-            { eventId: event.id, prevStatus: existing.status },
+            { eventId: event.id, prevStatus: lookup.event.status },
             'Retrying webhook event'
         );
-    } else {
-        try {
-            webhookEvent = await webhookRepo.insert({
-                source: 'stripe',
-                externalId: event.id,
-                eventType: event.type,
-                payload: event as unknown as Record<string, unknown>,
-            });
-        } catch (err) {
-            // Only swallow Postgres unique-violation (23505) — that's a
-            // concurrent redelivery race. Anything else (schema mismatch,
-            // connection drop, etc.) is a real failure and must surface.
-            if (isUniqueViolation(err)) {
-                log.debug(
-                    { eventId: event.id },
-                    'Concurrent duplicate skipped'
-                );
-                return NextResponse.json({
-                    received: true,
-                    duplicate: true,
-                });
-            }
-            throw err;
-        }
     }
+
+    const webhookEvent = lookup.event;
 
     const start = Date.now();
     log.info({ eventId: event.id, eventType: event.type }, 'Webhook received');
@@ -157,14 +132,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             'Webhook processing failed'
         );
 
-        const errorMessage = toErrorMessage(error);
-        await webhookRepo.update(webhookEvent.id, {
-            status: 'failed',
-            error: errorMessage,
-        });
+        // Rethrow so the 5xx makes Stripe retry — see `isTransientInfraError`
+        // for why nothing is written first (#331).
+        if (isTransientInfraError(error)) throw error;
 
-        await alerts.send({
-            severity: 'error',
+        await recordWebhookFailure(webhookRepo, webhookEvent.id, error, {
             title: 'Stripe webhook processing failed',
             message:
                 'Handler threw while processing a Stripe webhook; the event row is marked failed.',
@@ -172,7 +144,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
                 source: 'stripe',
                 eventType: event.type,
                 externalId: event.id,
-                error: errorMessage,
             },
         });
 

--- a/apps/web/lib/errors.test.ts
+++ b/apps/web/lib/errors.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+    isTransientInfraError,
+    isUniqueViolation,
+    toErrorMessage,
+} from './errors';
+
+function withCode(message: string, code: unknown): Error {
+    return Object.assign(new Error(message), { code });
+}
+
+describe('toErrorMessage', () => {
+    it('takes the message off an Error', () => {
+        expect(toErrorMessage(new Error('boom'))).toBe('boom');
+    });
+
+    it('stringifies anything else', () => {
+        expect(toErrorMessage('plain string')).toBe('plain string');
+        expect(toErrorMessage(undefined)).toBe('undefined');
+    });
+});
+
+describe('isUniqueViolation', () => {
+    it('matches Postgres 23505', () => {
+        expect(isUniqueViolation(withCode('duplicate key', '23505'))).toBe(
+            true
+        );
+    });
+
+    it('ignores other Postgres codes', () => {
+        expect(isUniqueViolation(withCode('bad column', '42703'))).toBe(false);
+    });
+
+    it('ignores an error with no code at all', () => {
+        expect(isUniqueViolation(new Error('duplicate key'))).toBe(false);
+    });
+});
+
+describe('isTransientInfraError', () => {
+    it('matches a Node socket code on the error itself', () => {
+        expect(
+            isTransientInfraError(withCode('connect failed', 'ECONNREFUSED'))
+        ).toBe(true);
+    });
+
+    it('matches a postgres.js connection state', () => {
+        expect(
+            isTransientInfraError(withCode('ended', 'CONNECTION_ENDED'))
+        ).toBe(true);
+    });
+
+    it('matches the whole Postgres class-08 family by prefix', () => {
+        for (const code of ['08000', '08003', '08006', '08P01']) {
+            expect(isTransientInfraError(withCode('conn', code))).toBe(true);
+        }
+    });
+
+    it('matches the named recoverable server states', () => {
+        for (const code of ['53300', '57P01', '40001', '40P01']) {
+            expect(isTransientInfraError(withCode('server', code))).toBe(true);
+        }
+    });
+
+    it('finds a code one cause level down', () => {
+        // How undici reports a refused connection.
+        const err = new TypeError('fetch failed', {
+            cause: withCode('connect ECONNREFUSED', 'ECONNREFUSED'),
+        });
+
+        expect(isTransientInfraError(err)).toBe(true);
+    });
+
+    it('finds a code several cause levels down', () => {
+        const err = new Error('outer', {
+            cause: new Error('middle', {
+                cause: withCode('inner', 'ETIMEDOUT'),
+            }),
+        });
+
+        expect(isTransientInfraError(err)).toBe(true);
+    });
+
+    it('terminates on a self-referential cause chain', () => {
+        const err: Error & { cause?: unknown } = new Error('loop');
+        err.cause = err;
+
+        expect(isTransientInfraError(err)).toBe(false);
+    });
+
+    it('treats an unrecognised code as a business error', () => {
+        expect(isTransientInfraError(withCode('bad column', '42703'))).toBe(
+            false
+        );
+        expect(isTransientInfraError(withCode('unique', '23505'))).toBe(false);
+    });
+
+    it('ignores a non-string code', () => {
+        expect(isTransientInfraError(withCode('numeric', 500))).toBe(false);
+    });
+
+    it('handles values that are not errors', () => {
+        expect(isTransientInfraError('ECONNREFUSED')).toBe(false);
+        expect(isTransientInfraError(null)).toBe(false);
+        expect(isTransientInfraError(undefined)).toBe(false);
+    });
+});

--- a/apps/web/lib/errors.ts
+++ b/apps/web/lib/errors.ts
@@ -6,3 +6,88 @@
 export function toErrorMessage(err: unknown): string {
     return err instanceof Error ? err.message : String(err);
 }
+
+/** Postgres SQLSTATE for a unique-constraint violation. */
+const POSTGRES_UNIQUE_VIOLATION = '23505';
+
+/** Postgres SQLSTATE class 08 — connection exception, in all its variants. */
+const POSTGRES_CONNECTION_EXCEPTION_CLASS = '08';
+
+/**
+ * Failures where the request was fine and the infrastructure under it was not,
+ * so retrying the identical request has a real chance of succeeding.
+ *
+ * Deliberately an allowlist: an unrecognised error counts as a business error,
+ * because a bug in our own code retried forever is worse than one recorded and
+ * investigated (#331).
+ */
+const TRANSIENT_ERROR_CODES = new Set([
+    // Node socket failures. Also how a `fetch` to S3 or Stripe surfaces —
+    // `TypeError: fetch failed` carries the real code on its `cause`.
+    'ECONNREFUSED',
+    'ECONNRESET',
+    'ETIMEDOUT',
+    'EPIPE',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_SOCKET',
+    // postgres.js connection lifecycle.
+    'CONNECTION_CLOSED',
+    'CONNECTION_ENDED',
+    'CONNECTION_DESTROYED',
+    'CONNECT_TIMEOUT',
+    // Postgres server states that clear on their own: pool exhausted, server
+    // shutting down, and the two concurrency collisions a retry resolves.
+    '53300',
+    '57P01',
+    '40001',
+    '40P01',
+]);
+
+/** Guards against a self-referential `cause` chain. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * Every `code` along the thrown value's `cause` chain. Wrappers are common —
+ * undici reports a refused connection as `TypeError: fetch failed` with the
+ * `ECONNREFUSED` one level down — so the outermost error rarely carries it.
+ */
+function getErrorCodes(err: unknown): string[] {
+    const codes: string[] = [];
+    let current = err;
+
+    for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+        if (typeof current !== 'object' || current === null) break;
+
+        const { code, cause } = current as { code?: unknown; cause?: unknown };
+        if (typeof code === 'string') codes.push(code);
+        current = cause;
+    }
+
+    return codes;
+}
+
+/**
+ * A concurrent insert of the same webhook event lost the race. Both webhook
+ * routes treat this as a duplicate delivery, not a failure.
+ */
+export function isUniqueViolation(err: unknown): boolean {
+    return getErrorCodes(err).includes(POSTGRES_UNIQUE_VIOLATION);
+}
+
+/**
+ * Whether a retry of the identical request would plausibly succeed.
+ *
+ * Webhook routes rethrow these instead of recording a `failed` row: the 5xx
+ * makes the provider retry, which is the only thing that recovers a delivery,
+ * since nothing re-drives a stored row on its own. They also skip the row
+ * update and the alert on that path — if the database is what broke, both
+ * would throw too, and a row left at `received` is what the nightly sweep in
+ * `check-s3-event-health` looks for when the retries never land (#331).
+ */
+export function isTransientInfraError(err: unknown): boolean {
+    return getErrorCodes(err).some(
+        (code) =>
+            TRANSIENT_ERROR_CODES.has(code) ||
+            code.startsWith(POSTGRES_CONNECTION_EXCEPTION_CLASS)
+    );
+}

--- a/apps/web/lib/webhooks/events.ts
+++ b/apps/web/lib/webhooks/events.ts
@@ -1,0 +1,82 @@
+import {
+    type NewWebhookEvent,
+    type WebhookEvent,
+    type createWebhookRepo,
+} from '@nexus/db/repo/webhooks';
+import { alerts } from '@/lib/alerts';
+import { isUniqueViolation, toErrorMessage } from '@/lib/errors';
+
+type WebhookRepo = ReturnType<typeof createWebhookRepo>;
+
+export type WebhookEventLookup =
+    | { outcome: 'duplicate'; reason: 'processed' | 'concurrent-insert' }
+    | { outcome: 'new'; event: WebhookEvent }
+    | { outcome: 'retry'; event: WebhookEvent };
+
+/**
+ * Finds or creates the `webhook_events` row for an inbound delivery, and says
+ * whether this delivery should be dispatched at all.
+ *
+ * Only `processed` counts as done. A row is inserted at `received` and moves
+ * to a terminal status only after dispatch, so a crash in between leaves a
+ * `received` row behind — short-circuiting on mere existence would strand it
+ * permanently, because provider redelivery is the only thing that recovers a
+ * delivery and it would be turned away (#331).
+ */
+export async function resolveWebhookEvent(
+    repo: WebhookRepo,
+    input: NewWebhookEvent
+): Promise<WebhookEventLookup> {
+    const existing = await repo.find(input.source, input.externalId);
+
+    if (existing?.status === 'processed') {
+        return { outcome: 'duplicate', reason: 'processed' };
+    }
+
+    if (existing) {
+        return { outcome: 'retry', event: existing };
+    }
+
+    try {
+        return { outcome: 'new', event: await repo.insert(input) };
+    } catch (err) {
+        // Only swallow Postgres unique-violation — that's a concurrent
+        // redelivery racing us to the same row. Anything else (schema
+        // mismatch, connection drop) is a real failure and must surface.
+        if (isUniqueViolation(err)) {
+            return { outcome: 'duplicate', reason: 'concurrent-insert' };
+        }
+        throw err;
+    }
+}
+
+interface WebhookFailureAlert {
+    title: string;
+    message: string;
+    /** Identifying facts; the error message is appended automatically. */
+    context: Record<string, string>;
+}
+
+/**
+ * Marks a delivery failed and alerts on it.
+ *
+ * Business errors only — callers rethrow the transient class before reaching
+ * here, so that a retry is the provider's job rather than a stored row's.
+ */
+export async function recordWebhookFailure(
+    repo: WebhookRepo,
+    eventId: string,
+    error: unknown,
+    alert: WebhookFailureAlert
+): Promise<void> {
+    const errorMessage = toErrorMessage(error);
+
+    await repo.update(eventId, { status: 'failed', error: errorMessage });
+
+    await alerts.send({
+        severity: 'error',
+        title: alert.title,
+        message: alert.message,
+        context: { ...alert.context, error: errorMessage },
+    });
+}

--- a/apps/web/scripts/check-s3-event-health.ts
+++ b/apps/web/scripts/check-s3-event-health.ts
@@ -5,6 +5,9 @@
  *   - any SNS webhook event landed in status 'failed' or 'unhandled' in the
  *     last 7 days (allowlisted expected events stay 'processed', so routine
  *     ObjectRestore:Post deliveries don't trip this)
+ *   - any webhook event from either source has sat in 'received' for over an
+ *     hour (#331): the route inserts at 'received' and only moves the row
+ *     after dispatch, so a crash in between strands it there
  *   - any retrieval has sat in 'pending'/'in_progress' for over 48 hours
  *     (Deep Archive bulk restores complete within 48h — older is stuck)
  *   - any file has sat in 'uploading' for over 24 hours (#330): the client
@@ -31,7 +34,20 @@ import { s3RestoreService } from '@/server/services/s3-restore';
 import { createFileRepo, STALE_UPLOAD_HOURS } from '@nexus/db/repo/files';
 import { retrievals, webhookEvents } from '@nexus/db/schema';
 
+/**
+ * How far back the failed/unhandled leg looks. Those rows are history: they
+ * record something that already went wrong and was dealt with, so they age
+ * out. The stranded leg below is deliberately unbounded — see there.
+ */
 const FAILED_WEBHOOK_WINDOW_DAYS = 7;
+
+/**
+ * How long a row may sit in 'received' before it counts as stranded. Real
+ * processing takes seconds; the hour is slack for a row inserted while this
+ * check runs, not a guess at how long dispatch takes.
+ */
+const STUCK_RECEIVED_MINUTES = 60;
+
 const STUCK_RETRIEVAL_HOURS = 48;
 
 function parseSinceArg(): Date | null {
@@ -78,6 +94,41 @@ async function main(): Promise<void> {
         );
     }
     if (failedWebhooks.length > 0) hasFailure = true;
+
+    // Both sources: a Stripe strand is the same silent hole as an SNS one.
+    //
+    // No lower bound, unlike the failed leg. A stranded row is an open
+    // incident, not history — an event was accepted and never acted on — and
+    // nothing re-drives it once the provider's retries are spent. Letting it
+    // age out of this query would restore the exact blindness #331 closed,
+    // just a week later. Resolve the row to clear the check.
+    const strandedBefore = new Date(
+        Date.now() - STUCK_RECEIVED_MINUTES * 60 * 1000
+    );
+    const strandedWebhooks = await db
+        .select({
+            id: webhookEvents.id,
+            source: webhookEvents.source,
+            eventType: webhookEvents.eventType,
+            createdAt: webhookEvents.createdAt,
+        })
+        .from(webhookEvents)
+        .where(
+            and(
+                eq(webhookEvents.status, 'received'),
+                lt(webhookEvents.createdAt, strandedBefore)
+            )
+        );
+
+    console.log(
+        `Webhook events stranded at 'received' >${STUCK_RECEIVED_MINUTES}m: ${strandedWebhooks.length}`
+    );
+    for (const event of strandedWebhooks) {
+        console.log(
+            `  ✗ ${event.createdAt.toISOString()}  ${event.source}  ${event.eventType}  event=${event.id}`
+        );
+    }
+    if (strandedWebhooks.length > 0) hasFailure = true;
 
     const stuckBefore = new Date(
         Date.now() - STUCK_RETRIEVAL_HOURS * 60 * 60 * 1000
@@ -158,7 +209,7 @@ async function main(): Promise<void> {
         await alerts.send({
             severity: 'error',
             title: 'S3 event pipeline health check failed',
-            message: `${failedWebhooks.length} failed/unhandled SNS webhook event(s) in the last ${FAILED_WEBHOOK_WINDOW_DAYS}d; ${stuckRetrievals.length} retrieval(s) stuck >${STUCK_RETRIEVAL_HOURS}h; ${staleUploads.length} upload(s) stuck >${STALE_UPLOAD_HOURS}h.`,
+            message: `${failedWebhooks.length} failed/unhandled SNS webhook event(s) in the last ${FAILED_WEBHOOK_WINDOW_DAYS}d; ${strandedWebhooks.length} webhook event(s) stranded at 'received' >${STUCK_RECEIVED_MINUTES}m; ${stuckRetrievals.length} retrieval(s) stuck >${STUCK_RETRIEVAL_HOURS}h; ${staleUploads.length} upload(s) stuck >${STALE_UPLOAD_HOURS}h.`,
             context: {
                 source: 'check-s3-event-health',
                 ...(runUrl && { workflowRun: runUrl }),

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -1,7 +1,7 @@
 ---
 title: Webhook Handling
 created: 2026-02-15
-updated: 2026-02-15
+updated: 2026-08-13
 status: active
 tags:
     - guide
@@ -183,51 +183,54 @@ External providers retry webhook deliveries. Stripe may send the same event mult
 
 Track every processed event in a `webhook_events` table with a unique constraint on the provider event ID. Before processing, check if the event was already handled.
 
+The check is on **status**, not existence. A row is inserted at `received` and only moves to a terminal status after dispatch, so a crash in between leaves a `received` row behind. Short-circuiting on any existing row makes that strand permanent — the provider's redelivery is the only thing that would recover it, and it gets turned away. Only `processed` means "already done".
+
+Both routes get this from `resolveWebhookEvent` in `apps/web/lib/webhooks/events.ts` rather than restating it — it owns the find-or-insert, the `processed` short-circuit, and the concurrent-insert race.
+
 ```typescript
-// Pattern used in the route handler
-const existing = await findWebhookEvent(db, {
-    source: 'stripe',
-    externalId: event.id,
-});
-
-if (existing) {
-    // Already processed — return 200 to stop retries
-    return NextResponse.json({ received: true, duplicate: true });
-}
-
-// Insert tracking record before processing
-const webhookEvent = await insertWebhookEvent(db, {
+const lookup = await resolveWebhookEvent(webhookRepo, {
     source: 'stripe',
     externalId: event.id,
     eventType: event.type,
     payload: event,
 });
 
+// 'duplicate' — genuinely done, or a concurrent insert won the race
+if (lookup.outcome === 'duplicate') {
+    return NextResponse.json({ received: true, duplicate: true });
+}
+
+// 'new' or 'retry' — a 'received'/'failed'/'unhandled' row is re-driven
+const webhookEvent = lookup.event;
+
 // Process the event...
-// On success: mark as 'processed'
-// On failure: mark as 'failed' with error message
+// On success: mark as 'processed' (or 'unhandled' if no handler matched)
+// On business failure: recordWebhookFailure() marks it and alerts
+// On transient failure: rethrow, leaving the row at its current status
 ```
+
+Rows that never reach a terminal status are swept nightly — see [When to Return 5xx](#when-to-return-5xx).
 
 ### Table Schema
 
 See `packages/db/src/schema/webhooks.ts` for the full schema. Key columns:
 
-| Column       | Purpose                                                |
-| ------------ | ------------------------------------------------------ |
-| `externalId` | Provider's event ID (e.g., `evt_1234` from Stripe)     |
-| `source`     | Provider name (`stripe`, `sns`)                        |
-| `eventType`  | Event type string (e.g., `invoice.paid`)               |
-| `payload`    | Full event payload as JSONB (for debugging/replaying)  |
-| `status`     | Processing status: `received` → `processed` / `failed` |
-| `error`      | Error message if processing failed                     |
+| Column       | Purpose                                            |
+| ------------ | -------------------------------------------------- |
+| `externalId` | Provider's event ID (e.g., `evt_1234` from Stripe) |
+| `source`     | Provider name (`stripe`, `sns`)                    |
+| `eventType`  | Event type string (e.g., `invoice.paid`)           |
+| `payload`    | Full event payload as JSONB (for debugging)        |
+| `status`     | `received` → `processed` / `failed` / `unhandled`  |
+| `error`      | Error message if processing failed                 |
 
 **Unique constraint** on `(source, external_id)` prevents duplicate inserts. If a concurrent request tries to insert the same event, the DB rejects it.
 
 ### Payload Retention & Cleanup
 
-Webhook payloads are stored for **debugging and replay** purposes. Cleanup strategy:
+Webhook payloads are stored for **debugging**. There is no replay tooling — the payload lets you reconstruct what happened, not re-run it. Recovery comes from provider redelivery hitting the status-aware idempotency check above.
 
-- **Active retention:** 90 days — payloads available for debugging and replay
+- **Active retention:** 90 days
 - **Cleanup:** Scheduled job (or manual query) deletes `webhook_events` rows older than 90 days where `status = 'processed'`
 - **Failed events:** Retained indefinitely until manually reviewed and resolved
 
@@ -300,6 +303,8 @@ Webhook error handling must consider provider retry behavior. The HTTP status co
 
 **Key insight:** Return `200` for business logic errors. Returning `5xx` would trigger retries, which would fail the same way. Log the error, mark the `webhook_events` record as `failed`, and investigate.
 
+The split is not a judgment call at the call site — `isTransientInfraError` in `@/lib/errors` decides it, and both routes rethrow when it says yes.
+
 ### Route Handler Error Handling
 
 ```typescript
@@ -326,14 +331,18 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
             'Webhook processing failed'
         );
 
+        // Transient failures rethrow: Next.js turns that into a 500 and the
+        // provider retries. Nothing is written first — if the database is
+        // what broke, the write fails too, and the row staying at 'received'
+        // is what the nightly sweep looks for.
+        if (isTransientInfraError(error)) throw error;
+
         await updateWebhookEvent(db, webhookEvent.id, {
             status: 'failed',
-            error: error instanceof Error ? error.message : String(error),
+            error: toErrorMessage(error),
         });
 
-        // Return 200 to prevent retries for business logic errors.
-        // Only throw (return 5xx) for truly transient failures
-        // that would benefit from a retry.
+        // Business errors return 200: a retry hits the same bug.
         return NextResponse.json({ received: true });
     }
 }
@@ -347,7 +356,21 @@ Reserve `500` for infrastructure failures where a retry would genuinely help:
 - Connection timeout to a dependent service
 - Out of memory / process crash (automatic — Vercel returns 500)
 
-If you're unsure, default to `200`. You can always replay events from the `webhook_events` table.
+Don't decide this by hand. `isTransientInfraError` (`apps/web/lib/errors.ts`) is an **allowlist** of Node socket codes, postgres.js connection states, and the Postgres SQLSTATE families that clear on their own (class `08`, plus `53300`, `57P01`, `40001`, `40P01`). It walks the `cause` chain, because undici reports a refused connection as `TypeError: fetch failed` with the real code one level down. Anything it doesn't recognise is a business error and returns `200`.
+
+Allowlist, not denylist, on purpose: an unrecognised error retried forever is worse than one recorded as `failed` and investigated.
+
+#### This supersedes #281 for the transient class
+
+#281 decided "responses stay 200 in all cases", on the premise that "you can always replay events from the `webhook_events` table." That premise was never true. No replay tooling was built, and until #331 the nightly health check never queried `status = 'received'` at all — so a crash between the insert and the status update produced a row that was invisible to every check and that no redelivery could recover, because the S3-restore route's idempotency check turned away any existing row regardless of status.
+
+What changed in #331:
+
+- The S3-restore check became status-aware, so provider redelivery re-drives stranded rows (the Stripe route already did this, from #201).
+- `check-s3-event-health` gained a leg for rows sitting at `received` for over an hour, across both sources. Unlike the failed leg it has no lower time bound: a `failed` row is history, a `received` row is an open incident, so it holds the check red until someone resolves it.
+- Transient failures rethrow, so the provider's own retry is the first line of recovery rather than a nightly script.
+
+The rest of #281 stands: unhandled events, business errors, and duplicates all still return `200`.
 
 ## Logging
 


### PR DESCRIPTION
## Summary

A crash between the `webhook_events` insert and the post-dispatch status update left a row at `received` that nothing could recover: the S3-restore route turned away any redelivery regardless of status, the nightly sweep never queried `received`, and both routes answered 200 from their catch blocks so providers never retried even a dead database.

Closes #331

## Changes

- **Status-aware dedup on the SNS route.** Only `processed` short-circuits now; `received`, `failed` and `unhandled` rows are re-driven by the provider's redelivery, matching what the Stripe route has done since #201.
- **`resolveWebhookEvent` / `recordWebhookFailure`** (`apps/web/lib/webhooks/events.ts`). Both routes had grown near-identical find-or-insert and mark-failed blocks, so the recovery policy lives in one place rather than being restated per route. This also gave the SNS route the concurrent-insert (23505) guard it was missing.
- **`isTransientInfraError`** (`apps/web/lib/errors.ts`). An allowlist of Node socket codes, postgres.js connection states, and the Postgres SQLSTATE families that clear on their own (class `08`, `53300`, `57P01`, `40001`, `40P01`). It walks the `cause` chain, because undici reports a refused connection as `TypeError: fetch failed` with the real code one level down. Both routes rethrow on a match, so the provider retries; everything else stays a business error with a 200 and a `failed` row. `isUniqueViolation` moved here from the Stripe route since both routes now need it.
- **Stranded-row leg in `check-s3-event-health`.** Flags rows sitting at `received` for over an hour, across both sources.
- **`alerts.send` on subscription-confirmation failure**, plus a `response.ok` check — `fetch` resolves on a 4xx/5xx, so an SNS-side rejection logged as "confirmed" and the new alert would never have fired for the likeliest failure.
- **`docs/guides/webhooks.md`** rewritten where it was wrong: the idempotency sample was the pre-#201 status-blind form, the payload section claimed replay tooling that does not exist, and "if you're unsure, default to 200 — you can always replay events from the `webhook_events` table" rested on a premise that was never true.

## Reversal of #281

#281 decided "responses stay 200 in all cases" on the premise that events can always be replayed from `webhook_events`. No replay tooling was ever built and nothing queried `received`, so that premise did not hold. This PR reverses it **for the transient class only** — unhandled events, business errors and duplicates still return 200. The rationale is written into `docs/guides/webhooks.md` under "When to Return 5xx"; a comment goes on #281 pointing at it.

## Notes for review

Two things beyond the literal acceptance criteria, both deliberate:

- The `response.ok` check above. AC4 asks for an alert on confirmation failure; without this, the most likely failure isn't detected as one.
- The stranded leg has **no** lower time bound, unlike the failed leg's 7 days. I originally bounded it by symmetry and self-review pushed back correctly: a `failed` row is history, a `received` row is an open incident that nothing re-drives once provider retries are spent. Ageing it out would restore the exact blindness this issue closes, a week later. It holds the check red until the row is resolved.

Two self-review findings were skipped: moving the stranded query into a `findStrandedAtReceived` repo method (the `findStaleUploads` precedent exists because two scripts share that threshold; here there's one consumer and the adjacent leg in the same file uses inline drizzle), and a generic `reportLeg<T>` helper for the script's four legs (more machinery than the repetition costs in a 180-line script).

## Test Plan

- [x] `pnpm check` green (42 tests across the three touched/added specs)
- [x] New `apps/web/app/api/webhooks/s3-restore/route.test.ts` — the route previously had integration-only coverage, which never runs in CI. Covers `processed` skip, `received` re-drive, `failed` re-drive, 23505 duplicate, business-error 200, transient rethrow, and all three confirmation-alert paths
- [x] New `apps/web/lib/errors.test.ts` — cause-chain depth, cycle guard, class-08 prefix, non-string codes, non-Error values
- [x] `pnpm -F web check:s3-event-health` run against dev: new leg prints, 0 stranded rows
- [x] Stranded query shape verified against the real DB via `pnpm -F db db:query`
- [ ] After merge: confirm the nightly `s3-event-health` workflow still passes on both the dev and prod matrix legs
