### PR TITLE
feat: guard destructive upload cancel and warn before quota overrun (#389)

### DIFF
--- a/apps/web/components/dashboard/CancelUploadDialog.tsx
+++ b/apps/web/components/dashboard/CancelUploadDialog.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogDescription,
+    AlertDialogPopup,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { MiddleTruncateName } from './MiddleTruncateName';
+
+interface CancelUploadDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** Name of the upload being cancelled; null while no row is targeted. */
+    fileName: string | null;
+    onConfirm: () => void;
+}
+
+/**
+ * Confirmation guard for the destructive per-row Cancel (#389). Unlike the
+ * Remove X on a pending row, cancelling an in-flight or resumable upload
+ * aborts the S3 session and deletes the resume record — a misclick deep into
+ * a large upload is unrecoverable, so this one click gets a second step.
+ * Controlled by the caller, mirroring `RetrieveDialog`.
+ */
+export function CancelUploadDialog({
+    open,
+    onOpenChange,
+    fileName,
+    onConfirm,
+}: CancelUploadDialogProps) {
+    return (
+        <AlertDialog open={open} onOpenChange={onOpenChange}>
+            <AlertDialogPopup>
+                <AlertDialogTitle>Cancel this upload?</AlertDialogTitle>
+                <AlertDialogDescription>
+                    Its progress will be thrown away — a cancelled upload can’t
+                    be resumed.
+                </AlertDialogDescription>
+                {fileName && (
+                    <div className="rounded-lg border border-border bg-muted/50 px-3 py-2.5 text-sm">
+                        <MiddleTruncateName
+                            name={fileName}
+                            className="font-medium"
+                        />
+                    </div>
+                )}
+                <div className="flex justify-end gap-2">
+                    <AlertDialogCancel>Keep upload</AlertDialogCancel>
+                    <AlertDialogAction onClick={onConfirm}>
+                        Cancel upload
+                    </AlertDialogAction>
+                </div>
+            </AlertDialogPopup>
+        </AlertDialog>
+    );
+}

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { Archive } from 'lucide-react';
+import { NEAR_LIMIT_RATIO } from '@nexus/db/plans';
 import { useSession } from '@/lib/auth/client';
 import { cn } from '@/lib/cn';
 import { getNavItems } from '@/lib/dashboard/navigation';
