### PR TITLE
fix: s3-event-health prod leg is false-green (#318)

### DIFF
--- a/.github/workflows/s3-event-health.yml
+++ b/.github/workflows/s3-event-health.yml
@@ -24,19 +24,29 @@ jobs:
                 include:
                     - env: dev
                       db-secret: DATABASE_URL
+                      aws-key-id-secret: AWS_ACCESS_KEY_ID
+                      aws-secret-key-secret: AWS_SECRET_ACCESS_KEY
+                      bucket-secret: S3_BUCKET
                     - env: prod
                       db-secret: DATABASE_URL_PROD
-        # Only DATABASE_URL is matrixed. AWS/Stripe/etc. stay dev-scoped: no
-        # prod S3 bucket exists yet, so on prod the storage-tier check
-        # compares an empty prod DB against dev AWS credentials (trivially
-        # green). Provisioning prod AWS resources + secrets is a follow-up
-        # for when the prod bucket exists.
+                      aws-key-id-secret: AWS_ACCESS_KEY_ID_PROD
+                      aws-secret-key-secret: AWS_SECRET_ACCESS_KEY_PROD
+                      bucket-secret: S3_BUCKET_PROD
+        # The DB and the bucket must come from the same environment or the
+        # storage-tier check compares prod rows against the dev bucket and
+        # reports every one as missing — which used to exit 0, so the prod leg
+        # was permanently green while checking nothing (#318).
+        #
+        # AWS_REGION is genuinely shared (us-east-1 both). The rest below stays
+        # dev-scoped and is inert: neither script reads Stripe, Resend, SQS or
+        # auth, but @/lib/env validates the whole server schema at import, so
+        # each var still has to be present and well-formed.
         env:
             DATABASE_URL: ${{ secrets[matrix.db-secret] }}
-            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets[matrix.aws-key-id-secret] }}
+            AWS_SECRET_ACCESS_KEY: ${{ secrets[matrix.aws-secret-key-secret] }}
             AWS_REGION: ${{ secrets.AWS_REGION }}
-            S3_BUCKET: ${{ secrets.S3_BUCKET }}
+            S3_BUCKET: ${{ secrets[matrix.bucket-secret] }}
             SQS_QUEUE_URL: ${{ secrets.SQS_QUEUE_URL }}
             STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
             STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
@@ -50,11 +60,18 @@ jobs:
             DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_ALERT_WEBHOOK_URL }}
             VERCEL_ENV: ${{ matrix.env }}
         steps:
-            # DATABASE_URL comes from the job env above (matrixed secret).
-            - name: Verify database secret is configured
+            # All four come from the job env above (matrixed secrets). An unset
+            # one has to fail loudly here: empty AWS creds would otherwise send
+            # the drift check off to compare against nothing.
+            - name: Verify environment secrets are configured
               run: |
