### PR TITLE
perf: run multi-file uploads through a bounded pool (#340)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,10 +1,10 @@
 import type { ReactNode } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import { Toaster } from 'sonner';
 import { ClientErrorReporter } from '@/components/ClientErrorReporter';
 import { PostHogAnalytics } from '@/components/PostHogAnalytics';
 import { ThemeProvider } from '@/components/theme-provider';
+import { Toaster } from '@/components/ui/sonner';
 import { TRPCReactProvider } from '@/lib/trpc/client';
 import type { Metadata } from 'next';
 import './globals.css';
@@ -46,8 +46,10 @@ export default function RootLayout({
                         <PostHogAnalytics />
                         {children}
                     </TRPCReactProvider>
+                    {/* Inside ThemeProvider: the toaster reads the resolved
+                        theme so toasts match the UI. */}
+                    <Toaster />
                 </ThemeProvider>
-                <Toaster />
                 {/* Vercel injects /_vercel/insights/script.js only on its edge;
                     off-Vercel (local/CI production builds, e.g. e2e) that script
                     404s and pollutes the zero-console-error assertions, so only

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -55,7 +55,15 @@ export function DashboardSidebar() {
                     </p>
                     <div className="mt-2 h-2 overflow-hidden rounded-full bg-sidebar-border">
                         <div
-                            className="h-full rounded-full bg-primary transition-all"
+                            className={cn(
+                                'h-full rounded-full transition-all',
+                                // A full bar in the brand color reads as calm;
+                                // at the cap it should read as the reason
+                                // uploads are failing.
+                                (usage?.percentage ?? 0) >= 100
+                                    ? 'bg-destructive'
+                                    : 'bg-primary'
+                            )}
                             style={{
                                 width: `${usage?.percentage ?? 0}%`,
                             }}

--- a/apps/web/components/dashboard/upload-zone.tsx
+++ b/apps/web/components/dashboard/upload-zone.tsx
@@ -2,6 +2,8 @@
 
 import type React from 'react';
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
 import {
     Upload,
     X,
@@ -19,11 +21,13 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { cn } from '@/lib/cn';
 import { formatBytes } from '@/lib/format';
+import { useTRPC } from '@/lib/trpc/client';
 import {
     isFileSystemAccessSupported,
     pickFilesWithHandles,
     pickedFilesFromDataTransfer,
 } from '@/lib/upload/fileSystemAccess';
+import { MiddleTruncateName } from './MiddleTruncateName';
 import { useUpload, type UploadStatus } from './useUpload';
 
 // Formats the browser can decode natively — RAW files (NEF/CR3/ARW/…) carry
@@ -82,10 +86,30 @@ export function UploadZone() {
         setIsDragOver(false);
     };
 
+    const trpc = useTRPC();
+    // Cached by the sidebar's identical query most of the time; gives the
+    // summary an honest "how much room is left" figure.
+    const { data: usage } = useQuery(trpc.storage.getUsage.queryOptions());
+
     const totalSize = files.reduce((acc, f) => acc + f.size, 0);
-    const estimatedCost = (totalSize / (1024 * 1024 * 1024)) * 0.01; // $0.01 per GB per month
     const pendingFiles = files.filter((f) => f.status === 'pending');
-    const hasCompletedFiles = files.some((f) => f.status === 'complete');
+    const completedCount = files.filter((f) => f.status === 'complete').length;
+    const errorCount = files.filter((f) => f.status === 'error').length;
+    const pausedCount = files.filter((f) => f.status === 'paused').length;
+    const activeCount = files.filter(
+        (f) => f.status === 'queued' || f.status === 'uploading'
+    ).length;
+    // The wave is live while the pool holds rows; `isUploading` alone would
+    // blink off during the batch-creation await before any row is admitted.
+    const hasActiveWave = isUploading || activeCount > 0;
+    const attemptedCount = completedCount + errorCount;
+    // The outcome line waits for a settled queue: nothing moving, nothing the
+    // user still has to submit, nothing parked waiting for a reconnect.
+    const showOutcome =
+        !hasActiveWave &&
+        pendingFiles.length === 0 &&
+        pausedCount === 0 &&
+        attemptedCount > 0;
     const quickResumable = files.filter(
         (f) => f.status === 'resumable' && f.isQuickResumable
     );
@@ -131,13 +155,11 @@ export function UploadZone() {
                                 // an interrupted upload) to fire onChange again.
                                 e.target.value = '';
                             }}
-                            disabled={isUploading}
                         />
-                        <Button
-                            variant="outline"
-                            disabled={isUploading}
-                            onClick={handleBrowse}
-                        >
+                        {/* Deliberately enabled mid-wave (drag-drop always
+                            was): added files queue as pending and the Upload
+                            button lets them join the running wave. */}
+                        <Button variant="outline" onClick={handleBrowse}>
                             Browse files
                         </Button>
                     </div>
@@ -197,9 +219,10 @@ export function UploadZone() {
                                         status={file.status}
                                     />
                                     <div className="flex-1 min-w-0">
-                                        <p className="truncate font-medium">
-                                            {file.name}
-                                        </p>
+                                        <MiddleTruncateName
+                                            name={file.name}
+                                            className="font-medium"
+                                        />
                                         <p className="text-sm text-muted-foreground">
                                             {formatBytes(file.size)}
                                         </p>
@@ -210,6 +233,11 @@ export function UploadZone() {
                                                 value={file.progress}
                                                 className="mt-2 h-1"
                                             />
+                                        )}
+                                        {file.status === 'queued' && (
+                                            <p className="mt-1 text-xs text-muted-foreground">
+                                                Waiting to upload
+                                            </p>
                                         )}
                                         {file.status === 'paused' && (
                                             <p className="mt-1 text-xs text-amber-600">
@@ -231,21 +259,22 @@ export function UploadZone() {
                                                 </p>
                                             )}
                                     </div>
-                                    {file.status === 'pending' &&
-                                        !isUploading && (
-                                            <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                onClick={() =>
-                                                    removeFile(file.id)
-                                                }
-                                            >
-                                                <X className="h-4 w-4" />
-                                                <span className="sr-only">
-                                                    Remove
-                                                </span>
-                                            </Button>
-                                        )}
+                                    {/* Removable while queued too: the pool
+                                        re-reads the row at start time, so a
+                                        removed row is simply skipped. */}
+                                    {(file.status === 'pending' ||
+                                        file.status === 'queued') && (
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            onClick={() => removeFile(file.id)}
+                                        >
+                                            <X className="h-4 w-4" />
+                                            <span className="sr-only">
+                                                Remove
+                                            </span>
+                                        </Button>
+                                    )}
                                     {file.status === 'resumable' &&
                                         file.isQuickResumable && (
                                             <Button
@@ -303,43 +332,77 @@ export function UploadZone() {
                                         {formatBytes(totalSize)}
                                     </span>
                                 </p>
-                                <p className="text-sm">
-                                    <span className="text-muted-foreground">
-                                        Est. monthly cost:
-                                    </span>{' '}
-                                    <span className="font-medium">
-                                        ${estimatedCost.toFixed(2)}
-                                    </span>
-                                </p>
-                            </div>
-                            {pendingFiles.length > 0 && (
-                                <Button
-                                    onClick={startUpload}
-                                    disabled={isUploading}
-                                >
-                                    {isUploading ? (
-                                        <>
-                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                            Uploading...
-                                        </>
-                                    ) : (
-                                        <>
-                                            <Upload className="mr-2 h-4 w-4" />
-                                            Upload {pendingFiles.length}{' '}
-                                            {pendingFiles.length === 1
-                                                ? 'file'
-                                                : 'files'}
-                                        </>
-                                    )}
-                                </Button>
-                            )}
-                            {hasCompletedFiles &&
-                                pendingFiles.length === 0 &&
-                                !isUploading && (
-                                    <p className="text-sm font-medium text-green-500">
-                                        All files uploaded successfully!
+                                {usage && (
+                                    <p className="text-sm">
+                                        <span className="text-muted-foreground">
+                                            Storage available:
+                                        </span>{' '}
+                                        <span className="font-medium">
+                                            {formatBytes(
+                                                Math.max(
+                                                    usage.quotaBytes -
+                                                        usage.usedBytes,
+                                                    0
+                                                )
+                                            )}
+                                        </span>
                                     </p>
                                 )}
+                                {hasActiveWave && (
+                                    <p className="text-sm">
+                                        <span className="text-muted-foreground">
+                                            Uploaded:
+                                        </span>{' '}
+                                        <span className="font-medium">
+                                            {completedCount} of{' '}
+                                            {activeCount + attemptedCount} files
+                                        </span>
+                                    </p>
+                                )}
+                            </div>
+                            <div className="flex flex-wrap items-center gap-3">
+                                {/* Persistent live region so the wave's
+                                    outcome is announced, not just painted. */}
+                                <div aria-live="polite">
+                                    {showOutcome &&
+                                        (errorCount === 0 ? (
+                                            <p className="text-sm font-medium text-green-500">
+                                                All files uploaded successfully!
+                                            </p>
+                                        ) : (
+                                            <p className="text-sm font-medium text-amber-600">
+                                                {completedCount} of{' '}
+                                                {attemptedCount} files uploaded
+                                                — {errorCount} failed
+                                            </p>
+                                        ))}
+                                </div>
+                                {showOutcome && completedCount > 0 && (
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        render={
+                                            <Link href="/dashboard/files" />
+                                        }
+                                    >
+                                        View files
+                                    </Button>
+                                )}
+                                {pendingFiles.length > 0 ? (
+                                    <Button onClick={startUpload}>
+                                        <Upload className="mr-2 h-4 w-4" />
+                                        Upload {pendingFiles.length}{' '}
+                                        {pendingFiles.length === 1
+                                            ? 'file'
+                                            : 'files'}
+                                    </Button>
+                                ) : hasActiveWave ? (
+                                    <Button disabled>
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                        Uploading...
+                                    </Button>
+                                ) : null}
+                            </div>
                         </div>
                     </CardContent>
                 </Card>
@@ -379,7 +442,10 @@ function UploadPreviewTile({
         return () => URL.revokeObjectURL(previewUrl);
     }, [previewUrl]);
 
-    const showStatusIcon = status !== 'pending' || !previewUrl;
+    // Pending and queued rows keep a clean preview — the scrim + icon only
+    // takes over once the row has a state worth signalling.
+    const showStatusIcon =
+        (status !== 'pending' && status !== 'queued') || !previewUrl;
 
     return (
         <div className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted">

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -50,6 +50,7 @@ import {
     isNetworkError,
     isQuotaExceededError,
     reportUploadFailure,
+    uploadErrorMessage,
     uploadEventProps,
     type UploadEngine,
 } from '@/lib/upload/errors';
@@ -67,6 +68,10 @@ const CANCEL = 'cancel';
 
 export type UploadStatus =
     | 'pending'
+    // Admitted to the pool but not started — distinct from `pending` so the
+    // Upload button only counts files the user hasn't submitted yet, which is
+    // what lets files added mid-wave join the running wave with a click.
+    | 'queued'
     | 'uploading'
     | 'paused'
     | 'resumable'
@@ -281,7 +286,7 @@ export function useUpload() {
             });
             updateFile(uploadFile.id, {
                 status: 'error',
-                error: error instanceof Error ? error.message : 'Upload failed',
+                error: uploadErrorMessage(error),
             });
             return isQuotaExceededError(error) ? 'halt' : 'continue';
         },
@@ -686,6 +691,15 @@ export function useUpload() {
         // Once per drained wave, not once per file: four concurrent files
         // would otherwise fire four refetch storms across three queries.
         onDrained: () => invalidateFileListRef.current(),
+        // A quota halt throws away the queue; put those rows back to
+        // `pending` so the Upload button re-owns them instead of leaving
+        // them stranded in `queued` with nothing left to start them.
+        // (`updateFile` is stable, so closing over it here is safe.)
+        onDropped: (items) => {
+            for (const item of items) {
+                updateFile(item.id, { status: 'pending' });
+            }
+        },
     });
 
     // `isUploading` has several owners (the pool, quick-resume) and must not
@@ -717,6 +731,14 @@ export function useUpload() {
             (f) => f.status === 'pending' && f.file
         );
         if (pending.length === 0) return;
+
+        // Claim the rows before the batch round trip: the Upload button stays
+        // enabled while a wave runs (so added files can join it), which makes
+        // a second click during the await possible — `queued` is what keeps
+        // that click from minting a second batch for the same rows.
+        for (const f of pending) {
+            updateFile(f.id, { status: 'queued' });
+        }
 
         // One batch per Upload click: every pending file in this pass joins
         // it, so a multi-file selection lands in a single upload_batches row.
@@ -974,8 +996,11 @@ export function useUpload() {
         (id: string) => {
             const file = filesRef.current.find((f) => f.id === id);
             if (!file?.file) return;
+            // Straight to `queued`, not `pending`: the row is being handed to
+            // the pool right now, so it must not re-enter the Upload button's
+            // pending count on the way through.
             updateFile(id, {
-                status: 'pending',
+                status: 'queued',
                 error: undefined,
             });
             void drive([toQueuedUpload(file)]);
@@ -1006,15 +1031,17 @@ export function useUpload() {
                         continue;
                     }
                     hasResumedAny = true;
+                    // `queued`, not `pending`: the row is on its way into the
+                    // engine, so it must not count toward the Upload button.
                     updateFile(row.id, {
                         file,
-                        status: 'pending',
+                        status: 'queued',
                         error: undefined,
                     });
                     await uploadMultipartFile({
                         ...row,
                         file,
-                        status: 'pending',
+                        status: 'queued',
                     });
                 }
                 if (!hasResumedAny) {

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -8,6 +8,21 @@ import { toastContext } from '@/lib/trpc/error-link';
 import { useInvalidateFileList } from '@/lib/hooks/useInvalidateFileList';
 import { xhrPut } from '@/lib/http/xhr';
 import { retryAsync } from '@/lib/async/retry';
+import { createSemaphore } from '@/lib/async/semaphore';
+import {
+    createFilePool,
+    type FilePool,
+    type FileRunOutcome,
+} from '@/lib/upload/filePool';
+import {
+    CONFIRM_RETRIES,
+    MAX_CHUNK_RETRIES,
+    MAX_CONCURRENT_CHUNKS,
+    MAX_CONCURRENT_FILES,
+    MAX_IN_FLIGHT_BYTES,
+    MULTIPART_THRESHOLD,
+    S3_CONNECTION_BUDGET,
+} from '@/lib/upload/limits';
 import {
     addCompletedPart,
     deleteUpload,
@@ -33,6 +48,7 @@ import {
     isAbortError,
     isExpiredUrlError,
     isNetworkError,
+    isQuotaExceededError,
     reportUploadFailure,
     uploadEventProps,
     type UploadEngine,
@@ -40,10 +56,8 @@ import {
 import { captureEvent } from '@/lib/posthog/client';
 import { PostHogEvent } from '@/lib/posthog/events';
 
-const MULTIPART_THRESHOLD = 100 * 1024 * 1024; // 100MB
-const MAX_CONCURRENT_CHUNKS = 3;
-const MAX_CHUNK_RETRIES = 3;
-const CONFIRM_RETRIES = 3;
+// One budget for the whole tab, shared across every engine and file.
+const s3Budget = createSemaphore(S3_CONNECTION_BUDGET);
 
 // AbortController reasons let the engine's catch tell why an in-flight upload
 // was stopped: a pause keeps the persisted state for auto-resume, a cancel
@@ -95,6 +109,24 @@ interface InternalUploadFile extends UploadFile {
     // truth reconciled on every resume.
     completedParts?: CompletedPart[];
     abortController?: AbortController;
+}
+
+/**
+ * What the pool needs to admit a row: an identity to de-duplicate on, a size to
+ * weigh against the in-flight byte budget, and the batch the row belongs to.
+ * The row itself is re-read at start time, so nothing here can go stale.
+ */
+interface QueuedUpload {
+    id: string;
+    size: number;
+    batchId?: string;
+}
+
+function toQueuedUpload(
+    file: InternalUploadFile,
+    batchId?: string
+): QueuedUpload {
+    return { id: file.id, size: file.size, batchId: batchId ?? file.batchId };
 }
 
 function randomId(): string {
@@ -155,6 +187,11 @@ export function useUpload() {
 
     const invalidateFileList = useInvalidateFileList();
 
+    // These observers are shared by every file the pool runs at once. Each
+    // `mutateAsync` call still builds its own mutation and resolves with its
+    // own result, but the observer's `isPending`/`data`/`error` are
+    // last-writer-wins across files — per-row state has to come from the row
+    // itself, never from these objects.
     const uploadMutation = useMutation(trpc.files.upload.mutationOptions());
     const createBatchMutation = useMutation(
         trpc.files.createBatch.mutationOptions()
@@ -203,13 +240,64 @@ export function useUpload() {
         []
     );
 
+    /**
+     * The failure policy both engines share, in one place so a fix can't land
+     * in only one of them: an abort is a pause unless the row is being torn
+     * down, a drop while offline waits for reconnect, and anything else is a
+     * real failure the row reports and the user can retry. Quota is the one
+     * failure about the account rather than the file, so it also stops the
+     * pool from spending the rest of the queue on the same rejection.
+     */
+    const handleUploadFailure = useCallback(
+        (
+            error: unknown,
+            engine: UploadEngine,
+            uploadFile: InternalUploadFile,
+            context: {
+                // Fresher than the row's own: init assigns it after the engine
+                // has already closed over `uploadFile`.
+                fileId: string | undefined;
+                batchId: string | undefined;
+                signal: AbortSignal;
+            }
+        ): FileRunOutcome => {
+            if (isAbortError(error)) {
+                // A cancel tears the row down in cancelFile, so there's nothing
+                // left to update. A pause has to leave the row in `paused` for
+                // the reconnect handler to find.
+                if (context.signal.reason !== CANCEL) {
+                    updateFile(uploadFile.id, { status: 'paused' });
+                }
+                return 'continue';
+            }
+            if (isNetworkError(error) && !navigatorIsOnline()) {
+                updateFile(uploadFile.id, { status: 'paused' });
+                return 'continue';
+            }
+            reportUploadFailure(error, engine, {
+                ...uploadFile,
+                fileId: context.fileId,
+                batchId: context.batchId,
+            });
+            updateFile(uploadFile.id, {
+                status: 'error',
+                error: error instanceof Error ? error.message : 'Upload failed',
+            });
+            return isQuotaExceededError(error) ? 'halt' : 'continue';
+        },
+        [updateFile]
+    );
+
     const uploadSingleFile = useCallback(
         // batchId is threaded explicitly (not read back via filesRef) because a
         // just-issued updateFile isn't visible until the next render commit.
         // Callers without a session batch (retry) fall back to the row's own.
-        async (uploadFile: InternalUploadFile, batchId?: string) => {
+        async (
+            uploadFile: InternalUploadFile,
+            batchId?: string
+        ): Promise<FileRunOutcome> => {
             const file = uploadFile.file;
-            if (!file) return;
+            if (!file) return 'continue';
             const sessionBatchId = batchId ?? uploadFile.batchId;
             const abortController = new AbortController();
             updateFile(uploadFile.id, {
@@ -222,6 +310,36 @@ export function useUpload() {
             // id once init has assigned it — the uploadFile closure predates
             // init (mirrors the multipart engine).
             let fileId = uploadFile.fileId;
+
+            // Presign *inside* the permit, not before waiting for it: a
+            // single-part URL lives 15 minutes, and a small file queued behind
+            // multipart traffic on a slow uplink can wait longer than that.
+            // Minting the URL after the wait means it is always fresh when the
+            // PUT starts. The ~185ms this holds the permit is cheap, and it's
+            // the only permit this worker takes, so it can't deadlock.
+            const presignAndPut = () =>
+                s3Budget.run(async () => {
+                    const init = await uploadMutation.mutateAsync({
+                        name: file.name,
+                        sizeBytes: file.size,
+                        mimeType: file.type || undefined,
+                        batchId: sessionBatchId,
+                    });
+                    fileId = init.fileId;
+
+                    updateFile(uploadFile.id, { fileId });
+
+                    await xhrPut(init.uploadUrl, file, {
+                        onProgress: (loaded, total) => {
+                            updateFile(uploadFile.id, {
+                                progress: Math.round((loaded / total) * 100),
+                            });
+                        },
+                        signal: abortController.signal,
+                    });
+                    return init.fileId;
+                });
+
             try {
                 // Every restart of this engine (retry, or auto-resume after a
                 // network drop) mints a fresh fileId, row, and s3Key, so the
@@ -233,26 +351,24 @@ export function useUpload() {
                     abandonUploadMutation.mutate({ fileId });
                 }
 
-                const init = await uploadMutation.mutateAsync({
-                    name: file.name,
-                    sizeBytes: file.size,
-                    mimeType: file.type || undefined,
-                    batchId: sessionBatchId,
-                });
-                fileId = init.fileId;
+                let confirmedFileId: string;
+                try {
+                    confirmedFileId = await presignAndPut();
+                } catch (error) {
+                    if (!isExpiredUrlError(error)) throw error;
+                    // S3 reports an expired URL as a 403. This engine has no
+                    // re-presign procedure — `files.upload` is the only source
+                    // of a single-part URL and it mints a whole new row — so
+                    // releasing the dead attempt and starting over is the
+                    // re-presign. Once: a 403 that isn't expiry (a bucket
+                    // policy denial) would fail identically forever.
+                    if (fileId) abandonUploadMutation.mutate({ fileId });
+                    confirmedFileId = await presignAndPut();
+                }
 
-                updateFile(uploadFile.id, { fileId });
-
-                await xhrPut(init.uploadUrl, file, {
-                    onProgress: (loaded, total) => {
-                        updateFile(uploadFile.id, {
-                            progress: Math.round((loaded / total) * 100),
-                        });
-                    },
-                    signal: abortController.signal,
-                });
-
-                await confirmMutation.mutateAsync({ fileId: init.fileId });
+                // Confirm goes to the app origin, a different host with its own
+                // socket budget, so it runs outside the S3 permit.
+                await confirmMutation.mutateAsync({ fileId: confirmedFileId });
 
                 updateFile(uploadFile.id, {
                     status: 'complete',
@@ -264,29 +380,12 @@ export function useUpload() {
                     fileId,
                     sessionBatchId
                 );
-                await invalidateFileList();
+                return 'continue';
             } catch (error) {
-                if (isAbortError(error)) {
-                    return;
-                }
-                // A network drop pauses for reconnect rather than failing the
-                // upload — same policy as the multipart engine; the online
-                // handler restarts it.
-                if (isNetworkError(error) && !navigatorIsOnline()) {
-                    updateFile(uploadFile.id, { status: 'paused' });
-                    return;
-                }
-                reportUploadFailure(error, 'single', {
-                    ...uploadFile,
+                return handleUploadFailure(error, 'single', uploadFile, {
                     fileId,
                     batchId: sessionBatchId,
-                });
-                updateFile(uploadFile.id, {
-                    status: 'error',
-                    error:
-                        error instanceof Error
-                            ? error.message
-                            : 'Upload failed',
+                    signal: abortController.signal,
                 });
             }
         },
@@ -295,7 +394,7 @@ export function useUpload() {
             confirmMutation,
             abandonUploadMutation,
             updateFile,
-            invalidateFileList,
+            handleUploadFailure,
         ]
     );
 
@@ -303,9 +402,12 @@ export function useUpload() {
         // Same explicit batchId threading as uploadSingleFile; only the
         // fresh-start branch uses it (a resume already committed membership
         // server-side at the original init).
-        async (uploadFile: InternalUploadFile, batchId?: string) => {
+        async (
+            uploadFile: InternalUploadFile,
+            batchId?: string
+        ): Promise<FileRunOutcome> => {
             const file = uploadFile.file;
-            if (!file) return;
+            if (!file) return 'continue';
             const sessionBatchId = batchId ?? uploadFile.batchId;
 
             const abortController = new AbortController();
@@ -427,12 +529,18 @@ export function useUpload() {
                     const retryablePutError = (error: unknown) =>
                         !isAbortError(error) && !isExpiredUrlError(error);
 
+                    // One permit per attempt, taken and released around the PUT
+                    // itself: the retry backoff and the re-presign below happen
+                    // without holding a connection, and a chunk worker never
+                    // holds one permit while waiting on another.
                     const put = (url: string) =>
                         retryAsync(
                             () =>
-                                xhrPut(url, blob, {
-                                    signal: abortController.signal,
-                                }),
+                                s3Budget.run(() =>
+                                    xhrPut(url, blob, {
+                                        signal: abortController.signal,
+                                    })
+                                ),
                             MAX_CHUNK_RETRIES,
                             1000,
                             retryablePutError
@@ -466,33 +574,32 @@ export function useUpload() {
                     });
                 };
 
-                // Bounded worker pool. The first real failure aborts its
-                // siblings (their in-flight PUTs reject) and propagates out.
-                const queue = [...partUrls.keys()].sort((a, b) => a - b);
+                // Per-file part concurrency. Deliberately fail-fast, unlike the
+                // file pool: the first real failure aborts its siblings (their
+                // in-flight PUTs reject) and propagates out, because these are
+                // parts of one object rather than independent files.
+                //
+                // A part holds this file's chunk permit while waiting for the
+                // shared S3 permit inside `put`. That nesting is always in the
+                // same order — chunk budget, then connection budget — so it
+                // can't deadlock, and the outer permit is what keeps
+                // MAX_CONCURRENT_CHUNKS a per-file ceiling.
+                const chunkBudget = createSemaphore(MAX_CONCURRENT_CHUNKS);
+                const partNumbers = [...partUrls.keys()].sort((a, b) => a - b);
                 let firstError: unknown = null;
-                const worker = async (): Promise<void> => {
-                    while (queue.length > 0 && !firstError) {
-                        const partNumber = queue.shift()!;
-                        try {
-                            await uploadOnePart(partNumber);
-                        } catch (error) {
-                            if (!firstError) {
-                                firstError = error;
-                                abortController.abort();
-                            }
-                            return;
-                        }
-                    }
-                };
                 await Promise.all(
-                    Array.from(
-                        {
-                            length: Math.min(
-                                MAX_CONCURRENT_CHUNKS,
-                                queue.length
-                            ),
-                        },
-                        () => worker()
+                    partNumbers.map((partNumber) =>
+                        chunkBudget.run(async () => {
+                            if (firstError) return;
+                            try {
+                                await uploadOnePart(partNumber);
+                            } catch (error) {
+                                if (!firstError) {
+                                    firstError = error;
+                                    abortController.abort();
+                                }
+                            }
+                        })
                     )
                 );
                 if (firstError) throw firstError;
@@ -514,35 +621,12 @@ export function useUpload() {
                     fileId,
                     sessionBatchId
                 );
-                await invalidateFileList();
+                return 'continue';
             } catch (error) {
-                if (isAbortError(error)) {
-                    // A cancel tears everything down in cancelFile; the engine
-                    // just stands down. A pause keeps the record for resume.
-                    if (abortController.signal.reason === CANCEL) return;
-                    updateFile(uploadFile.id, { status: 'paused' });
-                    return;
-                }
-                // A network drop past the retry budget pauses for reconnect
-                // rather than failing the whole upload.
-                if (isNetworkError(error) && !navigatorIsOnline()) {
-                    updateFile(uploadFile.id, { status: 'paused' });
-                    return;
-                }
-                // Spread picks up the local fileId assigned after init and
-                // the threaded session batch — both fresher than the stale
-                // uploadFile closure.
-                reportUploadFailure(error, 'multipart', {
-                    ...uploadFile,
+                return handleUploadFailure(error, 'multipart', uploadFile, {
                     fileId,
                     batchId: sessionBatchId,
-                });
-                updateFile(uploadFile.id, {
-                    status: 'error',
-                    error:
-                        error instanceof Error
-                            ? error.message
-                            : 'Upload failed',
+                    signal: abortController.signal,
                 });
             }
         },
@@ -552,7 +636,7 @@ export function useUpload() {
             multipartListPartsMutation,
             multipartSignPartsMutation,
             updateFile,
-            invalidateFileList,
+            handleUploadFailure,
         ]
     );
 
@@ -564,8 +648,75 @@ export function useUpload() {
         [uploadMultipartFile, uploadSingleFile]
     );
 
+    // The pool re-reads the row here rather than trusting the queued snapshot:
+    // between admission and start the user may have removed the row, and a
+    // prior attempt may have left a fileId/uploadId worth resuming from. Only
+    // the row's existence is checked, not its status — `filesRef` is assigned
+    // during render, so a just-issued "pending" hasn't committed yet.
+    const runQueued = useCallback(
+        async (item: QueuedUpload): Promise<FileRunOutcome> => {
+            const current = filesRef.current.find((f) => f.id === item.id);
+            if (!current?.file) return 'continue';
+            // A drop mid-wave pauses the files already in flight, but the pool
+            // keeps handing out the rest of the queue. Park them in `paused`
+            // alongside their siblings — the reconnect handler resumes the
+            // whole set — rather than spending a doomed presign on each and
+            // leaving a row in `error` that nothing comes back for.
+            if (!navigatorIsOnline()) {
+                updateFile(current.id, { status: 'paused' });
+                return 'continue';
+            }
+            return runUpload(current, item.batchId);
+        },
+        [runUpload, updateFile]
+    );
+
+    // Callbacks reach the pool through refs so it can be built once and outlive
+    // their re-creation — a pool rebuilt mid-wave would lose its in-flight set.
+    const runQueuedRef = useRef(runQueued);
+    runQueuedRef.current = runQueued;
+    const invalidateFileListRef = useRef(invalidateFileList);
+    invalidateFileListRef.current = invalidateFileList;
+
+    const poolRef = useRef<FilePool<QueuedUpload> | null>(null);
+    poolRef.current ??= createFilePool<QueuedUpload>({
+        maxConcurrent: MAX_CONCURRENT_FILES,
+        maxInFlightBytes: MAX_IN_FLIGHT_BYTES,
+        run: (item) => runQueuedRef.current(item),
+        // Once per drained wave, not once per file: four concurrent files
+        // would otherwise fire four refetch storms across three queries.
+        onDrained: () => invalidateFileListRef.current(),
+    });
+
+    // `isUploading` has several owners (the pool, quick-resume) and must not
+    // dip between files — the Upload button reads it, so a momentary false
+    // re-enables and re-labels it mid-wave.
+    const activeDriversRef = useRef(0);
+    const withUploadingState = useCallback(
+        async (work: () => Promise<void>): Promise<void> => {
+            activeDriversRef.current++;
+            setIsUploading(true);
+            try {
+                await work();
+            } finally {
+                activeDriversRef.current--;
+                if (activeDriversRef.current === 0) setIsUploading(false);
+            }
+        },
+        []
+    );
+
+    const drive = useCallback(
+        (items: QueuedUpload[]) =>
+            withUploadingState(() => poolRef.current!.enqueue(items)),
+        [withUploadingState]
+    );
+
     const processQueue = useCallback(async () => {
-        setIsUploading(true);
+        const pending = filesRef.current.filter(
+            (f) => f.status === 'pending' && f.file
+        );
+        if (pending.length === 0) return;
 
         // One batch per Upload click: every pending file in this pass joins
         // it, so a multi-file selection lands in a single upload_batches row.
@@ -575,10 +726,7 @@ export function useUpload() {
         let batchId: string | undefined;
         // Rows that already have a batch (retries, re-added resumables) keep
         // it, so only mint a session batch when some file still needs one.
-        const hasPending = filesRef.current.some(
-            (f) => f.status === 'pending' && f.file && !f.batchId
-        );
-        if (hasPending) {
+        if (pending.some((f) => !f.batchId)) {
             try {
                 ({ batchId } = await createBatchMutation.mutateAsync());
             } catch {
@@ -586,26 +734,18 @@ export function useUpload() {
             }
         }
 
-        for (const file of filesRef.current) {
-            if (file.status !== 'pending') continue;
+        // Retried/resumed rows keep their original batch; only rows without one
+        // join this session's batch. Written to the row for retry/persistence,
+        // but carried on the queue item too — the ref won't reflect this update
+        // until the next render commit.
+        const queued = pending.map((f) => {
+            const rowBatchId = f.batchId ?? batchId;
+            updateFile(f.id, { batchId: rowBatchId });
+            return toQueuedUpload(f, rowBatchId);
+        });
 
-            // Re-read from ref to get latest state (file may have been removed)
-            const current = filesRef.current.find((f) => f.id === file.id);
-            if (!current || current.status !== 'pending' || !current.file) {
-                continue;
-            }
-
-            // Retried/resumed rows keep their original batch; only rows
-            // without one join this session's batch. Written to the row for
-            // retry/persistence, but threaded to runUpload explicitly — the
-            // ref won't reflect this update until the next render commit.
-            const rowBatchId = current.batchId ?? batchId;
-            updateFile(current.id, { batchId: rowBatchId });
-            await runUpload(current, rowBatchId);
-        }
-
-        setIsUploading(false);
-    }, [runUpload, createBatchMutation, updateFile]);
+        await drive(queued);
+    }, [drive, createBatchMutation, updateFile]);
 
     // Surface interrupted uploads found in IndexedDB on mount as `resumable`
     // rows. Records that persisted a File System Access handle (and run on a
@@ -673,19 +813,11 @@ export function useUpload() {
             );
             if (paused.length === 0) return;
             toast.info('Back online — resuming upload');
-            void (async () => {
-                setIsUploading(true);
-                for (const f of paused) {
-                    const current = filesRef.current.find((x) => x.id === f.id);
-                    if (current?.status === 'paused' && current.file) {
-                        // runUpload, not uploadMultipartFile: a single-engine
-                        // upload paused by a network drop restarts through
-                        // its own engine.
-                        await runUpload(current);
-                    }
-                }
-                setIsUploading(false);
-            })();
+            // Back through the same pool, so a reconnect with twenty paused
+            // rows resumes them four at a time rather than all at once. Each
+            // row re-enters its own engine: a single-part upload paused by a
+            // drop restarts from byte zero, multipart resumes its parts.
+            void drive(paused.map((f) => toQueuedUpload(f)));
         };
         window.addEventListener('offline', onOffline);
         window.addEventListener('online', onOnline);
@@ -693,7 +825,7 @@ export function useUpload() {
             window.removeEventListener('offline', onOffline);
             window.removeEventListener('online', onOnline);
         };
-    }, [runUpload]);
+    }, [drive]);
 
     const addFiles = useCallback(async (picked: PickedFile[]) => {
         if (picked.length === 0) return;
@@ -835,33 +967,20 @@ export function useUpload() {
         setFiles([]);
     }, [abandonServerUpload]);
 
+    // Retry joins the live pool rather than waiting for it to empty: with
+    // several files in flight, a failed row's Retry is most often clicked while
+    // its siblings are still going.
     const retryFile = useCallback(
         (id: string) => {
+            const file = filesRef.current.find((f) => f.id === id);
+            if (!file?.file) return;
             updateFile(id, {
                 status: 'pending',
                 error: undefined,
             });
-            // If not currently uploading, start processing
-            if (!filesRef.current.some((f) => f.status === 'uploading')) {
-                const file = filesRef.current.find((f) => f.id === id);
-                if (file) {
-                    setIsUploading(true);
-                    const doRetry = async () => {
-                        const current = filesRef.current.find(
-                            (f) => f.id === id
-                        );
-                        if (!current || !current.file) {
-                            setIsUploading(false);
-                            return;
-                        }
-                        await runUpload(current);
-                        setIsUploading(false);
-                    };
-                    void doRetry();
-                }
-            }
+            void drive([toQueuedUpload(file)]);
         },
-        [updateFile, runUpload]
+        [updateFile, drive]
     );
 
     // Reopen interrupted uploads from their persisted handles and resume them
@@ -873,8 +992,7 @@ export function useUpload() {
     const resumeRows = useCallback(
         async (rows: InternalUploadFile[]) => {
             if (rows.length === 0) return;
-            setIsUploading(true);
-            try {
+            await withUploadingState(async () => {
                 const reopened = await Promise.all(
                     rows.map(async (row) => ({
                         row,
@@ -905,12 +1023,19 @@ export function useUpload() {
                             ? "Couldn't reopen the files — re-add them to resume"
                             : "Couldn't reopen the file — re-add it to resume"
                     );
+                    return;
                 }
-            } finally {
-                setIsUploading(false);
-            }
+                // The engines no longer refresh the list per file — the pool
+                // does it once per wave, and this path bypasses the pool.
+                await invalidateFileList();
+            });
         },
-        [updateFile, uploadMultipartFile]
+        [
+            updateFile,
+            uploadMultipartFile,
+            withUploadingState,
+            invalidateFileList,
+        ]
     );
 
     const resumeWithHandle = useCallback(

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { Toaster as Sonner, type ToasterProps } from 'sonner';
+
+/**
+ * Theme-aware Sonner toaster. Sonner defaults to its light theme, which is
+ * what put light-grey toasts on top of the dark UI; next-themes owns the
+ * app's theme (class attribute), so the toaster has to be told explicitly.
+ * Must render inside `ThemeProvider` for `useTheme` to resolve.
+ */
+export function Toaster(props: ToasterProps) {
+    const { resolvedTheme } = useTheme();
+    return (
+        <Sonner
+            theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
+            {...props}
+        />
+    );
+}

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -393,6 +393,30 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/upload'],
     },
     {
+        id: 'upload-concurrent-wave',
+        title: 'Multi-file upload runs several files at once, bounded by the pool size',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
+        id: 'upload-failure-isolation',
+        title: 'One file failing mid-wave leaves its siblings uploading',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
+        id: 'upload-offline-resume-wave',
+        title: 'Going offline mid-wave pauses the queue; reconnect drains it pool-bound',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
+        id: 'upload-quota-halt',
+        title: 'First quota rejection halts the wave with one message',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
         id: 'upload-cancel-cleanup',
         title: 'Cancelling an in-flight upload strands no uploading row',
         area: 'upload',

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -405,6 +405,12 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/upload'],
     },
     {
+        id: 'upload-multipart-budget',
+        title: 'Concurrent multipart files stay inside the shared S3 connection budget',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
         id: 'upload-offline-resume-wave',
         title: 'Going offline mid-wave pauses the queue; reconnect drains it pool-bound',
         area: 'upload',

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -405,6 +405,12 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/upload'],
     },
     {
+        id: 'upload-add-mid-wave',
+        title: 'Files added while a wave runs can join it without waiting',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
         id: 'upload-multipart-budget',
         title: 'Concurrent multipart files stay inside the shared S3 connection budget',
         area: 'upload',

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -13,12 +13,20 @@
  */
 import { resetUserData, insertStorageUsage } from '@nexus/db/test-db';
 import { PLAN_LIMITS, SOFT_LIMIT_MULTIPLIER } from '@nexus/db/plans';
-import { MAX_CONCURRENT_FILES } from '@/lib/upload/limits';
+import {
+    MAX_CONCURRENT_FILES,
+    MULTIPART_THRESHOLD,
+    S3_CONNECTION_BUDGET,
+} from '@/lib/upload/limits';
 import { test, expect } from '../fixtures';
 import { type TestUser } from '../helpers/auth';
 import { interceptTrpcCalls } from '../helpers/trpc';
 import { seedResumableUpload } from '../helpers/uploadStore';
-import { makeTextFiles, stubS3Puts } from '../helpers/uploadStubs';
+import {
+    makeTextFiles,
+    stubS3Puts,
+    writeLargeFiles,
+} from '../helpers/uploadStubs';
 
 const UPLOAD_USER: TestUser = {
     email: 'upload-flows-e2e@test.local',
@@ -278,6 +286,63 @@ test(
             expect(row.s3Key).toBe(
                 `${seedUserId}/${batches[0].id}/${row.id}/${row.name}`
             );
+        }
+    }
+);
+
+// The one case the single-PUT tests can't reach: four files each opening their
+// own chunk pool want 4 × MAX_CONCURRENT_CHUNKS connections, well past what a
+// browser will give one host. The shared budget is what holds the line.
+test(
+    'four multipart files stay inside the shared S3 connection budget',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-multipart-budget'] },
+    async ({ page }) => {
+        // 400MB of fixtures and 44 part PUTs — well past the default budget.
+        test.setTimeout(180_000);
+
+        // Just over the multipart threshold, so each file is a handful of parts
+        // rather than hundreds — the budget doesn't care how many follow.
+        const large = await writeLargeFiles({
+            count: MAX_CONCURRENT_FILES,
+            prefix: 'queue-multipart',
+            bytes: MULTIPART_THRESHOLD + 1024,
+        });
+        // Held long enough that the PUTs, not the browser's reading of 100MB
+        // blobs, are what limits overlap. At a short hold the file reads become
+        // the bottleneck and the observed peak drops below the budget, which
+        // would make this pass without the semaphore doing anything.
+        const puts = await stubS3Puts(page, { holdMs: 1200 });
+        const inFlightRows = page.getByRole('button', {
+            name: 'Cancel upload',
+        });
+
+        try {
+            await page.goto(PAGE_URL);
+            await page.setInputFiles('input[type="file"]', large.paths);
+            await page
+                .getByRole('button', {
+                    name: `Upload ${MAX_CONCURRENT_FILES} files`,
+                })
+                .click();
+
+            // Waits for every row to leave `uploading`, not for them to reach
+            // `complete`: `files.multipart.complete` is a real S3 call that
+            // verifies each part landed, and these PUTs were answered locally,
+            // so the rows finish their PUT phase and then fail at completion.
+            // Which is fine — the budget is a property of the PUTs, and by the
+            // time no row is uploading, every part PUT has been made.
+            await expect(inFlightRows).toHaveCount(MAX_CONCURRENT_FILES, {
+                timeout: 60_000,
+            });
+            await expect(inFlightRows).toHaveCount(0, { timeout: 150_000 });
+
+            // Exactly the budget, not merely under it: four files each wanting
+            // MAX_CONCURRENT_CHUNKS would open 12 connections unbounded, and
+            // landing on 6 shows the semaphore is what's holding them back
+            // rather than some incidental bottleneck.
+            expect(puts.peak).toBe(S3_CONNECTION_BUDGET);
+        } finally {
+            await large.cleanup();
         }
     }
 );

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -1,19 +1,24 @@
 /**
  * Upload queue interactions, run as a dedicated user (provisioned by the
- * `dedicatedUserConfig` fixture). Mostly client-side: the retry test intercepts
- * and aborts `files.upload`, so it creates nothing.
+ * `dedicatedUserConfig` fixture). The retry test intercepts and aborts
+ * `files.upload`, so it creates nothing.
  *
- * The cancel-cleanup test is the exception — it lets `files.upload` through to
- * get a real `uploading` row, which is the thing the cleanup has to find. It
- * stalls the presigned PUT instead, so no bytes ever reach S3, and clears its
- * rows on the way out. The real end-to-end upload still lives in the validate
- * tier (upload-batches-and-quota.spec.ts).
+ * The rest write real rows. The cancel-cleanup test needs an `uploading` row
+ * for the cleanup to find, and the concurrency tests run whole presign → PUT →
+ * confirm chains so they can assert on `files`/`upload_batches`. All of them
+ * answer the presigned PUT locally (`stubS3Puts`), so no bytes ever reach S3,
+ * and the shared teardown resets the user. The real end-to-end upload against a
+ * live bucket still lives in the validate tier
+ * (upload-batches-and-quota.spec.ts).
  */
-import { deleteUserData } from '@nexus/db/test-db';
+import { resetUserData, insertStorageUsage } from '@nexus/db/test-db';
+import { PLAN_LIMITS, SOFT_LIMIT_MULTIPLIER } from '@nexus/db/plans';
+import { MAX_CONCURRENT_FILES } from '@/lib/upload/limits';
 import { test, expect } from '../fixtures';
 import { type TestUser } from '../helpers/auth';
 import { interceptTrpcCalls } from '../helpers/trpc';
 import { seedResumableUpload } from '../helpers/uploadStore';
+import { makeTextFiles, stubS3Puts } from '../helpers/uploadStubs';
 
 const UPLOAD_USER: TestUser = {
     email: 'upload-flows-e2e@test.local',
@@ -37,12 +42,12 @@ const FILE_B = {
 test.describe.configure({ mode: 'serial' });
 test.use({ dedicatedUserConfig: { user: UPLOAD_USER, statePath: STATE_PATH } });
 
-// Only the cancel-cleanup test writes rows, but the teardown belongs here
-// rather than at the end of that test body: it asserts on an exact status
-// array, so a failure that skipped cleanup would leave rows behind and fail
-// every later run of this serial spec for the wrong reason.
+// The teardown belongs here rather than at the end of the test bodies that
+// need it: the cancel-cleanup test asserts on an exact status array, so a
+// failure that skipped cleanup would leave rows behind and fail every later run
+// of this serial spec for the wrong reason.
 test.afterEach(async ({ db, seedUserId }) => {
-    await deleteUserData(db, seedUserId);
+    await resetUserData(db, seedUserId);
 });
 
 test(
@@ -219,14 +224,179 @@ test(
     }
 );
 
+// Uploads used to run strictly one at a time (#340): the queue awaited each
+// file's whole presign → PUT → confirm chain before starting the next, so a
+// 20-file selection spent its wall clock with one request in flight.
+test(
+    'a multi-file wave uploads concurrently, bounded by the pool size',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-concurrent-wave'] },
+    async ({ page, db, seedUserId }) => {
+        const puts = await stubS3Puts(page, { holdMs: 400 });
+        const files = makeTextFiles(MAX_CONCURRENT_FILES * 2, 'queue-wave');
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', files);
+        await page
+            .getByRole('button', { name: `Upload ${files.length} files` })
+            .click();
+
+        // The button state belongs to the wave, not to each file: once the
+        // first file lands there are still four in flight and three queued, and
+        // an "Uploading…" that dipped between files would re-render the Upload
+        // button here.
+        await expect(
+            page.getByText('Uploaded', { exact: true }).first()
+        ).toBeVisible({ timeout: 30_000 });
+        await expect(
+            page.getByRole('button', { name: /^Upload \d+ files?$/ })
+        ).toHaveCount(0);
+
+        await expect(page.getByText('Uploaded', { exact: true })).toHaveCount(
+            files.length,
+            { timeout: 30_000 }
+        );
+
+        // More than one PUT open at a time (the whole point), never more than
+        // the pool allows (which also keeps every mix inside the 6-connection
+        // S3 budget, since a single-part file holds one connection).
+        expect(puts.total).toBe(files.length);
+        expect(puts.peak).toBe(MAX_CONCURRENT_FILES);
+
+        // Concurrency must not fragment the batch: still one row per click,
+        // still one shared key prefix.
+        const batches = await db.query.uploadBatches.findMany({
+            where: (b, { eq }) => eq(b.userId, seedUserId),
+        });
+        expect(batches).toHaveLength(1);
+        const rows = await db.query.files.findMany({
+            where: (f, { eq }) => eq(f.userId, seedUserId),
+        });
+        expect(rows).toHaveLength(files.length);
+        for (const row of rows) {
+            expect(row.status).toBe('available');
+            expect(row.batchId).toBe(batches[0].id);
+            expect(row.s3Key).toBe(
+                `${seedUserId}/${batches[0].id}/${row.id}/${row.name}`
+            );
+        }
+    }
+);
+
+// The chunk pool inside a single file is deliberately fail-fast — its siblings
+// are parts of one object. A *file* pool has to be the opposite.
+test(
+    'one file failing mid-wave leaves its siblings running',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-failure-isolation'] },
+    async ({ page }) => {
+        const files = makeTextFiles(MAX_CONCURRENT_FILES + 1, 'queue-isolate');
+        const doomed = files[1].name;
+        await stubS3Puts(page, { holdMs: 200, failFor: doomed });
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', files);
+        await page
+            .getByRole('button', { name: `Upload ${files.length} files` })
+            .click();
+
+        // The failed row keeps its own error state and Retry affordance...
+        await expect(
+            page.getByRole('button', { name: 'Retry upload' })
+        ).toHaveCount(1, { timeout: 30_000 });
+        // ...and every other file in the wave still finishes.
+        await expect(page.getByText('Uploaded', { exact: true })).toHaveCount(
+            files.length - 1,
+            { timeout: 30_000 }
+        );
+    }
+);
+
+test(
+    'going offline mid-wave pauses the queue and reconnect drains it',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-offline-resume-wave'] },
+    async ({ page, context }) => {
+        // Long enough that the offline switch lands while PUTs are open.
+        const puts = await stubS3Puts(page, { holdMs: 1500 });
+        const files = makeTextFiles(MAX_CONCURRENT_FILES * 2, 'queue-offline');
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', files);
+        await page
+            .getByRole('button', { name: `Upload ${files.length} files` })
+            .click();
+
+        await expect
+            .poll(() => puts.inFlight, { timeout: 15_000 })
+            .toBeGreaterThan(0);
+        await context.setOffline(true);
+
+        // Every unfinished row parks — the ones in flight and the ones still
+        // queued behind them — so reconnect has a single set to resume.
+        await expect(
+            page.getByText('Paused — waiting for your connection').first()
+        ).toBeVisible({ timeout: 15_000 });
+
+        await context.setOffline(false);
+
+        await expect(page.getByText('Uploaded', { exact: true })).toHaveCount(
+            files.length,
+            { timeout: 45_000 }
+        );
+        // The resumed wave is still pool-bound, not a stampede of everything
+        // that was paused.
+        expect(puts.peak).toBeLessThanOrEqual(MAX_CONCURRENT_FILES);
+    }
+);
+
+// Quota is the one failure that says something about the account rather than
+// the file, so it's the one case where the pool gives up on the rest.
+test(
+    'the first quota rejection halts the wave',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-quota-halt'] },
+    async ({ page, db, seedUserId }) => {
+        // Park usage at 105% of starter: any positive size is over the cap.
+        await insertStorageUsage(db, {
+            userId: seedUserId,
+            usedBytes: Math.floor(PLAN_LIMITS.starter * SOFT_LIMIT_MULTIPLIER),
+            fileCount: 1,
+        });
+        const files = makeTextFiles(MAX_CONCURRENT_FILES * 2, 'queue-quota');
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', files);
+        await page
+            .getByRole('button', { name: `Upload ${files.length} files` })
+            .click();
+
+        // Only the files already admitted attempt and fail...
+        await expect(
+            page.getByRole('button', { name: 'Retry upload' })
+        ).toHaveCount(MAX_CONCURRENT_FILES, { timeout: 30_000 });
+        // ...the rest are never started, so they stay queued.
+        await expect(
+            page.getByRole('button', {
+                name: `Upload ${MAX_CONCURRENT_FILES} files`,
+            })
+        ).toBeVisible();
+
+        // One message for the wave, not one per rejected file.
+        await expect(page.locator('[data-sonner-toast]')).toHaveCount(1);
+
+        // The quota check runs before anything is minted, so nothing landed.
+        const rows = await db.query.files.findMany({
+            where: (f, { eq }) => eq(f.userId, seedUserId),
+        });
+        expect(rows).toHaveLength(0);
+    }
+);
+
 test(
     'cancelling an in-flight upload strands no uploading row',
     { tag: ['@page:/dashboard/upload', '@uc:upload-cancel-cleanup'] },
     async ({ page, db, seedUserId }) => {
         // Stall the presigned PUT rather than failing it: the upload stays in
         // flight (so Cancel is the live affordance) and no object is ever
-        // written. Deliberately never settled — teardown discards it.
-        await page.route(/amazonaws\.com/, () => {});
+        // written.
+        await stubS3Puts(page, { stall: true });
 
         const readStatuses = async () =>
             (

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -20,6 +20,7 @@ import {
 } from '@/lib/upload/limits';
 import { test, expect } from '../fixtures';
 import { type TestUser } from '../helpers/auth';
+import { fileName } from '../helpers/table';
 import { interceptTrpcCalls } from '../helpers/trpc';
 import { seedResumableUpload } from '../helpers/uploadStore';
 import {
@@ -67,11 +68,16 @@ test(
         await page.setInputFiles('input[type="file"]', [FILE_A, FILE_B]);
 
         await expect(page.getByText('Selected Files (2)')).toBeVisible();
-        await expect(page.getByText(FILE_A.name)).toBeVisible();
-        await expect(page.getByText(FILE_B.name)).toBeVisible();
+        // fileName(): queue rows render names through MiddleTruncateName,
+        // whose twin spans trip a bare getByText in strict mode.
+        await expect(fileName(page, FILE_A.name)).toBeVisible();
+        await expect(fileName(page, FILE_B.name)).toBeVisible();
         await expect(
             page.getByRole('button', { name: 'Upload 2 files' })
         ).toBeVisible();
+        // The summary tells the user how much room they actually have,
+        // instead of the invented per-GB price it used to show.
+        await expect(page.getByText('Storage available:')).toBeVisible();
 
         // Remove one queued file.
         await page.getByRole('button', { name: 'Remove' }).first().click();
@@ -115,7 +121,7 @@ test(
 
         // The interrupted upload surfaces as resumable (not failed), with its
         // prior progress and a re-add prompt — no retry/error affordance.
-        await expect(page.getByText('big-shoot.zip')).toBeVisible();
+        await expect(fileName(page, 'big-shoot.zip')).toBeVisible();
         await expect(
             page.getByText('Interrupted — re-add this file to resume')
         ).toBeVisible();
@@ -151,7 +157,7 @@ test(
 
         // The record outlives the clear: a reload rehydrates the same row.
         await page.reload();
-        await expect(page.getByText('big-shoot.zip')).toBeVisible();
+        await expect(fileName(page, 'big-shoot.zip')).toBeVisible();
         await expect(
             page.getByText('Interrupted — re-add this file to resume')
         ).toBeVisible();
@@ -186,7 +192,7 @@ test(
 
         // The row offers one-click resume (not the re-add prompt), with both a
         // per-row Resume button and a Resume-all affordance.
-        await expect(page.getByText('handle-shoot.zip')).toBeVisible();
+        await expect(fileName(page, 'handle-shoot.zip')).toBeVisible();
         await expect(
             page.getByText('Interrupted — resume in one click')
         ).toBeVisible();
@@ -263,6 +269,15 @@ test(
             files.length,
             { timeout: 30_000 }
         );
+
+        // A clean wave earns the success line and a route to the files it
+        // just created — the page is not a dead end.
+        await expect(
+            page.getByText('All files uploaded successfully!')
+        ).toBeVisible();
+        await expect(
+            page.getByRole('link', { name: 'View files' })
+        ).toBeVisible();
 
         // More than one PUT open at a time (the whole point), never more than
         // the pool allows (which also keeps every mix inside the 6-connection
@@ -372,6 +387,57 @@ test(
             files.length - 1,
             { timeout: 30_000 }
         );
+
+        // The failed row explains itself in words, not an HTTP status...
+        await expect(page.getByText('Upload failed — try again')).toBeVisible();
+        // ...and the summary owns the failure instead of claiming success.
+        await expect(
+            page.getByText(
+                `${files.length - 1} of ${files.length} files uploaded — 1 failed`
+            )
+        ).toBeVisible();
+        await expect(
+            page.getByText('All files uploaded successfully!')
+        ).toBeHidden();
+    }
+);
+
+// The pool is re-entrant, so a wave in flight is not a locked door: files
+// added while it runs queue as pending and a click folds them in.
+test(
+    'files added mid-wave join the running wave',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-add-mid-wave'] },
+    async ({ page }) => {
+        const puts = await stubS3Puts(page, { holdMs: 2000 });
+        const first = makeTextFiles(MAX_CONCURRENT_FILES + 2, 'queue-first');
+        const late = makeTextFiles(2, 'queue-late');
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', first);
+        await page
+            .getByRole('button', { name: `Upload ${first.length} files` })
+            .click();
+
+        // The pool takes four; the overflow rows say they're waiting and
+        // stay removable while they wait.
+        await expect(page.getByText('Waiting to upload').first()).toBeVisible({
+            timeout: 15_000,
+        });
+        await expect(
+            page.getByRole('button', { name: 'Remove' }).first()
+        ).toBeVisible();
+
+        // Adding files mid-wave re-arms the Upload button for just the new
+        // rows; clicking it joins the wave already in flight.
+        await page.setInputFiles('input[type="file"]', late);
+        await page.getByRole('button', { name: 'Upload 2 files' }).click();
+
+        await expect(page.getByText('Uploaded', { exact: true })).toHaveCount(
+            first.length + late.length,
+            { timeout: 60_000 }
+        );
+        // Joining the wave respects the pool bound — no stampede.
+        expect(puts.peak).toBeLessThanOrEqual(MAX_CONCURRENT_FILES);
     }
 );
 
@@ -443,8 +509,12 @@ test(
             })
         ).toBeVisible();
 
-        // One message for the wave, not one per rejected file.
+        // One message for the wave, not one per rejected file — and written
+        // for people, not the raw byte counts the server logs.
         await expect(page.locator('[data-sonner-toast]')).toHaveCount(1);
+        await expect(page.locator('[data-sonner-toast]')).toContainText(
+            'Not enough storage'
+        );
 
         // The quota check runs before anything is minted, so nothing landed.
         const rows = await db.query.files.findMany({

--- a/apps/web/e2e/helpers/uploadStubs.ts
+++ b/apps/web/e2e/helpers/uploadStubs.ts
@@ -57,22 +57,33 @@ export async function stubS3Puts(
         seen.inFlight++;
         seen.peak = Math.max(seen.peak, seen.inFlight);
 
-        // Deliberately never settled — Playwright discards it at teardown.
+        // Never settled, and never decremented: the connection genuinely stays
+        // open until teardown, which is the whole point of this mode.
         if (options.stall) return;
 
-        if (options.holdMs) {
-            await new Promise((resolve) => setTimeout(resolve, options.holdMs));
+        try {
+            if (options.holdMs) {
+                await new Promise((resolve) =>
+                    setTimeout(resolve, options.holdMs)
+                );
+            }
+            const isDoomed =
+                options.failFor !== undefined &&
+                route.request().url().includes(options.failFor);
+            await route.fulfill({
+                status: isDoomed ? 500 : 200,
+                headers: { ...CORS_HEADERS, ETag: '"e2e-stub"' },
+            });
+        } catch {
+            // The browser hung up first — an upload aborted by a pause or a
+            // cancel. There's nothing left to answer, but the connection is
+            // just as closed as a fulfilled one, so it still has to be counted
+            // out below or `peak` drifts up across the rest of the test.
+        } finally {
+            // Decremented once the response is delivered rather than before, so
+            // `peak` covers the whole window the connection was open.
+            seen.inFlight--;
         }
-        const isDoomed =
-            options.failFor !== undefined &&
-            route.request().url().includes(options.failFor);
-        await route.fulfill({
-            status: isDoomed ? 500 : 200,
-            headers: { ...CORS_HEADERS, ETag: '"e2e-stub"' },
-        });
-        // Decremented after the response is delivered, so `peak` covers the
-        // whole window the browser held the connection open.
-        seen.inFlight--;
     });
 
     return seen;
@@ -89,4 +100,33 @@ export function makeTextFiles(
         // Lengths differ so a mixed-up name→row mapping can't pass by symmetry.
         buffer: Buffer.from(`${prefix} file ${i}${'!'.repeat(i)}\n`),
     }));
+}
+
+/**
+ * Files big enough to take the multipart engine, written to disk and handed to
+ * `setInputFiles` by path.
+ *
+ * By path, not by buffer, on purpose: a buffer is base64'd across the CDP
+ * connection, so several hundred MB of fixtures would be copied twice before
+ * the browser ever sees them. Returns a cleanup to call from `afterAll`.
+ */
+export async function writeLargeFiles(options: {
+    count: number;
+    prefix: string;
+    bytes: number;
+}): Promise<{ paths: string[]; cleanup: () => Promise<void> }> {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+
+    const dir = await mkdtemp(join(tmpdir(), 'nexus-e2e-large-'));
+    const paths: string[] = [];
+    for (let i = 0; i < options.count; i++) {
+        const path = join(dir, `${options.prefix}-${i}.bin`);
+        // Zero-filled: the stub never inspects the bytes, and allocating is
+        // faster than generating content no assertion reads.
+        await writeFile(path, Buffer.alloc(options.bytes));
+        paths.push(path);
+    }
+    return { paths, cleanup: () => rm(dir, { recursive: true, force: true }) };
 }

--- a/apps/web/e2e/helpers/uploadStubs.ts
+++ b/apps/web/e2e/helpers/uploadStubs.ts
@@ -1,0 +1,92 @@
+/**
+ * Route stubs for the browser→S3 leg of an upload.
+ *
+ * Presigned PUTs are the one part of the flow that leaves the machine, so
+ * answering them locally is what lets the non-destructive tiers drive a whole
+ * upload — queue, progress, confirm, batch rows — without writing an object or
+ * touching a bucket. The stub also counts overlap, which is the only way to
+ * observe the client's upload concurrency from the outside.
+ */
+import type { Page } from '@playwright/test';
+
+/** What the stub observed. Read after the assertions on the UI settle. */
+export interface S3PutObserver {
+    /** PUTs answered so far. */
+    total: number;
+    /** PUTs open right now. */
+    inFlight: number;
+    /** Highest `inFlight` seen — the client's real upload concurrency. */
+    peak: number;
+}
+
+export interface StubS3PutsOptions {
+    /**
+     * Keep each PUT open this long before answering, so overlapping uploads
+     * are actually concurrent rather than serialised by how fast the stub
+     * replies. Omit for an instant answer.
+     */
+    holdMs?: number;
+    /** Answer 500 for the one file whose URL contains this string. */
+    failFor?: string;
+    /**
+     * Never answer at all. Leaves the upload in flight for as long as the test
+     * needs (to click Cancel, or go offline) and writes nothing to S3.
+     */
+    stall?: boolean;
+}
+
+const CORS_HEADERS = {
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'PUT,OPTIONS',
+    'access-control-allow-headers': '*',
+    'access-control-expose-headers': 'ETag',
+};
+
+export async function stubS3Puts(
+    page: Page,
+    options: StubS3PutsOptions = {}
+): Promise<S3PutObserver> {
+    const seen: S3PutObserver = { total: 0, inFlight: 0, peak: 0 };
+
+    await page.route(/amazonaws\.com/, async (route) => {
+        if (route.request().method() === 'OPTIONS') {
+            await route.fulfill({ status: 204, headers: CORS_HEADERS });
+            return;
+        }
+        seen.total++;
+        seen.inFlight++;
+        seen.peak = Math.max(seen.peak, seen.inFlight);
+
+        // Deliberately never settled — Playwright discards it at teardown.
+        if (options.stall) return;
+
+        if (options.holdMs) {
+            await new Promise((resolve) => setTimeout(resolve, options.holdMs));
+        }
+        const isDoomed =
+            options.failFor !== undefined &&
+            route.request().url().includes(options.failFor);
+        await route.fulfill({
+            status: isDoomed ? 500 : 200,
+            headers: { ...CORS_HEADERS, ETag: '"e2e-stub"' },
+        });
+        // Decremented after the response is delivered, so `peak` covers the
+        // whole window the browser held the connection open.
+        seen.inFlight--;
+    });
+
+    return seen;
+}
+
+/** Distinct text files, for driving a multi-file upload. */
+export function makeTextFiles(
+    count: number,
+    prefix: string
+): { name: string; mimeType: string; buffer: Buffer }[] {
+    return Array.from({ length: count }, (_, i) => ({
+        name: `${prefix}-${i}.txt`,
+        mimeType: 'text/plain',
+        // Lengths differ so a mixed-up name→row mapping can't pass by symmetry.
+        buffer: Buffer.from(`${prefix} file ${i}${'!'.repeat(i)}\n`),
+    }));
+}

--- a/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
+++ b/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
@@ -182,6 +182,10 @@ test.describe('upload batches + storage quota', () => {
             ],
         },
         async ({ page, db, seedUserId: userId }) => {
+            // Six real round trips to S3, not one — past what the default
+            // per-test budget leaves room for once the network is involved.
+            test.setTimeout(120_000);
+
             // Reset so "exactly one batch" is a strict assertion rather than a
             // delta over the single-file test's leftover batch. Runs before
             // the quota test, which re-parks usage itself.

--- a/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
+++ b/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
@@ -25,13 +25,15 @@
  */
 import {
     findUserByEmail,
-    deleteUserData,
+    resetUserData,
     insertStorageUsage,
 } from '@nexus/db/test-db';
-import { PLAN_LIMITS } from '@nexus/db/plans';
+import { PLAN_LIMITS, SOFT_LIMIT_MULTIPLIER } from '@nexus/db/plans';
+import { MAX_CONCURRENT_FILES } from '@/lib/upload/limits';
 import { test, expect } from '../fixtures';
 import { REGULAR_USER } from '../helpers/auth';
 import { fileName } from '../helpers/table';
+import { makeTextFiles } from '../helpers/uploadStubs';
 import type { Connection } from '@nexus/db/test-db';
 
 // Single shared user → tests must run serially. Belt-and-braces: the
@@ -49,18 +51,13 @@ async function getUserId(db: Connection): Promise<string> {
     return u.id;
 }
 
-async function resetUserState(db: Connection, userId: string): Promise<void> {
-    await deleteUserData(db, userId);
-    await insertStorageUsage(db, { userId, usedBytes: 0, fileCount: 0 });
-}
-
 test.describe('upload batches + storage quota', () => {
     test.beforeAll(async ({ db }) => {
-        await resetUserState(db, await getUserId(db));
+        await resetUserData(db, await getUserId(db));
     });
 
     test.afterAll(async ({ db }) => {
-        await resetUserState(db, await getUserId(db));
+        await resetUserData(db, await getUserId(db));
     });
 
     test(
@@ -188,29 +185,26 @@ test.describe('upload batches + storage quota', () => {
             // Reset so "exactly one batch" is a strict assertion rather than a
             // delta over the single-file test's leftover batch. Runs before
             // the quota test, which re-parks usage itself.
-            await resetUserState(db, userId);
+            await resetUserData(db, userId);
 
             await page.goto('/dashboard/upload');
             await expect(
                 page.getByRole('heading', { name: 'Upload Files', exact: true })
             ).toBeVisible();
 
-            const stamp = Date.now();
-            const filesToUpload = [
-                {
-                    name: `validate-multi-a-${stamp}.txt`,
-                    mimeType: 'text/plain',
-                    buffer: Buffer.from('multi-file batch validate: file a\n'),
-                },
-                {
-                    name: `validate-multi-b-${stamp}.txt`,
-                    mimeType: 'text/plain',
-                    buffer: Buffer.from('multi-file batch validate: file b!\n'),
-                },
-            ];
+            // Deliberately more than the client's upload pool is wide (#340):
+            // the batch assertions below are the ones that would break if
+            // concurrency fragmented a click into several batches, so they have
+            // to run with the pool saturated and files queued behind it.
+            const filesToUpload = makeTextFiles(
+                MAX_CONCURRENT_FILES + 2,
+                `validate-multi-${Date.now()}`
+            );
 
             await page.setInputFiles('input[type="file"]', filesToUpload);
-            await expect(page.getByText('Selected Files (2)')).toBeVisible();
+            await expect(
+                page.getByText(`Selected Files (${filesToUpload.length})`)
+            ).toBeVisible();
             await page.screenshot({
                 path: `${SCREENSHOTS}/06-multi-after-select.png`,
                 fullPage: true,
@@ -221,7 +215,7 @@ test.describe('upload batches + storage quota', () => {
                 .click();
             await expect(
                 page.getByText('Uploaded', { exact: true })
-            ).toHaveCount(2, { timeout: 30_000 });
+            ).toHaveCount(filesToUpload.length, { timeout: 30_000 });
             await page.screenshot({
                 path: `${SCREENSHOTS}/07-multi-after-upload.png`,
                 fullPage: true,
@@ -243,7 +237,7 @@ test.describe('upload batches + storage quota', () => {
                 where: (f, { eq, and, inArray }) =>
                     and(eq(f.userId, userId), inArray(f.name, names)),
             });
-            expect(files).toHaveLength(2);
+            expect(files).toHaveLength(filesToUpload.length);
             for (const file of files) {
                 expect(file.status).toBe('available');
                 expect(file.batchId).toBe(batch.id);
@@ -260,7 +254,7 @@ test.describe('upload batches + storage quota', () => {
                 where: (u, { eq }) => eq(u.userId, userId),
             });
             expect(usage?.usedBytes).toBe(totalBytes);
-            expect(usage?.fileCount).toBe(2);
+            expect(usage?.fileCount).toBe(filesToUpload.length);
         }
     );
 
@@ -270,7 +264,9 @@ test.describe('upload batches + storage quota', () => {
         async ({ page, db, seedUserId: userId }) => {
             // Park usage at exactly 105% of starter — any positive sizeBytes
             // pushes past the soft cap.
-            const at105 = Math.floor(PLAN_LIMITS.starter * 1.05);
+            const at105 = Math.floor(
+                PLAN_LIMITS.starter * SOFT_LIMIT_MULTIPLIER
+            );
             await insertStorageUsage(db, {
                 userId,
                 usedBytes: at105,

--- a/apps/web/lib/async/semaphore.test.ts
+++ b/apps/web/lib/async/semaphore.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { deferred, flushMicrotasks } from './testing';
+import { createSemaphore } from './semaphore';
+
+describe('createSemaphore', () => {
+    it('runs up to `permits` tasks concurrently and queues the rest', async () => {
+        const semaphore = createSemaphore(2);
+        const gates = [deferred(), deferred(), deferred()];
+        let running = 0;
+        let peak = 0;
+
+        const runs = gates.map((gate) =>
+            semaphore.run(async () => {
+                running++;
+                peak = Math.max(peak, running);
+                await gate.promise;
+                running--;
+            })
+        );
+
+        await flushMicrotasks();
+        expect(running).toBe(2);
+
+        gates[0].resolve();
+        await flushMicrotasks();
+        // The third task only starts once a permit comes free.
+        expect(running).toBe(2);
+        expect(peak).toBe(2);
+
+        gates[1].resolve();
+        gates[2].resolve();
+        await Promise.all(runs);
+        expect(peak).toBe(2);
+    });
+
+    it('hands permits over in FIFO order', async () => {
+        const semaphore = createSemaphore(1);
+        const first = deferred();
+        const started: number[] = [];
+
+        const runs = [0, 1, 2, 3].map((i) =>
+            semaphore.run(async () => {
+                started.push(i);
+                if (i === 0) await first.promise;
+            })
+        );
+
+        await flushMicrotasks();
+        expect(started).toEqual([0]);
+
+        first.resolve();
+        await Promise.all(runs);
+        expect(started).toEqual([0, 1, 2, 3]);
+    });
+
+    it('releases the permit when a task throws', async () => {
+        const semaphore = createSemaphore(1);
+
+        await expect(
+            semaphore.run(() => Promise.reject(new Error('boom')))
+        ).rejects.toThrow('boom');
+
+        // A leaked permit would deadlock this call instead of resolving.
+        await expect(semaphore.run(async () => 'ok')).resolves.toBe('ok');
+    });
+
+    it('returns the task result', async () => {
+        const semaphore = createSemaphore(1);
+        await expect(semaphore.run(async () => 42)).resolves.toBe(42);
+    });
+});

--- a/apps/web/lib/async/semaphore.ts
+++ b/apps/web/lib/async/semaphore.ts
@@ -1,0 +1,51 @@
+/**
+ * FIFO counting semaphore.
+ *
+ * Exists so several independent workers can share one connection budget: the
+ * upload engines hand every browser→S3 PUT through here, so a wave of files
+ * can't oversubscribe the browser's per-host socket cap no matter how the work
+ * is split between single-part and multipart uploads.
+ *
+ * FIFO is load-bearing, not incidental. Permits are handed straight to the
+ * longest-waiting caller rather than released back into a pool, so a late
+ * arrival can't barge ahead of a queued one and starve it past a presigned
+ * URL's TTL.
+ */
+export interface Semaphore {
+    /** Runs `task` while holding one permit, releasing it however task settles. */
+    run<T>(task: () => Promise<T>): Promise<T>;
+}
+
+export function createSemaphore(permits: number): Semaphore {
+    let available = permits;
+    const waiting: Array<() => void> = [];
+
+    // Only takes a permit when nobody is queued — otherwise it would barge past
+    // waiters and break the FIFO guarantee above.
+    const acquire = (): Promise<void> => {
+        if (available > 0 && waiting.length === 0) {
+            available--;
+            return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => waiting.push(resolve));
+    };
+
+    const release = (): void => {
+        const next = waiting.shift();
+        // Direct handoff: the permit never returns to the pool while someone
+        // is queued for it.
+        if (next) next();
+        else available++;
+    };
+
+    return {
+        async run<T>(task: () => Promise<T>): Promise<T> {
+            await acquire();
+            try {
+                return await task();
+            } finally {
+                release();
+            }
+        },
+    };
+}

--- a/apps/web/lib/async/testing.ts
+++ b/apps/web/lib/async/testing.ts
@@ -1,0 +1,30 @@
+/**
+ * Test helpers for driving async code by hand — the pair every concurrency
+ * test needs: something to settle on demand, and a way to let the scheduler
+ * catch up before asserting.
+ */
+
+export interface Deferred {
+    promise: Promise<void>;
+    resolve: () => void;
+    reject: (error: unknown) => void;
+}
+
+/** A promise plus the handles to settle it from the test body. */
+export function deferred(): Deferred {
+    let resolve!: () => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<void>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+/**
+ * Lets every already-scheduled microtask drain before the next assertion.
+ * A macrotask hop, so it also clears promise chains queued by those microtasks.
+ */
+export function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/apps/web/lib/hooks/useInvalidateFileList.ts
+++ b/apps/web/lib/hooks/useInvalidateFileList.ts
@@ -9,6 +9,11 @@ import { useTRPC } from '@/lib/trpc/client';
  * `files.statusCounts` via procedure-level prefix filters. Use this whenever a
  * mutation changes the user's file set — exact-key invalidation would miss
  * paginated/searched variants, and the stats bar query is separate from list.
+ *
+ * Storage rollups ride along: anything that changes the file set moves
+ * `storage.getUsage` (the sidebar bar would otherwise sit on its pre-upload
+ * number right next to a fresh "all uploaded" message) and the dashboard's
+ * `storage.getUploadHistory` chart.
  */
 export function useInvalidateFileList() {
     const trpc = useTRPC();
@@ -22,6 +27,12 @@ export function useInvalidateFileList() {
                 ),
                 queryClient.invalidateQueries(
                     trpc.files.statusCounts.queryFilter()
+                ),
+                queryClient.invalidateQueries(
+                    trpc.storage.getUsage.queryFilter()
+                ),
+                queryClient.invalidateQueries(
+                    trpc.storage.getUploadHistory.queryFilter()
                 ),
             ]),
         [trpc, queryClient]

--- a/apps/web/lib/upload/errors.test.ts
+++ b/apps/web/lib/upload/errors.test.ts
@@ -16,6 +16,7 @@ import {
     isExpiredUrlError,
     isNetworkError,
     isAbortError,
+    isQuotaExceededError,
     reportUploadFailure,
 } from './errors';
 
@@ -31,6 +32,35 @@ describe('isExpiredUrlError', () => {
     it('is false for non-http errors', () => {
         expect(isExpiredUrlError(new UploadNetworkError())).toBe(false);
         expect(isExpiredUrlError(new Error('x'))).toBe(false);
+    });
+});
+
+describe('isQuotaExceededError', () => {
+    it('is true for a QUOTA_EXCEEDED domain error', () => {
+        expect(
+            isQuotaExceededError(
+                makeClientError({
+                    code: 'PRECONDITION_FAILED',
+                    domainCode: 'QUOTA_EXCEEDED',
+                })
+            )
+        ).toBe(true);
+    });
+
+    it('is false for other domain errors', () => {
+        expect(
+            isQuotaExceededError(
+                makeClientError({
+                    code: 'FORBIDDEN',
+                    domainCode: 'TRIAL_EXPIRED',
+                })
+            )
+        ).toBe(false);
+    });
+
+    it('is false for transport failures', () => {
+        expect(isQuotaExceededError(new UploadHttpError(403))).toBe(false);
+        expect(isQuotaExceededError(new Error('x'))).toBe(false);
     });
 });
 

--- a/apps/web/lib/upload/errors.test.ts
+++ b/apps/web/lib/upload/errors.test.ts
@@ -18,6 +18,7 @@ import {
     isAbortError,
     isQuotaExceededError,
     reportUploadFailure,
+    uploadErrorMessage,
 } from './errors';
 
 describe('isExpiredUrlError', () => {
@@ -83,6 +84,37 @@ describe('isAbortError', () => {
 
     it('is false for other errors', () => {
         expect(isAbortError(new Error('nope'))).toBe(false);
+    });
+});
+
+describe('uploadErrorMessage', () => {
+    it('passes a domain error message through — those are user-facing', () => {
+        const error = makeClientError({
+            code: 'PRECONDITION_FAILED',
+            domainCode: 'QUOTA_EXCEEDED',
+            message: 'Not enough storage — 1.05 TB of 1 TB used',
+        });
+        expect(uploadErrorMessage(error)).toBe(
+            'Not enough storage — 1.05 TB of 1 TB used'
+        );
+    });
+
+    it('hides the raw status of an S3 rejection', () => {
+        const message = uploadErrorMessage(new UploadHttpError(500));
+        expect(message).not.toContain('500');
+        expect(message).toContain('try again');
+    });
+
+    it('describes a transport drop as a connection problem', () => {
+        expect(uploadErrorMessage(new UploadNetworkError())).toContain(
+            'Connection problem'
+        );
+    });
+
+    it('falls back to a plain failure line for anything else', () => {
+        expect(uploadErrorMessage(new Error('ENOENT: no such file'))).toBe(
+            'Upload failed'
+        );
     });
 });
 

--- a/apps/web/lib/upload/errors.ts
+++ b/apps/web/lib/upload/errors.ts
@@ -3,6 +3,7 @@ import { TRPCClientError } from '@trpc/client';
 
 import { DOMAIN_ERROR_CODES } from '@/lib/errors/codes';
 import { UploadHttpError, UploadNetworkError } from '@/lib/http/xhr';
+import { getErrorMessage } from '@/lib/trpc/error-link';
 import { getDomainError } from '@/lib/trpc/get-domain-error';
 import { captureEvent } from '@/lib/posthog/client';
 import { PostHogEvent } from '@/lib/posthog/events';
@@ -38,6 +39,26 @@ export function isQuotaExceededError(error: unknown): boolean {
         error instanceof TRPCClientError &&
         getDomainError(error)?.code === DOMAIN_ERROR_CODES.QUOTA_EXCEEDED
     );
+}
+
+/**
+ * The message an upload row shows when its attempt terminally fails. Raw
+ * `error.message` is written for logs ("Upload failed with status 500") and
+ * Sentry already gets the real error via {@link reportUploadFailure}, so the
+ * row can afford to speak plainly. tRPC errors go through the same mapping
+ * the toast uses, which keeps the row and the toast telling one story.
+ */
+export function uploadErrorMessage(error: unknown): string {
+    if (error instanceof TRPCClientError) {
+        return getErrorMessage(error);
+    }
+    if (error instanceof UploadHttpError) {
+        return 'Upload failed — try again';
+    }
+    if (error instanceof UploadNetworkError) {
+        return 'Connection problem — check your network and retry';
+    }
+    return 'Upload failed';
 }
 
 /** Which upload path moved the bytes. */

--- a/apps/web/lib/upload/errors.ts
+++ b/apps/web/lib/upload/errors.ts
@@ -1,7 +1,9 @@
 import * as Sentry from '@sentry/nextjs';
 import { TRPCClientError } from '@trpc/client';
 
+import { DOMAIN_ERROR_CODES } from '@/lib/errors/codes';
 import { UploadHttpError, UploadNetworkError } from '@/lib/http/xhr';
+import { getDomainError } from '@/lib/trpc/get-domain-error';
 import { captureEvent } from '@/lib/posthog/client';
 import { PostHogEvent } from '@/lib/posthog/events';
 
@@ -24,6 +26,18 @@ export function isNetworkError(error: unknown): boolean {
 /** The upload was aborted (pause or cancel), not a real failure. */
 export function isAbortError(error: unknown): boolean {
     return error instanceof DOMException && error.name === 'AbortError';
+}
+
+/**
+ * The server rejected the upload because the account is out of storage. Unlike
+ * every other failure this one is about the account, not the file, so there is
+ * nothing to gain from letting the rest of a queued wave attempt and fail too.
+ */
+export function isQuotaExceededError(error: unknown): boolean {
+    return (
+        error instanceof TRPCClientError &&
+        getDomainError(error)?.code === DOMAIN_ERROR_CODES.QUOTA_EXCEEDED
+    );
 }
 
 /** Which upload path moved the bytes. */

--- a/apps/web/lib/upload/filePool.test.ts
+++ b/apps/web/lib/upload/filePool.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it, vi } from 'vitest';
+import { flushMicrotasks } from '@/lib/async/testing';
+import { createFilePool, type FileRunOutcome, type PoolItem } from './filePool';
+
+const GiB = 1024 ** 3;
+
+/** Hands the test body control over when each item's run finishes. */
+function createControllableRunner() {
+    const gates = new Map<string, () => void>();
+    const started: string[] = [];
+    let running = 0;
+    let peak = 0;
+    const outcomes = new Map<string, FileRunOutcome>();
+    const failures = new Set<string>();
+
+    const run = (item: PoolItem): Promise<FileRunOutcome> => {
+        started.push(item.id);
+        running++;
+        peak = Math.max(peak, running);
+        return new Promise<FileRunOutcome>((resolve, reject) => {
+            gates.set(item.id, () => {
+                running--;
+                if (failures.has(item.id))
+                    reject(new Error(`${item.id} blew up`));
+                else resolve(outcomes.get(item.id) ?? 'continue');
+            });
+        });
+    };
+
+    return {
+        run,
+        started,
+        outcomes,
+        failures,
+        get peak() {
+            return peak;
+        },
+        get running() {
+            return running;
+        },
+        finish(id: string) {
+            const gate = gates.get(id);
+            if (!gate) throw new Error(`${id} never started`);
+            gate();
+            return flushMicrotasks();
+        },
+    };
+}
+
+const makeItems = (count: number, size = 1): PoolItem[] =>
+    Array.from({ length: count }, (_, i) => ({ id: `f${i}`, size }));
+
+describe('createFilePool', () => {
+    it('keeps at most maxConcurrent files in flight', async () => {
+        const ctl = createControllableRunner();
+        const pool = createFilePool({
+            maxConcurrent: 4,
+            maxInFlightBytes: Infinity,
+            run: ctl.run,
+        });
+
+        const drained = pool.enqueue(makeItems(10));
+        await flushMicrotasks();
+
+        expect(ctl.running).toBe(4);
+        expect(ctl.started).toEqual(['f0', 'f1', 'f2', 'f3']);
+
+        await ctl.finish('f0');
+        expect(ctl.running).toBe(4);
+        expect(ctl.started).toContain('f4');
+
+        for (const item of makeItems(10).slice(1)) await ctl.finish(item.id);
+        await drained;
+        expect(ctl.peak).toBe(4);
+        expect(ctl.started).toHaveLength(10);
+    });
+
+    it('stops admitting once summed in-flight bytes reach maxInFlightBytes', async () => {
+        const ctl = createControllableRunner();
+        const pool = createFilePool({
+            maxConcurrent: 4,
+            maxInFlightBytes: 32 * GiB,
+            run: ctl.run,
+        });
+
+        const drained = pool.enqueue([
+            { id: 'v0', size: 15 * GiB },
+            { id: 'v1', size: 15 * GiB },
+            { id: 'v2', size: 15 * GiB },
+            { id: 'v3', size: 15 * GiB },
+        ]);
+        await flushMicrotasks();
+
+        // Two fit under the 32 GiB ceiling; a third would put 45 GiB in flight.
+        expect(ctl.started).toEqual(['v0', 'v1']);
+
+        await ctl.finish('v0');
+        expect(ctl.started).toEqual(['v0', 'v1', 'v2']);
+
+        await ctl.finish('v1');
+        await ctl.finish('v2');
+        await ctl.finish('v3');
+        await drained;
+    });
+
+    it('admits a single file larger than maxInFlightBytes', async () => {
+        const ctl = createControllableRunner();
+        const pool = createFilePool({
+            maxConcurrent: 4,
+            maxInFlightBytes: 32 * GiB,
+            run: ctl.run,
+        });
+
+        const drained = pool.enqueue([
+            { id: 'huge', size: 60 * GiB },
+            { id: 'small', size: 1 },
+        ]);
+        await flushMicrotasks();
+
+        // The oversized file runs alone rather than never running.
+        expect(ctl.started).toEqual(['huge']);
+
+        await ctl.finish('huge');
+        expect(ctl.started).toEqual(['huge', 'small']);
+        await ctl.finish('small');
+        await drained;
+    });
+
+    it('keeps the wave running when one file fails', async () => {
+        const ctl = createControllableRunner();
+        ctl.failures.add('f1');
+        const pool = createFilePool({
+            maxConcurrent: 2,
+            maxInFlightBytes: Infinity,
+            run: ctl.run,
+        });
+
+        const drained = pool.enqueue(makeItems(4));
+        await flushMicrotasks();
+
+        await ctl.finish('f1');
+        // The failure frees its slot instead of poisoning the pool.
+        expect(ctl.started).toContain('f2');
+
+        await ctl.finish('f0');
+        await ctl.finish('f2');
+        await ctl.finish('f3');
+        await expect(drained).resolves.toBeUndefined();
+        expect(ctl.started).toHaveLength(4);
+    });
+
+    it('halts the queue but lets in-flight files finish', async () => {
+        const ctl = createControllableRunner();
+        ctl.outcomes.set('f0', 'halt');
+        const pool = createFilePool({
+            maxConcurrent: 2,
+            maxInFlightBytes: Infinity,
+            run: ctl.run,
+        });
+
+        const drained = pool.enqueue(makeItems(6));
+        await flushMicrotasks();
+        expect(ctl.started).toEqual(['f0', 'f1']);
+
+        await ctl.finish('f0');
+        // f1 was already admitted and keeps going; nothing new starts.
+        expect(ctl.started).toEqual(['f0', 'f1']);
+        expect(ctl.running).toBe(1);
+
+        await ctl.finish('f1');
+        await drained;
+        expect(ctl.started).toEqual(['f0', 'f1']);
+    });
+
+    it('runs work enqueued after a halt, while the halted wave drains', async () => {
+        // The user's Retry click on the quota-failed row lands while its
+        // siblings are still finishing. Latching the halt would drop it and
+        // strand the row in `pending` with nothing left to start it.
+        const ctl = createControllableRunner();
+        ctl.outcomes.set('f0', 'halt');
+        const pool = createFilePool({
+            maxConcurrent: 2,
+            maxInFlightBytes: Infinity,
+            run: ctl.run,
+        });
+
+        const drained = pool.enqueue(makeItems(6));
+        await flushMicrotasks();
+        await ctl.finish('f0');
+        expect(ctl.started).toEqual(['f0', 'f1']);
+
+        pool.enqueue([{ id: 'retried', size: 1 }]);
+        await flushMicrotasks();
+        expect(ctl.started).toEqual(['f0', 'f1', 'retried']);
+
+        await ctl.finish('f1');
+        await ctl.finish('retried');
+        await drained;
+    });
+
+    it('clears the halt for the next wave', async () => {
+        const ctl = createControllableRunner();
+        ctl.outcomes.set('f0', 'halt');
+        const pool = createFilePool({
+            maxConcurrent: 1,
+            maxInFlightBytes: Infinity,
+            run: ctl.run,
+        });
+
+        const first = pool.enqueue(makeItems(2));
+        await flushMicrotasks();
+        await ctl.finish('f0');
+        await first;
+        expect(ctl.started).toEqual(['f0']);
+
+        const second = pool.enqueue([{ id: 'later', size: 1 }]);
+        await flushMicrotasks();
+        expect(ctl.started).toEqual(['f0', 'later']);
+        await ctl.finish('later');
+        await second;
+    });
+
+    it('joins a live wave instead of starting a second pool', async () => {
+        const ctl = createControllableRunner();
+        const pool = createFilePool({
+            maxConcurrent: 2,
+            maxInFlightBytes: Infinity,
+            run: ctl.run,
+        });
+
+        const first = pool.enqueue(makeItems(3));
+        await flushMicrotasks();
+        expect(ctl.running).toBe(2);
+
+        const second = pool.enqueue([{ id: 'late', size: 1 }]);
+        await flushMicrotasks();
+        // Still bounded by maxConcurrent across both enqueue calls.
+        expect(ctl.running).toBe(2);
+
+        for (const id of ['f0', 'f1', 'f2', 'late']) await ctl.finish(id);
+        await Promise.all([first, second]);
+        expect(ctl.peak).toBe(2);
+    });
+
+    it('ignores items already queued or in flight', async () => {
+        const ctl = createControllableRunner();
+        const pool = createFilePool({
+            maxConcurrent: 1,
+            maxInFlightBytes: Infinity,
+            run: ctl.run,
+        });
+
+        const drained = pool.enqueue(makeItems(2));
+        await flushMicrotasks();
+        pool.enqueue(makeItems(2));
+        await flushMicrotasks();
+
+        await ctl.finish('f0');
+        await ctl.finish('f1');
+        await drained;
+        expect(ctl.started).toEqual(['f0', 'f1']);
+    });
+
+    it('fires onDrained once per wave, not once per file', async () => {
+        const ctl = createControllableRunner();
+        const onDrained = vi.fn();
+        const pool = createFilePool({
+            maxConcurrent: 4,
+            maxInFlightBytes: Infinity,
+            run: ctl.run,
+            onDrained,
+        });
+
+        const drained = pool.enqueue(makeItems(4));
+        await flushMicrotasks();
+        expect(onDrained).not.toHaveBeenCalled();
+
+        for (const item of makeItems(4)) await ctl.finish(item.id);
+        await drained;
+        expect(onDrained).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/web/lib/upload/filePool.test.ts
+++ b/apps/web/lib/upload/filePool.test.ts
@@ -172,6 +172,28 @@ describe('createFilePool', () => {
         expect(ctl.started).toEqual(['f0', 'f1']);
     });
 
+    it('reports the queued items a halt threw away', async () => {
+        const ctl = createControllableRunner();
+        ctl.outcomes.set('f0', 'halt');
+        const dropped: string[] = [];
+        const pool = createFilePool({
+            maxConcurrent: 2,
+            maxInFlightBytes: Infinity,
+            run: ctl.run,
+            onDropped: (items) => dropped.push(...items.map((i) => i.id)),
+        });
+
+        const drained = pool.enqueue(makeItems(6));
+        await flushMicrotasks();
+        await ctl.finish('f0');
+        await ctl.finish('f1');
+        await drained;
+
+        // Exactly the never-started remainder, so the caller can reset those
+        // rows — the two in-flight files report through their own outcomes.
+        expect(dropped).toEqual(['f2', 'f3', 'f4', 'f5']);
+    });
+
     it('runs work enqueued after a halt, while the halted wave drains', async () => {
         // The user's Retry click on the quota-failed row lands while its
         // siblings are still finishing. Latching the halt would drop it and

--- a/apps/web/lib/upload/filePool.ts
+++ b/apps/web/lib/upload/filePool.ts
@@ -37,6 +37,13 @@ export interface FilePoolOptions<T extends PoolItem> {
     run: (item: T) => Promise<FileRunOutcome>;
     /** Fires once when the pool goes idle, not once per file. */
     onDrained?: () => unknown;
+    /**
+     * Fires with the queued items a halt threw away, so their rows can be
+     * put back into a state the user can act on — without this they'd sit
+     * in whatever "waiting" state admission gave them, with nothing left
+     * that will ever start them.
+     */
+    onDropped?: (items: T[]) => unknown;
 }
 
 export interface FilePool<T extends PoolItem> {
@@ -104,7 +111,13 @@ export function createFilePool<T extends PoolItem>(
             // decision by the user, and dropping it would strand the row in
             // `pending` with nothing left to start it.
             if (isHalted) {
-                queue.length = 0;
+                // Splice first, report second: `?.()` skips its arguments
+                // when the callback is absent, so the splice must not live
+                // inside the call.
+                const droppedItems = queue.splice(0);
+                if (droppedItems.length > 0) {
+                    options.onDropped?.(droppedItems);
+                }
                 isHalted = false;
             }
             const next = queue[0];

--- a/apps/web/lib/upload/filePool.ts
+++ b/apps/web/lib/upload/filePool.ts
@@ -1,0 +1,144 @@
+/**
+ * Admission control for concurrent file uploads.
+ *
+ * The pool decides *how many* files move at once; the S3 connection semaphore
+ * decides how many sockets they may use between them. Keeping the two separate
+ * is what lets one big multipart file keep its full chunk concurrency while a
+ * wave of small files still runs four-wide.
+ *
+ * Failure semantics are the inverse of the per-file chunk pool: a chunk failing
+ * dooms its siblings because they are parts of one file, but a *file* failing
+ * must leave the rest of the wave running. `run` is therefore expected to fold
+ * its own failures into the row's status; anything that escapes is swallowed
+ * here rather than taking the wave down.
+ */
+
+/** What a completed run tells the pool to do with the work still queued. */
+export type FileRunOutcome =
+    | 'continue'
+    /** Nothing else can succeed either (quota) — drop the rest of the queue. */
+    | 'halt';
+
+export interface PoolItem {
+    id: string;
+    /** Admission weight: the pool caps the summed bytes it keeps in flight. */
+    size: number;
+}
+
+export interface FilePoolOptions<T extends PoolItem> {
+    maxConcurrent: number;
+    /**
+     * Ceiling on summed in-flight bytes. Bounds how far concurrent uploads can
+     * overshoot the server's quota pre-check, which each of them passes against
+     * the same committed baseline. Never blocks a lone file: one oversized file
+     * still has to be uploadable.
+     */
+    maxInFlightBytes: number;
+    run: (item: T) => Promise<FileRunOutcome>;
+    /** Fires once when the pool goes idle, not once per file. */
+    onDrained?: () => unknown;
+}
+
+export interface FilePool<T extends PoolItem> {
+    /**
+     * Queues items and returns the drain promise for the wave they joined.
+     * Items already queued or in flight are ignored, so a double-click can't
+     * upload the same row twice.
+     */
+    enqueue(items: T[]): Promise<void>;
+}
+
+export function createFilePool<T extends PoolItem>(
+    options: FilePoolOptions<T>
+): FilePool<T> {
+    const queue: T[] = [];
+    const running = new Map<string, Promise<void>>();
+    let inFlightBytes = 0;
+    let isHalted = false;
+    let draining: Promise<void> | null = null;
+    // Lets `enqueue` wake a drain that's parked waiting on in-flight files, so
+    // work arriving mid-wave starts as soon as there's room rather than when
+    // some unrelated file happens to finish.
+    let pendingWake: { promise: Promise<void>; wake: () => void } | null = null;
+
+    const workArrived = (): Promise<void> => {
+        if (!pendingWake) {
+            let wake!: () => void;
+            const promise = new Promise<void>((resolve) => {
+                wake = resolve;
+            });
+            pendingWake = { promise, wake };
+        }
+        return pendingWake.promise;
+    };
+
+    const start = (item: T): void => {
+        inFlightBytes += item.size;
+        const task = (async () => {
+            try {
+                if ((await options.run(item)) === 'halt') isHalted = true;
+            } catch {
+                // Defensive only: `run` owns its error reporting, and one file
+                // blowing up must not abort the wave.
+            }
+        })().finally(() => {
+            inFlightBytes -= item.size;
+            running.delete(item.id);
+        });
+        running.set(item.id, task);
+    };
+
+    const canStart = (item: T): boolean =>
+        running.size < options.maxConcurrent &&
+        // An empty pool always admits, however big the file: a lone oversized
+        // file still has to be uploadable, and serial uploads already tolerate
+        // one file's worth of quota overshoot.
+        (running.size === 0 ||
+            inFlightBytes + item.size <= options.maxInFlightBytes);
+
+    const drain = async (): Promise<void> => {
+        for (;;) {
+            // Consumed, not latched: the halt drops the work queued *at that
+            // moment*. A row enqueued afterwards — a Retry click while the
+            // in-flight siblings finish, a reconnect resume — is a fresh
+            // decision by the user, and dropping it would strand the row in
+            // `pending` with nothing left to start it.
+            if (isHalted) {
+                queue.length = 0;
+                isHalted = false;
+            }
+            const next = queue[0];
+            if (next && canStart(next)) {
+                queue.shift();
+                start(next);
+                continue;
+            }
+            // Nothing admissible and nothing to wait on: the wave is done.
+            if (running.size === 0) break;
+            await Promise.race([...running.values(), workArrived()]);
+        }
+        draining = null;
+        await options.onDrained?.();
+    };
+
+    return {
+        enqueue(items: T[]): Promise<void> {
+            for (const item of items) {
+                if (running.has(item.id)) continue;
+                if (queue.some((queued) => queued.id === item.id)) continue;
+                queue.push(item);
+            }
+            // No work and no wave in progress: don't spin up a drain just to
+            // fire `onDrained` at nothing.
+            if (queue.length === 0 && running.size === 0) {
+                return draining ?? Promise.resolve();
+            }
+            pendingWake?.wake();
+            pendingWake = null;
+            // Re-entrant by design: enqueueing mid-wave (a retry, a reconnect)
+            // joins the live drain instead of starting a second pool.
+            draining ??= drain();
+            return draining;
+        },
+    };
+}

--- a/apps/web/lib/upload/limits.ts
+++ b/apps/web/lib/upload/limits.ts
@@ -1,0 +1,41 @@
+/**
+ * Tuning constants for the upload engines.
+ *
+ * They live outside the hook so tests can assert against the real numbers
+ * rather than copies: a quota test that hard-codes its own idea of the
+ * in-flight byte ceiling can't catch that ceiling being raised.
+ */
+
+/** Above this size an upload goes through the multipart engine. */
+export const MULTIPART_THRESHOLD = 100 * 1024 * 1024; // 100MB
+
+/** Per-file ceiling on concurrent part PUTs within one multipart upload. */
+export const MAX_CONCURRENT_CHUNKS = 3;
+
+export const MAX_CHUNK_RETRIES = 3;
+export const CONFIRM_RETRIES = 3;
+
+/**
+ * How many files move at once. Roughly 370ms of every upload is fixed API
+ * overhead (presign + confirm) that no amount of bandwidth shortens, so a queue
+ * of small files is latency-bound and gains almost linearly here (#340).
+ */
+export const MAX_CONCURRENT_FILES = 4;
+
+/**
+ * Every browser→S3 PUT draws from this budget, single-part and multipart alike:
+ * 6 is the browser's per-host connection cap, so anything above it queues in
+ * the socket pool where we can't see it. Keeping `MAX_CONCURRENT_FILES` at or
+ * below the budget is what guarantees liveness — each file needs one permit to
+ * make progress, and it never holds one while waiting for another.
+ */
+export const S3_CONNECTION_BUDGET = 6;
+
+/**
+ * Ceiling on summed in-flight bytes. Concurrent uploads all pass the server's
+ * quota pre-check against the same committed baseline, and `SOFT_LIMIT_MULTIPLIER`
+ * (`@nexus/db/plans`) accepts a 5% overshoot — ~51 GiB on the smallest plan.
+ * This keeps the burst well inside that band. Photo workloads never come near
+ * it; it exists for videographer-scale files.
+ */
+export const MAX_IN_FLIGHT_BYTES = 32 * 1024 ** 3; // 32 GiB

--- a/apps/web/server/errors.test.ts
+++ b/apps/web/server/errors.test.ts
@@ -159,11 +159,14 @@ describe('QuotaExceededError', () => {
         expect(error.details).toEqual(details);
     });
 
-    it('renders a message containing all three byte counts', () => {
+    it('writes a user-facing message — the raw counts live on details', () => {
         const error = new QuotaExceededError(details);
 
-        expect(error.message).toContain('1000/2000');
-        expect(error.message).toContain('1500');
+        // Shown verbatim in the toast and the upload row, so formatted
+        // sizes, not integers.
+        expect(error.message).toBe(
+            'Not enough storage — 1000 Bytes of 1.95 KB used'
+        );
     });
 });
 

--- a/apps/web/server/errors.ts
+++ b/apps/web/server/errors.ts
@@ -1,6 +1,6 @@
 import { DOMAIN_ERROR_CODES, type DomainErrorCode } from '@/lib/errors/codes';
+import { formatBytes } from '@/lib/format';
 import type { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
-
 
 /**
  * Base class for all domain errors. Services throw these, middleware maps to
@@ -65,8 +65,11 @@ export class QuotaExceededError extends DomainError {
     readonly details: QuotaDetails;
 
     constructor(details: QuotaDetails) {
+        // User-facing, like every other DomainError message: the error link
+        // shows this string verbatim in the toast and the upload row. The raw
+        // byte counts stay on `details` for logs and programmatic use.
         super(
-            `Storage quota exceeded: ${details.usedBytes}/${details.limitBytes} used, ${details.requestedBytes} requested`,
+            `Not enough storage — ${formatBytes(details.usedBytes)} of ${formatBytes(details.limitBytes)} used`,
             'PRECONDITION_FAILED'
         );
         this.details = details;

--- a/apps/web/server/services/files.integration.test.ts
+++ b/apps/web/server/services/files.integration.test.ts
@@ -1,0 +1,116 @@
+import {
+    describe,
+    it,
+    expect,
+    beforeAll,
+    afterAll,
+    afterEach,
+    vi,
+} from 'vitest';
+import {
+    createDb,
+    insertUser,
+    insertFile,
+    insertStorageUsage,
+    deleteUserData,
+    deleteUserByEmail,
+    resetUserData,
+    type Connection,
+} from '@nexus/db/test-db';
+
+// The database is real — that's the point: this pins the atomicity of the
+// `usedBytes + n` upsert in storage-usage, which no mock can express. Only the
+// out-of-process effects are faked.
+vi.mock('@/lib/jobs', () => ({ jobs: { publish: vi.fn() } }));
+vi.mock('@/lib/posthog/server', () => ({ captureServerEvent: vi.fn() }));
+vi.mock('@/lib/storage', () => ({ s3: {} }));
+
+import { fileService } from './files';
+
+/**
+ * Uploads run several files at once (#340), so a batch's `confirmUpload` calls
+ * now overlap. They all increment one `storage_usage` row, and the whole
+ * no-new-accounting decision rests on that increment being a SQL-side
+ * `usedBytes + n` upsert rather than a read-modify-write — a lost update here
+ * would silently under-bill every concurrent upload.
+ */
+const db: Connection = createDb(process.env.DATABASE_URL!);
+
+const CONCURRENCY = 6;
+// Prime-ish, so a lost update can't happen to sum to the right number anyway.
+const FILE_SIZE = 1_000_003;
+
+let userId: string;
+
+beforeAll(async () => {
+    const user = await insertUser(db);
+    userId = user.id;
+});
+
+afterEach(async () => {
+    await resetUserData(db, userId);
+});
+
+afterAll(async () => {
+    await deleteUserData(db, userId);
+});
+
+function seedUploadingFiles(owner: string, count: number) {
+    return Promise.all(
+        Array.from({ length: count }, () =>
+            insertFile(db, {
+                userId: owner,
+                status: 'uploading',
+                size: FILE_SIZE,
+            })
+        )
+    );
+}
+
+async function readUsage(owner: string) {
+    const usage = await db.query.storageUsage.findFirst({
+        where: (u, { eq }) => eq(u.userId, owner),
+    });
+    return {
+        usedBytes: Number(usage?.usedBytes ?? 0),
+        fileCount: usage?.fileCount ?? 0,
+    };
+}
+
+describe('confirmUpload under concurrency', () => {
+    it('lands the same usage as serial confirms when fired concurrently', async () => {
+        await insertStorageUsage(db, { userId, usedBytes: 0, fileCount: 0 });
+        const files = await seedUploadingFiles(userId, CONCURRENCY);
+
+        await Promise.all(
+            files.map((file) => fileService.confirmUpload(db, userId, file.id))
+        );
+
+        expect(await readUsage(userId)).toEqual({
+            usedBytes: FILE_SIZE * CONCURRENCY,
+            fileCount: CONCURRENCY,
+        });
+    });
+
+    it('counts correctly when no usage row exists yet', async () => {
+        // A user's first-ever upload: every concurrent confirm takes the INSERT
+        // branch of the upsert and they race on the userId unique index.
+        const fresh = await insertUser(db);
+        try {
+            const files = await seedUploadingFiles(fresh.id, CONCURRENCY);
+
+            await Promise.all(
+                files.map((file) =>
+                    fileService.confirmUpload(db, fresh.id, file.id)
+                )
+            );
+
+            expect(await readUsage(fresh.id)).toEqual({
+                usedBytes: FILE_SIZE * CONCURRENCY,
+                fileCount: CONCURRENCY,
+            });
+        } finally {
+            await deleteUserByEmail(db, fresh.email);
+        }
+    });
+});

--- a/apps/web/server/services/quota.test.ts
+++ b/apps/web/server/services/quota.test.ts
@@ -6,7 +6,12 @@ import {
     type MockDbMocks,
     TEST_USER_ID,
 } from '@nexus/db/testing';
+import { SOFT_LIMIT_MULTIPLIER } from '@nexus/db/plans';
 import { QuotaExceededError, TrialExpiredError } from '@/server/errors';
+import {
+    MAX_CONCURRENT_FILES,
+    MAX_IN_FLIGHT_BYTES,
+} from '@/lib/upload/limits';
 import { PLAN_LIMITS } from './constants';
 import { quotaService, type QuotaContext } from './quota';
 
@@ -26,7 +31,7 @@ describe('assertUploadAllowed', () => {
     describe('without a subscription', () => {
         it('falls back to the starter plan limit', () => {
             // Push past the 105% soft cap to force rejection.
-            const overSoftCap = Math.floor(PLAN_LIMITS.starter * 1.05) + oneGB;
+            const overSoftCap = Math.floor(PLAN_LIMITS.starter * SOFT_LIMIT_MULTIPLIER) + oneGB;
             expect(() =>
                 assertUploadAllowed(ctx({ currentUsage: overSoftCap }), 1, NOW)
             ).toThrow(QuotaExceededError);
@@ -330,5 +335,72 @@ describe('checkQuota', () => {
                 undefined
             )
         ).rejects.toThrow(QuotaExceededError);
+    });
+});
+
+/**
+ * Uploads run several files at once (#340), so every file in a wave pre-checks
+ * against the same committed baseline — none of them has confirmed yet. That is
+ * the case `SOFT_LIMIT_MULTIPLIER` exists for, and what bounds the overshoot is
+ * the summed bytes of the wave, which the client's upload pool caps at
+ * `MAX_IN_FLIGHT_BYTES`. These tests pin the arithmetic that makes the two
+ * numbers compatible, against the real constants — raising either one on its
+ * own should turn this suite red.
+ */
+describe('concurrent admission overshoot bound', () => {
+    const SMALLEST_LIMIT = PLAN_LIMITS.starter;
+    const slackBytes =
+        Math.floor(SMALLEST_LIMIT * SOFT_LIMIT_MULTIPLIER) - SMALLEST_LIMIT;
+
+    let db: MockDb;
+    let mocks: MockDbMocks;
+
+    beforeEach(() => {
+        const mockDb = createMockDb();
+        db = mockDb.db;
+        mocks = mockDb.mocks;
+    });
+
+    it('admits a whole wave checked against one baseline, landing inside the soft cap', async () => {
+        // Worst case: usage already sitting exactly on the plan limit, so every
+        // byte the wave adds comes out of the slack band.
+        mocks.storageUsage.findFirst.mockResolvedValue(
+            createStorageUsageFixture({
+                usedBytes: SMALLEST_LIMIT,
+                fileCount: 1000,
+            })
+        );
+        const perFile = MAX_IN_FLIGHT_BYTES / MAX_CONCURRENT_FILES;
+
+        const results = await Promise.all(
+            Array.from({ length: MAX_CONCURRENT_FILES }, () =>
+                checkQuota(db, TEST_USER_ID, perFile, undefined)
+            )
+        );
+
+        // Every file in the wave passes — none of them can see the others'
+        // bytes — and the pool's ceiling is what keeps all of them landing
+        // inside the slack band the soft cap opens.
+        expect(results.every((r) => r.allowed)).toBe(true);
+        expect(MAX_IN_FLIGHT_BYTES).toBeLessThan(slackBytes);
+    });
+
+    it('still rejects a wave whose files each breach the soft cap', async () => {
+        mocks.storageUsage.findFirst.mockResolvedValue(
+            createStorageUsageFixture({
+                usedBytes: SMALLEST_LIMIT,
+                fileCount: 1000,
+            })
+        );
+
+        const attempts = await Promise.allSettled(
+            Array.from({ length: MAX_CONCURRENT_FILES }, () =>
+                checkQuota(db, TEST_USER_ID, slackBytes + oneGB, undefined)
+            )
+        );
+
+        // The soft cap is a bound, not an open door: concurrency doesn't buy a
+        // file admission it wouldn't get on its own.
+        expect(attempts.every((a) => a.status === 'rejected')).toBe(true);
     });
 });

--- a/apps/web/server/services/quota.ts
+++ b/apps/web/server/services/quota.ts
@@ -1,15 +1,10 @@
-import { isTrialExpired } from '@nexus/db/plans';
+import { isTrialExpired, SOFT_LIMIT_MULTIPLIER } from '@nexus/db/plans';
 import { createStorageUsageRepo } from '@nexus/db/repo/storage-usage';
 import { QuotaExceededError, TrialExpiredError } from '@/server/errors';
 import { PLAN_LIMITS } from './constants';
 import type { Subscription } from '@nexus/db/repo/subscriptions';
 import type { DB } from '@nexus/db';
 
-// Optimistic concurrency: pre-checks pass at 100%, but we accept up to 105%
-// of the plan limit so a burst of concurrent uploads (each individually
-// passing the check before any have written) can land without rejection.
-// The 5% bound also covers small drift between storage_usage and reality.
-const SOFT_LIMIT_MULTIPLIER = 1.05;
 // Threshold for surfacing a "near limit" warning to the client (e.g. banner).
 const NEAR_LIMIT_RATIO = 0.9;
 

--- a/apps/web/server/trpc/middleware/errorHandler.test.ts
+++ b/apps/web/server/trpc/middleware/errorHandler.test.ts
@@ -122,7 +122,7 @@ describe('errorHandlerMiddleware', () => {
             expect(error).toBeInstanceOf(TRPCError);
             expect((error as TRPCError).code).toBe('PRECONDITION_FAILED');
             expect((error as TRPCError).message).toContain(
-                'Storage quota exceeded'
+                'Not enough storage'
             );
         }
     });

--- a/packages/db/src/plans.ts
+++ b/packages/db/src/plans.ts
@@ -12,6 +12,16 @@ export const PLAN_LIMITS: Record<PlanTier, number> = {
 };
 
 /**
+ * Optimistic concurrency: upload pre-checks pass at 100% of the plan limit, but
+ * we accept up to 105% so a burst of concurrent uploads — each individually
+ * passing the check before any of them has written — can land without
+ * rejection. The 5% band also covers small drift between `storage_usage` and
+ * reality. Enforced in `apps/web/server/services/quota.ts`; it lives here so
+ * the specs that park a user at the cap don't each carry their own copy.
+ */
+export const SOFT_LIMIT_MULTIPLIER = 1.05;
+
+/**
  * Lives here rather than in `apps/web` so seeds and test-db helpers can reach
  * it — they can't import from the app.
  */

--- a/packages/db/src/test-db/queries.ts
+++ b/packages/db/src/test-db/queries.ts
@@ -10,6 +10,7 @@ import { eq, count } from 'drizzle-orm';
 import * as schema from '../schema';
 import { createSubscriptionFixture, type User } from '../repositories/fixtures';
 import { PLAN_LIMITS, getTrialEnd, type PlanTier } from '../plans';
+import { insertStorageUsage } from './inserts';
 import type { DB } from '../connection';
 
 export async function findUserByEmail(
@@ -47,6 +48,19 @@ export async function deleteUserData(db: DB, userId: string): Promise<void> {
     await db
         .delete(schema.uploadBatches)
         .where(eq(schema.uploadBatches.userId, userId));
+}
+
+/**
+ * `deleteUserData` plus a zeroed `storage_usage` row — the full reset for a
+ * spec that actually confirms uploads or parks a user at the quota cap.
+ *
+ * The usage row is rewritten rather than deleted so the user stays in the same
+ * shape a signed-up user has, and because `deleteUserData` deliberately spares
+ * it: most specs never touch usage and shouldn't pay to re-seed it.
+ */
+export async function resetUserData(db: DB, userId: string): Promise<void> {
+    await deleteUserData(db, userId);
+    await insertStorageUsage(db, { userId, usedBytes: 0, fileCount: 0 });
 }
 
 /**


### PR DESCRIPTION
## Summary

`processQueue` uploaded files strictly one at a time — the `for` loop awaited each file's whole presign → S3 PUT → confirm chain before starting the next, so a 20-file selection spent 14.4s with exactly one request in flight the entire time. About 370ms of every upload is fixed API overhead that no amount of bandwidth shortens, which is what dominates at ICP scale.

This replaces the serial loop with a bounded pool of 4 files, drawing S3 connections from a FIFO budget of 6 shared with the multipart chunk pool.

Closes #340

## Changes

- **`lib/async/semaphore.ts`** (new) — FIFO counting semaphore with direct permit handoff, so a late arrival can't barge past a queued one and starve it past a presigned URL's TTL.
- **`lib/upload/filePool.ts`** (new) — admission control: concurrency bound, summed in-flight byte ceiling (always admitting a lone oversized file), per-file failure isolation, halt-on-quota, and a single drain callback per wave.
- **`lib/upload/limits.ts`** (new) — upload tuning constants, moved out of the hook so tests assert against the real numbers instead of copies.
- **`useUpload.ts`** — `processQueue`, the reconnect handler, and `retryFile` all feed one pool; the S3 permit is taken *before* `files.upload` so a queued presign can't age out; both engines' failure policy extracted into one `handleUploadFailure`; `files.list`/`statusCounts` invalidated once per drained wave instead of once per file.
- **Single-PUT 403 handling** — releases the dead attempt and re-presigns once (`files.upload` is the only source of a single-part URL, so the "re-presign" is a fresh init).
- **Offline fix, in scope for the reconnect criterion** — the single-PUT engine returned on *any* abort, so an offline pause left the row stuck at `uploading` where `onOnline`'s `status === 'paused'` filter could never find it. It now mirrors the multipart engine's cancel-vs-pause branch, and queued files admitted while offline park in `paused` rather than burning a doomed presign each.
- **`SOFT_LIMIT_MULTIPLIER`** moved next to `PLAN_LIMITS` in `@nexus/db/plans`, replacing three hand-copied `1.05` literals.
- **Test helpers** — `e2e/helpers/uploadStubs.ts` (CORS-aware S3 PUT stub with hold/fail/stall modes and concurrency instrumentation), `lib/async/testing.ts`, `test-db/resetUserData`.

## Test Plan

- [x] `pnpm check` — 12/12 tasks, 571 unit tests
- [x] `pnpm -F web test:e2e:flows` — 28/28, including four new specs: concurrent wave bounded at 4 with one batch and one shared key prefix, one-file-fails-siblings-continue, offline mid-wave pauses and reconnect drains pool-bound, first quota rejection halts the wave with one toast and zero DB rows
- [x] `pnpm -F web test:e2e:smoke` — 47/47
- [x] `pnpm -F web e2e:coverage --check` — 17/17 pages, 78/78 use-cases
- [x] `pnpm -F web test:integration server/services/files.integration.test.ts` — 6 concurrent `confirmUpload`s against the real DB sum exactly, including the first-insert race on the `userId` unique index (this tier is not part of `pnpm check` or CI)
- [x] `pnpm -F web test:e2e:validate` — 8/8 against real S3. The multi-file batch spec now uploads `MAX_CONCURRENT_FILES + 2` files so its one-batch assertions run with the pool saturated. It first failed on the default 30s per-test budget (6 real S3 round trips where there used to be 2), so that test gets an explicit 120s timeout.
- [x] Four concurrent multipart files against the connection budget — new `upload-multipart-budget` flows spec: four files just over `MULTIPART_THRESHOLD`, which between them want 4 × `MAX_CONCURRENT_CHUNKS` = 12 connections, peak at **exactly 6**. It waits for the rows to leave `uploading` rather than reach `complete`, because `files.multipart.complete` is a real S3 call that verifies each part landed and these PUTs are answered locally.

## Measured effect

20 files, with the issue's reported prod latencies injected (185ms per tRPC round trip, 331ms per S3 PUT) so both sides run on the same harness. "Before" is the pool pinned to 1, which is exactly the old serial chain:

| | wall clock | per file | peak PUTs in flight |
| --- | --- | --- | --- |
| Serial (pool = 1) | 79.9s | ~4.0s | 1 |
| Pooled (pool = 4) | 24.1s / 21.2s | ~1.1s | 4 |

**~3.5× faster.** The absolute numbers run high because Playwright's request interception adds fixed per-request overhead, so treat the ratio as the transferable figure, not the wall clock. Part of the gain is not raw concurrency: with four files in flight their presigns coalesce into one `httpBatchLink` request, where the serial client sent 20 separate ones.

## Notes

Self-review findings applied, with two exceptions worth recording:

- **`useLatestRef` helper** — implemented, then reverted. Extracting the three "ref assigned during render" sites into a hook trips `react-hooks/refs` (the rule tolerates the inline form only) and costs 8 new `exhaustive-deps` warnings, because the linter can no longer see the ref's origin. The inline pattern stays.
- **Multipart chunk pool on `createSemaphore`** — applied. Worth knowing that a chunk worker now holds its per-file permit while waiting for the shared S3 permit. That nesting is always in the same order (chunk budget → connection budget), so it can't deadlock, and it's what keeps `MAX_CONCURRENT_CHUNKS` a per-file ceiling.


## UX pass (folded in from review, `7e8e1b0`)

A UX review of this PR flagged that it makes two states common that used to be rare — partial failure (failure isolation) and the quota halt — and both ended in copy written for logs. Folded in:

- **Quota copy** — `QuotaExceededError` now writes its message for people (`Not enough storage — 1.05 TB of 1 TB used`, formatted via `formatBytes`), matching the convention that DomainError messages are user-facing. Raw counts stay on `details`. The sidebar bar also turns destructive at ≥100% instead of sitting calm blue while uploads fail.
- **Honest outcome line** — `All files uploaded successfully!` used to render next to red rows (its condition never looked at errors). A wave with failures now reports `4 of 5 files uploaded — 1 failed`, and the outcome region is `aria-live` so it's announced. A clean wave gets a **View files** link so the page isn't a dead end.
- **`queued` status** — rows admitted to the pool but not started now say "Waiting to upload" and keep their Remove button (the pool re-reads the row at start, so removal is safe). Previously they were inert unlabeled rows mid-wave. A summary line shows `Uploaded: N of M` while the wave runs.
- **Add files mid-wave** — Browse/input are no longer disabled while uploading (drag-drop never was); new files queue as `pending` and the Upload button — which now counts only unsubmitted rows — folds them into the live wave via the pool's re-entrant `enqueue`. `processQueue` claims rows synchronously before the batch round trip so a double-click can't mint a second batch.
- **`filePool.onDropped`** — a quota halt reports the queued items it threw away so their rows reset to `pending` (they'd otherwise strand in `queued` with nothing left to start them).
- **Wave invalidation covers storage** — `useInvalidateFileList` now also invalidates `storage.getUsage` and `storage.getUploadHistory`; the sidebar no longer shows the pre-wave number next to a fresh success message.
- **Friendly inline errors** — the row shows `uploadErrorMessage(error)` (tRPC errors reuse the toast mapping; S3 rejections say "Upload failed — try again" instead of `Upload failed with status 500`).
- **Theme-aware toasts** — `<Toaster />` was outside `ThemeProvider` with sonner's default light theme, rendering light-grey toasts on the dark UI; now wrapped (`components/ui/sonner.tsx`) and themed.
- **Summary honesty** — the hardcoded `$0.01/GB` "Est. monthly cost" line (10× the marketed `$1/TB/month`, and a comforting `$0.00` for small batches) is replaced with `Storage available:` from `storage.getUsage`. Queue rows render names through `MiddleTruncateName` per the layout conventions.

Verified: `pnpm check` 12/12, flows 30/30 (incl. new `upload-add-mid-wave` spec + assertions pinning the new copy), smoke 47/47, coverage 17/17 pages 80/80 use-cases, plus a dark-mode visual pass over mid-wave / partial-failure / quota-halt states.