@@ -16,6 +17,17 @@ export function DashboardSidebar() {
     const navItems = getNavItems(session?.user?.role);
     const trpc = useTRPC();
     const { data: usage } = useQuery(trpc.storage.getUsage.queryOptions());
+    const usagePercent = usage?.percentage ?? 0;
+    // A full bar in the brand color reads as calm; at the cap it should read
+    // as the reason uploads are failing, and near it as a heads-up before
+    // they start to. Also a stable hook for tests, so they don't couple to
+    // the tint classes.
+    const usageLevel =
+        usagePercent >= 100
+            ? 'over-limit'
+            : usagePercent >= NEAR_LIMIT_RATIO * 100
+              ? 'near-limit'
+              : 'ok';
 
     return (
         <aside className="hidden w-64 flex-col border-r border-border bg-sidebar md:flex">
@@ -55,17 +67,17 @@ export function DashboardSidebar() {
                     </p>
                     <div className="mt-2 h-2 overflow-hidden rounded-full bg-sidebar-border">
                         <div
+                            data-usage-level={usageLevel}
                             className={cn(
                                 'h-full rounded-full transition-all',
-                                // A full bar in the brand color reads as calm;
-                                // at the cap it should read as the reason
-                                // uploads are failing.
-                                (usage?.percentage ?? 0) >= 100
+                                usageLevel === 'over-limit'
                                     ? 'bg-destructive'
-                                    : 'bg-primary'
+                                    : usageLevel === 'near-limit'
+                                      ? 'bg-amber-500'
+                                      : 'bg-primary'
                             )}
                             style={{
-                                width: `${usage?.percentage ?? 0}%`,
+                                width: `${usagePercent}%`,
                             }}
                         />
                     </div>

--- a/apps/web/components/dashboard/upload-zone.tsx
+++ b/apps/web/components/dashboard/upload-zone.tsx
@@ -27,6 +27,8 @@ import {
     pickFilesWithHandles,
     pickedFilesFromDataTransfer,
 } from '@/lib/upload/fileSystemAccess';
+import { preflightQuota } from '@/lib/upload/preflight';
+import { CancelUploadDialog } from './CancelUploadDialog';
 import { MiddleTruncateName } from './MiddleTruncateName';
 import { useUpload, type UploadStatus } from './useUpload';
 
@@ -51,6 +53,11 @@ export function UploadZone() {
     } = useUpload();
 
     const [isDragOver, setIsDragOver] = useState(false);
+    // Row awaiting cancel confirmation — the destructive X (in-flight or
+    // resumable rows) opens the dialog instead of dropping the row outright.
+    const [cancelCandidateId, setCancelCandidateId] = useState<string | null>(
+        null
+    );
     const inputRef = useRef<HTMLInputElement>(null);
 
     const handleDrop = useCallback(
@@ -113,6 +120,33 @@ export function UploadZone() {
     const quickResumable = files.filter(
         (f) => f.status === 'resumable' && f.isQuickResumable
     );
+    // Only while the row is still in a guarded state: if it finishes (or
+    // errors out) with the dialog open, the dialog auto-closes rather than
+    // dropping a settled row under "progress will be thrown away" copy.
+    const cancelCandidate =
+        files.find(
+            (f) =>
+                f.id === cancelCandidateId &&
+                (f.status === 'uploading' ||
+                    f.status === 'paused' ||
+                    f.status === 'resumable')
+        ) ?? null;
+
+    // Pre-flight quota: judge only the bytes the Upload button would submit.
+    // Resumable rows are excluded — their landed parts are already counted in
+    // `usedBytes`, so summing their full size would double-count.
+    const pendingBytes = pendingFiles.reduce((acc, f) => acc + f.size, 0);
+    const availableBytes = usage
+        ? Math.max(usage.quotaBytes - usage.usedBytes, 0)
+        : null;
+    const preflight =
+        usage && pendingFiles.length > 0
+            ? preflightQuota({
+                  pendingBytes,
+                  usedBytes: usage.usedBytes,
+                  quotaBytes: usage.quotaBytes,
+              })
+            : 'ok';
 
     return (
         <div className="space-y-6">
@@ -288,13 +322,18 @@ export function UploadZone() {
                                                 Resume
                                             </Button>
                                         )}
+                                    {/* Guarded, unlike Remove: this X aborts
+                                        the S3 session and deletes the resume
+                                        record, so it confirms first (#389). */}
                                     {(file.status === 'uploading' ||
                                         file.status === 'paused' ||
                                         file.status === 'resumable') && (
                                         <Button
                                             variant="ghost"
                                             size="icon"
-                                            onClick={() => cancelFile(file.id)}
+                                            onClick={() =>
+                                                setCancelCandidateId(file.id)
+                                            }
                                         >
                                             <X className="h-4 w-4" />
                                             <span className="sr-only">
@@ -359,6 +398,26 @@ export function UploadZone() {
                                         </span>
                                     </p>
                                 )}
+                                {preflight === 'blocked' && (
+                                    <p className="text-sm text-destructive">
+                                        Not enough storage — these files need{' '}
+                                        {formatBytes(pendingBytes)}, but only{' '}
+                                        {formatBytes(availableBytes ?? 0)} is
+                                        available.
+                                    </p>
+                                )}
+                                {preflight === 'over-limit' && (
+                                    <p className="text-sm text-amber-600">
+                                        This upload will put you over your
+                                        storage limit.
+                                    </p>
+                                )}
+                                {preflight === 'near-limit' && (
+                                    <p className="text-sm text-amber-600">
+                                        This upload will use most of your
+                                        remaining storage.
+                                    </p>
+                                )}
                             </div>
                             <div className="flex flex-wrap items-center gap-3">
                                 {/* Persistent live region so the wave's
@@ -389,7 +448,14 @@ export function UploadZone() {
                                     </Button>
                                 )}
                                 {pendingFiles.length > 0 ? (
-                                    <Button onClick={startUpload}>
+                                    <Button
+                                        onClick={startUpload}
+                                        // Only past the soft cap, where the
+                                        // server would reject the wave anyway;
+                                        // over-limit selections inside the 5%
+                                        // grace band still upload.
+                                        disabled={preflight === 'blocked'}
+                                    >
                                         <Upload className="mr-2 h-4 w-4" />
                                         Upload {pendingFiles.length}{' '}
                                         {pendingFiles.length === 1
@@ -407,6 +473,17 @@ export function UploadZone() {
                     </CardContent>
                 </Card>
             )}
+            <CancelUploadDialog
+                open={cancelCandidate !== null}
+                onOpenChange={(open) => {
+                    if (!open) setCancelCandidateId(null);
+                }}
+                fileName={cancelCandidate?.name ?? null}
+                onConfirm={() => {
+                    if (cancelCandidate) cancelFile(cancelCandidate.id);
+                    setCancelCandidateId(null);
+                }}
+            />
         </div>
     );
 }

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -359,6 +359,18 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/upload'],
     },
     {
+        id: 'upload-cancel-guard',
+        title: 'Cancelling an in-flight/resumable upload asks for confirmation',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
+        id: 'upload-preflight-quota',
+        title: 'Selection exceeding available storage warns before upload and blocks past the soft cap',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
         id: 'upload-single-file-flow',
         title: 'Upload a file end-to-end (S3 + DB + batch + usage)',
         area: 'upload',

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -525,11 +525,15 @@ test(
         const files = makeTextFiles(MAX_CONCURRENT_FILES * 2, 'queue-quota');
 
         await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', files);
         // Park usage at 105% of starter (any positive size is over the cap)
         // only after the page has cached a clear `getUsage`: with the #389
         // pre-flight in place, this stale-cache window is exactly where the
-        // server-side halt still fires.
+        // server-side halt still fires. The sidebar rendering the clear
+        // snapshot is the proof the cache holds it — under full-tier load the
+        // fetch can otherwise lose the race to the insert, and the pre-flight
+        // would see the parked row and disable Upload.
+        await expect(page.getByText('0 Bytes of')).toBeVisible();
+        await page.setInputFiles('input[type="file"]', files);
         await insertStorageUsage(db, {
             userId: seedUserId,
             usedBytes: Math.floor(PLAN_LIMITS.starter * SOFT_LIMIT_MULTIPLIER),

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -166,6 +166,44 @@ test(
     }
 );
 
+// The per-row X on an in-flight or resumable row aborts the S3 session and
+// deletes the resume record — visually identical to the harmless Remove on a
+// pending row, so a misclick deep into a big upload used to be unrecoverable
+// (#389). It now confirms first.
+test(
+    'cancelling a resumable upload asks for confirmation first',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-cancel-guard'] },
+    async ({ page }) => {
+        await page.goto(PAGE_URL);
+        await expect(page.getByText('Drop files here to upload')).toBeVisible();
+
+        await seedResumableUpload(page);
+        await page.reload();
+        await expect(fileName(page, 'big-shoot.zip')).toBeVisible();
+
+        // The X opens the guard instead of destroying the upload outright.
+        await page.getByRole('button', { name: 'Cancel upload' }).click();
+        const dialog = page.getByRole('alertdialog');
+        await expect(dialog.getByText('Cancel this upload?')).toBeVisible();
+
+        // Backing out leaves the upload untouched — still resumable after a
+        // reload.
+        await dialog.getByRole('button', { name: 'Keep upload' }).click();
+        await expect(dialog).toBeHidden();
+        await page.reload();
+        await expect(fileName(page, 'big-shoot.zip')).toBeVisible();
+
+        // Confirming destroys it for real: row gone, and the resume record
+        // with it — a reload resurrects nothing.
+        await page.getByRole('button', { name: 'Cancel upload' }).click();
+        await dialog.getByRole('button', { name: 'Cancel upload' }).click();
+        await expect(page.getByText(/Selected Files/)).toBeHidden();
+        await page.reload();
+        await expect(page.getByText('Drop files here to upload')).toBeVisible();
+        await expect(fileName(page, 'big-shoot.zip')).toBeHidden();
+    }
+);
+
 test(
     'an interrupted upload with a persisted handle is shown as one-click resumable',
     { tag: ['@page:/dashboard/upload', '@uc:upload-resume-one-click'] },
@@ -484,16 +522,19 @@ test(
     'the first quota rejection halts the wave',
     { tag: ['@page:/dashboard/upload', '@uc:upload-quota-halt'] },
     async ({ page, db, seedUserId }) => {
-        // Park usage at 105% of starter: any positive size is over the cap.
+        const files = makeTextFiles(MAX_CONCURRENT_FILES * 2, 'queue-quota');
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', files);
+        // Park usage at 105% of starter (any positive size is over the cap)
+        // only after the page has cached a clear `getUsage`: with the #389
+        // pre-flight in place, this stale-cache window is exactly where the
+        // server-side halt still fires.
         await insertStorageUsage(db, {
             userId: seedUserId,
             usedBytes: Math.floor(PLAN_LIMITS.starter * SOFT_LIMIT_MULTIPLIER),
             fileCount: 1,
         });
-        const files = makeTextFiles(MAX_CONCURRENT_FILES * 2, 'queue-quota');
-
-        await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', files);
         await page
             .getByRole('button', { name: `Upload ${files.length} files` })
             .click();
@@ -524,6 +565,65 @@ test(
     }
 );
 
+// Pre-flight quota (#389): the client already knows the usage and every
+// queued file's size, so a doomed wave is refused before Upload is clicked
+// instead of being discovered through a rejected wave.
+test(
+    'a selection that cannot fit disables Upload before the wave starts',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-preflight-quota'] },
+    async ({ page, db, seedUserId }) => {
+        // Park usage at the soft cap: any pending byte overflows what the
+        // server would accept.
+        await insertStorageUsage(db, {
+            userId: seedUserId,
+            usedBytes: Math.floor(PLAN_LIMITS.starter * SOFT_LIMIT_MULTIPLIER),
+            fileCount: 1,
+        });
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', [FILE_A]);
+
+        await expect(page.getByText(/Not enough storage —/)).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Upload 1 file' })
+        ).toBeDisabled();
+
+        // Removing the oversized selection clears the block.
+        await page.getByRole('button', { name: 'Remove' }).click();
+        await expect(page.getByText(/Not enough storage —/)).toBeHidden();
+    }
+);
+
+test(
+    'a selection past the limit but inside the grace band warns without blocking',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-preflight-quota'] },
+    async ({ page, db, seedUserId }) => {
+        // 10 bytes of the plan left: FILE_A projects past 100% but nowhere
+        // near the 5% soft-cap band, so it may still upload.
+        await insertStorageUsage(db, {
+            userId: seedUserId,
+            usedBytes: PLAN_LIMITS.starter - 10,
+            fileCount: 1,
+        });
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', [FILE_A]);
+
+        await expect(
+            page.getByText('This upload will put you over your storage limit.')
+        ).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Upload 1 file' })
+        ).toBeEnabled();
+
+        // The sidebar bar shows the near-limit state rather than the calm
+        // brand color at ~100% usage.
+        await expect(
+            page.locator('aside [data-usage-level="near-limit"]')
+        ).toBeVisible();
+    }
+);
+
 test(
     'cancelling an in-flight upload strands no uploading row',
     { tag: ['@page:/dashboard/upload', '@uc:upload-cancel-cleanup'] },
@@ -551,6 +651,12 @@ test(
             .toEqual(['uploading']);
 
         await page.getByRole('button', { name: 'Cancel upload' }).click();
+        // The X now opens the #389 confirmation guard; cleanup only fires
+        // once the cancel is confirmed.
+        await page
+            .getByRole('alertdialog')
+            .getByRole('button', { name: 'Cancel upload' })
+            .click();
 
         // The whole point of #330: no row left hidden in `uploading`, where no
         // list would ever show it and its S3 bytes would stay billed.

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -22,7 +22,10 @@ import { test, expect } from '../fixtures';
 import { type TestUser } from '../helpers/auth';
 import { fileName } from '../helpers/table';
 import { interceptTrpcCalls } from '../helpers/trpc';
-import { seedResumableUpload } from '../helpers/uploadStore';
+import {
+    seedResumableUpload,
+    readResumableUploadIds,
+} from '../helpers/uploadStore';
 import {
     makePngFile,
     makeTextFiles,
@@ -265,6 +268,10 @@ test(
         await page.getByRole('button', { name: 'Cancel upload' }).click();
         await dialog.getByRole('button', { name: 'Cancel upload' }).click();
         await expect(page.getByText(/Selected Files/)).toBeHidden();
+        // The row leaves the list before its resume record is deleted — that
+        // delete is fire-and-forget — so reloading on the empty queue alone
+        // races the store and resurrects the upload under load.
+        await expect.poll(() => readResumableUploadIds(page)).toEqual([]);
         await page.reload();
         await expect(page.getByText('Drop files here to upload')).toBeVisible();
         await expect(fileName(page, 'big-shoot.zip')).toBeHidden();

--- a/apps/web/e2e/helpers/uploadStore.ts
+++ b/apps/web/e2e/helpers/uploadStore.ts
@@ -72,3 +72,33 @@ export async function seedResumableUpload(
         db.close();
     }, record);
 }
+
+/**
+ * The fileIds the resume store currently holds.
+ *
+ * Cancelling a row deletes its record fire-and-forget (`abandonServerUpload`
+ * in `useUpload`), so the row leaves the UI before the delete lands. A test
+ * that reloads to prove the upload is really gone has to wait on the store
+ * itself — an empty queue is not evidence the record went with it.
+ */
+export async function readResumableUploadIds(page: Page): Promise<string[]> {
+    return page.evaluate(async () => {
+        const open = indexedDB.open('nexus-uploads', 1);
+        const db: IDBDatabase = await new Promise((res, rej) => {
+            open.onupgradeneeded = () =>
+                open.result.createObjectStore('uploads', { keyPath: 'fileId' });
+            open.onsuccess = () => res(open.result);
+            open.onerror = () => rej(open.error);
+        });
+        const keys = await new Promise<IDBValidKey[]>((res, rej) => {
+            const request = db
+                .transaction('uploads', 'readonly')
+                .objectStore('uploads')
+                .getAllKeys();
+            request.onsuccess = () => res(request.result);
+            request.onerror = () => rej(request.error);
+        });
+        db.close();
+        return keys.map(String);
+    });
+}

--- a/apps/web/e2e/helpers/uploadStubs.ts
+++ b/apps/web/e2e/helpers/uploadStubs.ts
@@ -7,7 +7,7 @@
  * touching a bucket. The stub also counts overlap, which is the only way to
  * observe the client's upload concurrency from the outside.
  */
-import type { Page } from '@playwright/test';
+import type { Page, Request } from '@playwright/test';
 
 /** What the stub observed. Read after the assertions on the UI settle. */
 export interface S3PutObserver {
@@ -48,6 +48,19 @@ export async function stubS3Puts(
 ): Promise<S3PutObserver> {
     const seen: S3PutObserver = { total: 0, inFlight: 0, peak: 0 };
 
+    // Each counted PUT is settled exactly once, whichever side closes it
+    // first. The browser aborting (a pause, a cancel, going offline) must
+    // count out immediately via `requestfailed` — waiting for the handler's
+    // `holdMs` sleep to notice leaves a window where dead connections still
+    // occupy the counter, and a resumed wave opening inside it reads as
+    // double the client's real concurrency (#392).
+    const counted = new Set<Request>();
+    const settle = (request: Request) => {
+        if (!counted.delete(request)) return;
+        seen.inFlight--;
+    };
+    page.on('requestfailed', settle);
+
     await page.route(/amazonaws\.com/, async (route) => {
         if (route.request().method() === 'OPTIONS') {
             await route.fulfill({ status: 204, headers: CORS_HEADERS });
@@ -56,9 +69,10 @@ export async function stubS3Puts(
         seen.total++;
         seen.inFlight++;
         seen.peak = Math.max(seen.peak, seen.inFlight);
+        counted.add(route.request());
 
-        // Never settled, and never decremented: the connection genuinely stays
-        // open until teardown, which is the whole point of this mode.
+        // Never answered: the connection stays open for as long as the test
+        // needs it, and only a browser-side abort settles it.
         if (options.stall) return;
 
         try {
@@ -75,14 +89,12 @@ export async function stubS3Puts(
                 headers: { ...CORS_HEADERS, ETag: '"e2e-stub"' },
             });
         } catch {
-            // The browser hung up first — an upload aborted by a pause or a
-            // cancel. There's nothing left to answer, but the connection is
-            // just as closed as a fulfilled one, so it still has to be counted
-            // out below or `peak` drifts up across the rest of the test.
+            // The browser hung up first — `requestfailed` already settled this
+            // PUT the moment it aborted; the settle below is a no-op.
         } finally {
-            // Decremented once the response is delivered rather than before, so
+            // Settled once the response is delivered rather than before, so
             // `peak` covers the whole window the connection was open.
-            seen.inFlight--;
+            settle(route.request());
         }
     });
 

--- a/apps/web/lib/upload/preflight.test.ts
+++ b/apps/web/lib/upload/preflight.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { PLAN_LIMITS, SOFT_LIMIT_MULTIPLIER } from '@nexus/db/plans';
+import { preflightQuota } from './preflight';
+
+const QUOTA = PLAN_LIMITS.starter;
+const SOFT_CAP = Math.floor(QUOTA * SOFT_LIMIT_MULTIPLIER);
+
+describe('preflightQuota', () => {
+    it('is ok well under the limit', () => {
+        expect(
+            preflightQuota({
+                pendingBytes: 100,
+                usedBytes: 0,
+                quotaBytes: QUOTA,
+            })
+        ).toBe('ok');
+    });
+
+    it('is ok with an empty selection at high usage', () => {
+        expect(
+            preflightQuota({
+                pendingBytes: 0,
+                usedBytes: QUOTA * 0.89,
+                quotaBytes: QUOTA,
+            })
+        ).toBe('ok');
+    });
+
+    it('warns near the limit once projected usage clears 90%', () => {
+        expect(
+            preflightQuota({
+                pendingBytes: QUOTA * 0.2,
+                usedBytes: QUOTA * 0.75,
+                quotaBytes: QUOTA,
+            })
+        ).toBe('near-limit');
+    });
+
+    it('exactly 90% projected is not yet near-limit (strict bound, like the server)', () => {
+        expect(
+            preflightQuota({
+                pendingBytes: QUOTA * 0.15,
+                usedBytes: QUOTA * 0.75,
+                quotaBytes: QUOTA,
+            })
+        ).toBe('ok');
+    });
+
+    it('is over-limit past 100% but inside the soft cap', () => {
+        expect(
+            preflightQuota({
+                pendingBytes: 1024,
+                usedBytes: QUOTA,
+                quotaBytes: QUOTA,
+            })
+        ).toBe('over-limit');
+    });
+
+    it('exactly the soft cap still lands (server accepts <= soft cap)', () => {
+        expect(
+            preflightQuota({
+                pendingBytes: SOFT_CAP - QUOTA,
+                usedBytes: QUOTA,
+                quotaBytes: QUOTA,
+            })
+        ).toBe('over-limit');
+    });
+
+    it('blocks one byte past the soft cap', () => {
+        expect(
+            preflightQuota({
+                pendingBytes: SOFT_CAP - QUOTA + 1,
+                usedBytes: QUOTA,
+                quotaBytes: QUOTA,
+            })
+        ).toBe('blocked');
+    });
+
+    it('blocks a selection that dwarfs the remaining space', () => {
+        expect(
+            preflightQuota({
+                pendingBytes: QUOTA,
+                usedBytes: QUOTA * 0.5,
+                quotaBytes: QUOTA,
+            })
+        ).toBe('blocked');
+    });
+});

--- a/apps/web/lib/upload/preflight.ts
+++ b/apps/web/lib/upload/preflight.ts
@@ -1,0 +1,36 @@
+import { NEAR_LIMIT_RATIO, softCapBytes } from '@nexus/db/plans';
+
+export interface PreflightInput {
+    /** Summed size of the rows the Upload button would submit (pending only). */
+    pendingBytes: number;
+    usedBytes: number;
+    quotaBytes: number;
+}
+
+/**
+ * What the queued selection means for the user's quota, judged before Upload
+ * is clicked — the client-side mirror of the server's `checkQuota`
+ * (`server/services/quota.ts`), sharing its constants so the two can't drift.
+ *
+ * - `blocked`: the wave can't fully land — projected usage clears even the
+ *   105% soft cap the server enforces, so uploading is refused up front.
+ * - `over-limit`: the wave lands (inside the soft cap's grace band) but puts
+ *   the account past 100% of its plan.
+ * - `near-limit`: the server's `nearLimit` signal — projected usage above 90%.
+ *
+ * Byte comparisons only: `getUsage().percentage` is clamped at 100 and can't
+ * express any of these states.
+ */
+export type PreflightLevel = 'ok' | 'near-limit' | 'over-limit' | 'blocked';
+
+export function preflightQuota({
+    pendingBytes,
+    usedBytes,
+    quotaBytes,
+}: PreflightInput): PreflightLevel {
+    const projected = usedBytes + pendingBytes;
+    if (projected > softCapBytes(quotaBytes)) return 'blocked';
+    if (projected > quotaBytes) return 'over-limit';
+    if (projected > quotaBytes * NEAR_LIMIT_RATIO) return 'near-limit';
+    return 'ok';
+}

--- a/apps/web/server/services/quota.ts
+++ b/apps/web/server/services/quota.ts
@@ -1,12 +1,13 @@
-import { isTrialExpired, SOFT_LIMIT_MULTIPLIER } from '@nexus/db/plans';
+import {
+    isTrialExpired,
+    NEAR_LIMIT_RATIO,
+    softCapBytes,
+} from '@nexus/db/plans';
 import { createStorageUsageRepo } from '@nexus/db/repo/storage-usage';
 import { QuotaExceededError, TrialExpiredError } from '@/server/errors';
 import { PLAN_LIMITS } from './constants';
 import type { Subscription } from '@nexus/db/repo/subscriptions';
 import type { DB } from '@nexus/db';
-
-// Threshold for surfacing a "near limit" warning to the client (e.g. banner).
-const NEAR_LIMIT_RATIO = 0.9;
 
 export interface QuotaContext {
     currentUsage: number;
@@ -50,7 +51,7 @@ function assertUploadAllowed(
 
     const limitBytes = subscription?.storageLimit ?? PLAN_LIMITS.starter;
     const projectedUsage = currentUsage + additionalBytes;
-    const softCap = Math.floor(limitBytes * SOFT_LIMIT_MULTIPLIER);
+    const softCap = softCapBytes(limitBytes);
 
     if (projectedUsage > softCap) {
         throw new QuotaExceededError({

--- a/packages/db/src/plans.ts
+++ b/packages/db/src/plans.ts
@@ -22,6 +22,24 @@ export const PLAN_LIMITS: Record<PlanTier, number> = {
 export const SOFT_LIMIT_MULTIPLIER = 1.05;
 
 /**
+ * The byte ceiling `checkQuota` actually enforces for a plan limit. A
+ * function rather than "multiply it yourself" so the client-side pre-flight
+ * (`apps/web/lib/upload/preflight.ts`) can't drift from the server on the
+ * rounding step.
+ */
+export function softCapBytes(limitBytes: number): number {
+    return Math.floor(limitBytes * SOFT_LIMIT_MULTIPLIER);
+}
+
+/**
+ * Projected usage above this fraction of the plan limit counts as "near the
+ * limit" — the server's `checkQuota` computes it and the upload page's
+ * pre-flight warning mirrors it client-side, so the two must share one
+ * number (same reasoning as `SOFT_LIMIT_MULTIPLIER` above).
+ */
+export const NEAR_LIMIT_RATIO = 0.9;
+
+/**
  * Lives here rather than in `apps/web` so seeds and test-db helpers can reach
  * it — they can't import from the app.
  */


### PR DESCRIPTION
## Summary

Two upload-queue safety gaps closed: the destructive per-row Cancel (which aborts the S3 multipart session and deletes the IndexedDB resume record) now confirms before firing, and quota problems surface before Upload is clicked instead of through a rejected wave.

Design decisions settled with Thomas up front: confirm dialog over undo-toast (no toast-action infra exists, and a real undo would mean deferring an irreversible S3 abort); warn at >90%/100% projected usage but disable Upload only past the 105% soft cap where the server would reject the wave anyway; near-limit signal in both the upload summary and the sidebar bar.

Also folds in the #392 fix: the offline-reconnect flows spec failed on a clean main because `stubS3Puts` only counted an aborted PUT out after its `holdMs` sleep elapsed, so the resumed wave's 4 PUTs overlapped 4 dead-but-still-counted connections (instrumented timeline: all 4 pre-offline PUTs fire `requestfailed net::ERR_ABORTED` at +314ms, resume opens at +709ms, stale decrements land at +1756ms — the browser never held more than 4 live connections; #340's pool is fine). The stub now settles each PUT exactly once, on `requestfailed` or on fulfill, whichever comes first.

Closes #389
Closes #392

## Changes

- **`CancelUploadDialog.tsx`** (new) — confirmation guard on the X of `uploading`/`paused`/`resumable` rows, modeled on `RetrieveDialog` (controlled, `AlertDialogPopup`). The Remove X on pending/queued rows stays instant. The candidate derives from the row's live status, so a row that completes with the dialog open auto-closes it instead of being dropped under "progress will be thrown away" copy.
- **`lib/upload/preflight.ts`** (new, unit-tested) — pure client mirror of the server's `checkQuota`: `ok` / `near-limit` (>90% projected) / `over-limit` (past 100%, inside the 5% grace band) / `blocked` (past the soft cap). Byte comparisons only, since `getUsage().percentage` clamps at 100. Sums pending rows only — resumable rows' landed parts are already billed in `usedBytes`.
- **`upload-zone.tsx`** — warning lines in the queue summary per level; Upload disabled (with destructive copy naming the needed vs. available bytes) only when `blocked`.
- **`sidebar.tsx`** — usage bar tints amber at ≥`NEAR_LIMIT_RATIO`, destructive at ≥100% as before; `data-usage-level` attribute as a stable test hook.
- **`@nexus/db/plans`** — `NEAR_LIMIT_RATIO` promoted from `server/services/quota.ts`, new `softCapBytes()` helper consumed by both the server check and the client pre-flight so the rounding step can't drift (same precedent as `SOFT_LIMIT_MULTIPLIER` in #380).
- **e2e** — new flows specs `upload-cancel-guard` (keep → survives reload; confirm → resume record gone) and `upload-preflight-quota` ×2 (blocked+disabled+recovers on remove; over-limit warns without blocking + sidebar tint); `upload-cancel-cleanup` updated to confirm through the dialog; the quota-halt spec now seeds over-cap usage *after* page load, deliberately preserving coverage of the stale-cache window where server-side enforcement still fires.
- **`e2e/helpers/uploadStubs.ts`** (#392) — `stubS3Puts` decrements an aborted PUT the moment `requestfailed` fires instead of after the hold sleep, settling each request exactly once. The quota-halt spec additionally waits for the sidebar to render the clear usage snapshot before parking the over-cap row — under full-tier load the `getUsage` fetch could lose the race to the insert, and the new pre-flight would disable Upload before the click.

Self-review findings (4/4) applied: shared `NEAR_LIMIT_RATIO` in the sidebar, `softCapBytes()` extraction, dialog stale-candidate race, `data-usage-level` instead of a Tailwind-class selector in the spec.

## Test Plan

- [x] `pnpm check` — green (includes 8 new `preflight.test.ts` boundary tests)
- [x] `pnpm -F web test:e2e:smoke` — green
- [x] `pnpm -F web e2e:coverage --check` — 17/17 pages, 82/82 use-cases (2 new)
- [x] Flows tier: new + touched specs (`upload-cancel-guard`, both `upload-preflight-quota`, `upload-quota-halt`, `upload-cancel-cleanup`) all green in targeted runs
- [x] Full `pnpm -F web test:e2e:flows` — 33/33 green after the #392 stub fix (previously 28/33: `upload-offline-resume-wave` failed identically on clean `origin/main` and serial-skipped 4 specs behind it)
- [x] `upload-offline-resume-wave` green in isolation post-fix; root cause confirmed by instrumented run (event timeline in the summary)