-                  if [ -z "$DATABASE_URL" ]; then
-                      echo "::error::secret ${{ matrix.db-secret }} is not configured (see docs/infra/supabase-manual-setup.md)"
+                  missing=()
+                  [ -n "$DATABASE_URL" ] || missing+=("${{ matrix.db-secret }}")
+                  [ -n "$AWS_ACCESS_KEY_ID" ] || missing+=("${{ matrix.aws-key-id-secret }}")
+                  [ -n "$AWS_SECRET_ACCESS_KEY" ] || missing+=("${{ matrix.aws-secret-key-secret }}")
+                  [ -n "$S3_BUCKET" ] || missing+=("${{ matrix.bucket-secret }}")
+                  if [ ${#missing[@]} -gt 0 ]; then
+                      echo "::error::secret(s) not configured for ${{ matrix.env }}: ${missing[*]} (see docs/infra/supabase-manual-setup.md)"
                       exit 1
                   fi
 

--- a/apps/web/scripts/backfill-storage-tier.ts
+++ b/apps/web/scripts/backfill-storage-tier.ts
@@ -13,15 +13,40 @@
  *   pnpm -F web backfill:storage-tier          # dry run (default)
  *   pnpm -F web backfill:storage-tier --apply  # actually update rows
  *   pnpm -F web backfill:storage-tier --check  # dry run, exit 1 on drift (CI)
+ *
+ * `--check` fails on anything that means the DB and the bucket disagree:
+ * mismatched tiers, an object-backed row whose object is gone, or a storage
+ * class the app doesn't model. It deliberately ignores S3 objects with no row
+ * (the bucket also holds keys `files` never tracks) and `uploading` rows with
+ * no object (in-flight or abandoned uploads — `reap:stale-uploads` owns those).
  */
 
 import { ne } from 'drizzle-orm';
 
+import { alerts, getWorkflowRunUrl } from '@/lib/alerts';
 import { db } from '@/server/db';
 import { s3 } from '@/lib/storage';
 import { resolveStorageTier, type StorageTier } from '@/lib/storage/types';
 import { createFileRepo } from '@nexus/db/repo/files';
 import { files } from '@nexus/db/schema';
+
+type FileStatus = (typeof files.status.enumValues)[number];
+
+/**
+ * Whether a row in this status is supposed to have an object in the bucket
+ * right now. Exhaustive over the enum on purpose: adding a status becomes a
+ * type error rather than a silent "not drift", which is the failure mode this
+ * script exists to remove (#318).
+ */
+const HAS_OBJECT: Record<FileStatus, boolean> = {
+    available: true,
+    restoring: true,
+    // The PUT is either in flight or was abandoned by a browser that never
+    // came back (#330); `reap:stale-uploads` owns those.
+    uploading: false,
+    // Filtered out by the query below — the object is already gone.
+    deleted: false,
+};
 
 async function main(): Promise<void> {
     const shouldApply = process.argv.includes('--apply');
@@ -34,6 +59,7 @@ async function main(): Promise<void> {
             id: files.id,
             s3Key: files.s3Key,
             storageTier: files.storageTier,
+            status: files.status,
         })
         .from(files)
         .where(ne(files.status, 'deleted'));
@@ -48,12 +74,12 @@ async function main(): Promise<void> {
         to: StorageTier;
     }[] = [];
     let inSync = 0;
-    const missing: string[] = [];
+    const missing: { s3Key: string; status: FileStatus }[] = [];
     const unmapped: { s3Key: string; storageClass: string | undefined }[] = [];
 
     for (const row of rows) {
         if (!classByKey.has(row.s3Key)) {
-            missing.push(row.s3Key);
+            missing.push({ s3Key: row.s3Key, status: row.status });
             continue;
         }
         const storageClass = classByKey.get(row.s3Key);
@@ -77,31 +103,63 @@ async function main(): Promise<void> {
     const rowKeys = new Set(rows.map((r) => r.s3Key));
     const orphans = objects.filter((o) => !rowKeys.has(o.key));
 
+    const missingDrift = missing.filter((m) => HAS_OBJECT[m.status]);
+    const missingInFlight = missing.length - missingDrift.length;
+
     console.log(`DB rows checked:      ${rows.length}`);
     console.log(`Already in sync:      ${inSync}`);
     console.log(`Mismatched tiers:     ${mismatches.length}`);
-    console.log(`Missing in S3:        ${missing.length}`);
+    console.log(`Missing in S3:        ${missingDrift.length}`);
+    console.log(`Missing, uploading:   ${missingInFlight}`);
     console.log(`Unmapped class:       ${unmapped.length}`);
     console.log(`S3 objects w/o row:   ${orphans.length}`);
 
     for (const m of mismatches) {
         console.log(`  ~ ${m.s3Key}  ${m.from} -> ${m.to}`);
     }
-    for (const key of missing) {
-        console.log(`  ? ${key}  (row has no S3 object)`);
+    for (const m of missing) {
+        console.log(`  ? ${m.s3Key}  (${m.status} row has no S3 object)`);
     }
     for (const u of unmapped) {
         console.log(`  ! ${u.s3Key}  (unmapped class: ${u.storageClass})`);
     }
 
-    if (mismatches.length === 0) {
-        console.log('\nNothing to update.');
+    if (isCheck) {
+        // Every condition that means DB and bucket disagree, not just the
+        // subset --apply can repair. Missing objects and unmapped classes need
+        // a human, so they used to pass silently while looking checked (#318).
+        const drift = mismatches.length + missingDrift.length + unmapped.length;
+        if (drift === 0) {
+            console.log('\nNo drift.');
+            return;
+        }
+
+        const detail =
+            `${mismatches.length} tier, ${missingDrift.length} missing, ` +
+            `${unmapped.length} unmapped`;
+        console.log(
+            `\nCheck failed: ${drift} row(s) disagree with S3 (${detail}).`
+        );
+        process.exitCode = 1;
+
+        // The exit-1 (and its workflow-failure email) stays as the dead-man
+        // backup for the check itself; this pushes the findings where they
+        // get seen (#288).
+        const runUrl = getWorkflowRunUrl();
+        await alerts.send({
+            severity: 'error',
+            title: 'Storage-tier drift detected',
+            message: `${drift} file row(s) disagree with S3 (${detail}).`,
+            context: {
+                source: 'backfill-storage-tier',
+                ...(runUrl && { workflowRun: runUrl }),
+            },
+        });
         return;
     }
 
-    if (isCheck) {
-        console.log('\nCheck failed: storage tiers have drifted from S3.');
-        process.exitCode = 1;
+    if (mismatches.length === 0) {
+        console.log('\nNothing to update.');
         return;
     }
 

--- a/docs/guides/environment-setup.md
+++ b/docs/guides/environment-setup.md
@@ -215,9 +215,9 @@ key manually (`aws iam create-access-key --user-name nexus-app-prod`).
   can't be scoped read-only: this token can also _write_ env vars, so treat
   it as a real credential.
 
-The prod DB health leg (`check:s3-event-health`) already runs nightly for
-both environments via the dev/prod matrix in `s3-event-health.yml`
-(`DATABASE_URL_PROD` secret).
+`s3-event-health.yml` runs nightly against both environments, matrixing
+`DATABASE_URL` and the AWS key/bucket per env. Secret names and how to create
+the prod key: [[../infra/supabase-manual-setup|Supabase Manual Setup]].
 
 ## Related
 

--- a/docs/infra/supabase-manual-setup.md
+++ b/docs/infra/supabase-manual-setup.md
@@ -48,7 +48,10 @@ postgresql://postgres.[PROJECT-REF]:[PASSWORD]@aws-0-[REGION].pooler.supabase.co
 > [!warning] Port 6543 is load-bearing, not a preference.
 > `packages/db/src/connection.ts` sets `prepare: false` unconditionally because Supabase's transaction-mode pooler does not support prepared statements — statements can land on different pooled backends, which intermittently loses transactions. **Both dev and prod `DATABASE_URL`s must be transaction-pooler URLs (port 6543).** Do not use the direct connection (5432) or session pooler.
 
-## GitHub Actions Secret
+## GitHub Actions Secrets
+
+Every prod-scoped secret the nightly workflows need, Supabase and otherwise —
+`docs/infra/aws-manual-setup.md` is superseded, so the AWS ones live here too.
 
 The existing `DATABASE_URL` secret stays pointed at **dev** (no rename). Add the prod pooler URL as a new secret:
 
@@ -63,6 +66,21 @@ Consumed by:
 - `migration-drift.yml` — nightly drift check (prod matrix leg)
 - `supabase-keepalive.yml` — keepalive ping (prod matrix leg)
 - `s3-event-health.yml` — DB health checks (prod matrix leg)
+
+That workflow's prod leg also compares `files` rows against the prod bucket, so
+it needs prod AWS credentials in the same matrix (#318). The key belongs to
+`nexus-ci-prod` — a read-only IAM user Terraform creates for exactly this, so a
+nightly job never holds write access to production data:
+
+```bash
+aws iam create-access-key --user-name nexus-ci-prod
+
+gh secret set AWS_ACCESS_KEY_ID_PROD --app actions
+gh secret set AWS_SECRET_ACCESS_KEY_PROD --app actions
+gh secret set S3_BUCKET_PROD --app actions   # nexus-storage-files-prod
+```
+
+`AWS_REGION` stays shared — both environments live in `us-east-1`.
 
 ## Vercel Environment Variables
 
@@ -106,7 +124,7 @@ gh workflow run supabase-keepalive.yml
 ## Follow-Ups
 
 - ~~Repoint the Vercel production deployment at the prod project~~ — done in #291 (PR #315); Production runs on the prod `DATABASE_URL` and prod AWS resources.
-- **`s3-event-health.yml` prod leg**: still runs with dev AWS credentials (only `DATABASE_URL` is matrixed), so its prod storage-tier check is false-green — tracked in #318.
+- ~~**`s3-event-health.yml` prod leg** runs with dev AWS credentials~~ — fixed in #318; the AWS key and bucket are matrixed per env alongside `DATABASE_URL`.
 
 ## Related
 

--- a/infra/terraform/iam.tf
+++ b/infra/terraform/iam.tf
@@ -52,3 +52,32 @@ resource "aws_iam_user_policy" "app_sqs" {
     }]
   })
 }
+
+# Nightly-CI IAM user (#318)
+#
+# Exists so the s3-event-health workflow never needs the app user's key: that
+# would hand a scheduled job PutObject/DeleteObject/RestoreObject on production
+# data to answer a read-only question.
+#
+# Both workspaces get one to keep the module set identical across environments
+# (#127). Only prod's key is wired into GitHub Actions — the dev leg shares the
+# flat AWS_* secrets with workflows that do need to write.
+resource "aws_iam_user" "ci" {
+  name = "nexus-ci-${var.environment}"
+}
+
+resource "aws_iam_user_policy" "ci_s3_read" {
+  name = "nexus-ci-s3-read-${var.environment}"
+  user = aws_iam_user.ci.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      # ListBucket alone: ListObjectsV2 reports each object's StorageClass, so
+      # the drift check never reads object bodies or metadata.
+      Effect   = "Allow"
+      Action   = "s3:ListBucket"
+      Resource = aws_s3_bucket.files.arn
+    }]
+  })
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -5,6 +5,9 @@
 #   AWS_REGION        <- aws_region
 #   SQS_QUEUE_URL     <- sqs_queue_url
 #   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY <- manual access key on app_iam_user
+#
+# GitHub Actions additionally holds a read-only key on ci_iam_user as
+# AWS_ACCESS_KEY_ID_PROD / AWS_SECRET_ACCESS_KEY_PROD (#318).
 
 output "s3_bucket" {
   description = "Files bucket name -> Vercel S3_BUCKET"
@@ -29,6 +32,11 @@ output "sqs_queue_url" {
 output "app_iam_user" {
   description = "Web-app IAM user; create its access key manually -> Vercel AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY"
   value       = aws_iam_user.app.name
+}
+
+output "ci_iam_user" {
+  description = "Read-only nightly-CI user (#318); create its access key manually -> GitHub Actions AWS_ACCESS_KEY_ID_PROD / AWS_SECRET_ACCESS_KEY_PROD"
+  value       = aws_iam_user.ci.name
 }
 
 output "sns_topic_arn" {


### PR DESCRIPTION
## Summary

The nightly `s3-event-health.yml` prod matrix leg looked like prod coverage but could not fail. Only `DATABASE_URL` was matrixed, so the storage-tier drift check compared **prod DB rows against the dev bucket** with dev credentials — and `--check` only exited 1 on tier *mismatches*, never on "missing in S3", which is all a cross-env comparison can produce. Permanent green, zero prod S3 coverage.

Two independent bugs, both fixed:

1. **Cross-env comparison.** The AWS key and bucket are now matrixed alongside `DATABASE_URL`. Prod's credentials come from a new read-only IAM user (`nexus-ci-prod`, `s3:ListBucket` on the files bucket and nothing else) rather than the read/write app user — a nightly scheduled job shouldn't hold `PutObject`/`DeleteObject` on production data to answer a read-only question.
2. **Vacuous exit code.** `if (mismatches.length === 0) return` fired *before* the `--check` branch, so missing objects and unmapped storage classes could never set exit 1. `--check` now fails on all three.

Missing-in-S3 is status-aware: an `uploading` row legitimately may have no object (PUT in flight, or abandoned — `reap:stale-uploads` owns those, #330), so only `available`/`restoring` rows count as drift. The status map is exhaustive over `fileStatusEnum`, so adding a status is a compile error rather than a silent pass back into the same failure mode.

The workflow comment rationalizing the old behaviour ("no prod S3 bucket exists yet") was stale since #53/#305 and is gone.

Closes #318

## Changes

- `.github/workflows/s3-event-health.yml` — matrix `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `S3_BUCKET` per env; preflight guard extended to fail loudly on any unset matrixed secret; stale comment replaced
- `apps/web/scripts/backfill-storage-tier.ts` — `--check` exits 1 on tier mismatches, object-backed rows missing from S3, and unmapped storage classes; failures also reach Discord via `@/lib/alerts`, matching the sibling check scripts (#288)
- `infra/terraform/iam.tf` / `outputs.tf` — read-only `nexus-ci-${environment}` IAM user
- Docs — `supabase-manual-setup.md` follow-up struck, prod AWS secret runbook added; `environment-setup.md` parity paragraph corrected

## Ops (applied via CLI — not in the diff)

- `terraform apply` on both workspaces: 2 resources added each, 0 changed, 0 destroyed
- `aws iam create-access-key --user-name nexus-ci-prod`
- `gh secret set AWS_ACCESS_KEY_ID_PROD / AWS_SECRET_ACCESS_KEY_PROD / S3_BUCKET_PROD`

Secrets are in place before merge, so the first scheduled run can't fail on a missing one.

## Test Plan

- [x] `pnpm check` — 10/10
- [x] `actionlint` + `terraform fmt -check` clean
- [x] Drift check against dev exits 1 with correct counts (73 rows, 6 in sync, 67 missing)
- [x] Prod simulated key-for-key before the change: 41 rows, 41 objects, all tiers aligned, 0 drift — the prod leg goes genuinely green
- [x] `gh workflow run s3-event-health.yml --ref issue-318` — first run ([31739730982](https://github.com/thomasreichmann/nexus/actions/runs/31739730982)): **prod green** (41 rows, 41 in sync, `No drift.` — real ListObjectsV2 against `nexus-storage-files-prod` with the new read-only key, proving both the credential and that `s3:ListBucket` alone suffices), **dev red** (73 rows, 67 missing, exit 1). After repairing the dev drift, second run ([31817126064](https://github.com/thomasreichmann/nexus/actions/runs/31817126064)): **both legs green**.

## Dev drift, found and repaired

The fix immediately turned the dev leg red on 67 `available` rows pointing at
objects that #316 deleted when it emptied and recreated that bucket. Invisible
until this PR made the check capable of failing — the bug finding its first real
instance.

Repaired via `fileService.deleteUserFile` (soft-delete + `storage_usage`
decrement in one transaction, the same path a user delete takes), 67 rows across
10 users, 0 failures. No new script committed; the durable version is an open
question on #378.

The decrement clamped while repairing — 207 MB / 6 files came off counters
instead of the 468 MB / 67 files passed in, because dev's `storage_usage` was
already understated. Checked rather than assumed: prod's counters match its rows
exactly, so `fileService` maintains the invariant correctly. Dev's drift comes
from test data writing `files` and `storage_usage` through independent back-door
helpers (`test-db/inserts.ts`, `seed/builders.ts`). Nothing to fix — see #378,
closed with the numbers.

The `--check` semantics changed, so the one-time PR #278 comment's
"`backfill:storage-tier --check`: no drift" line now means strictly more than it
did.

## Findings deferred from self-review

Cross-cutting cleanups, all pre-existing and out of scope here:

- Extract the `exit 1 + getWorkflowRunUrl() + alerts.send()` epilogue duplicated across four check scripts into `@/lib/alerts`
- Export `FileStatus` from `@nexus/db` instead of five local re-derivations
- Promote the secret-preflight guard into a `.github/actions/verify-secrets` composite (four workflows repeat it)
- Replace this job's inert real secrets (Stripe, Resend, `BETTER_AUTH_SECRET`) with literal placeholders, per the pattern `ci.yml` already documents — it would stop a nightly job from holding credentials no script reads
- Latent: the "unset `DISCORD_ALERT_WEBHOOK_URL` degrades to a no-op" comment isn't quite right — an empty string fails `z.string().url()`. Doesn't bite because the secret is set.


