### PR TITLE
fix: keep the upload queue usable at 50+ files (#390)

### DIFF
--- a/apps/web/components/dashboard/upload-zone.tsx
+++ b/apps/web/components/dashboard/upload-zone.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import type React from 'react';
-import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { memo, useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import {
     Upload,
     X,
@@ -27,8 +28,10 @@ import {
     pickFilesWithHandles,
     pickedFilesFromDataTransfer,
 } from '@/lib/upload/fileSystemAccess';
+import { waveProgress } from '@/lib/upload/parts';
+import { getImagePreviewUrl } from '@/lib/upload/thumbnails';
 import { MiddleTruncateName } from './MiddleTruncateName';
-import { useUpload, type UploadStatus } from './useUpload';
+import { useUpload, type UploadFile, type UploadStatus } from './useUpload';
 
 // Formats the browser can decode natively — RAW files (NEF/CR3/ARW/…) carry
 // an empty or opaque mime type and fall through to the plain icon tile; their
@@ -114,6 +117,29 @@ export function UploadZone() {
         (f) => f.status === 'resumable' && f.isQuickResumable
     );
 
+    // The aggregate header's view of the wave — at 50+ rows the per-row bars
+    // scroll out of sight, so the wave needs one bar that means something.
+    // One row set feeds both the bar and the "X of Y" caption, so they can
+    // never describe different waves (paused rows are in: a row parked by a
+    // connection drop is still the wave's work).
+    const waveRows = files.filter(
+        (f) => f.status !== 'pending' && f.status !== 'resumable'
+    );
+    const wavePercent = waveProgress(waveRows);
+
+    // The queue list is contained and virtualized: page scroll must not grow
+    // with the selection (#390), and neither may the DOM — reconciling 500
+    // mounted rows is what melted this page. Overscan is generous so small
+    // selections (a dozen rows) render fully.
+    const listScrollRef = useRef<HTMLDivElement>(null);
+    const rowVirtualizer = useVirtualizer({
+        count: files.length,
+        getScrollElement: () => listScrollRef.current,
+        estimateSize: () => 78,
+        overscan: 12,
+        getItemKey: (index) => files[index].id,
+    });
+
     return (
         <div className="space-y-6">
             <Card
@@ -183,6 +209,34 @@ export function UploadZone() {
                                 </Button>
                             )}
                         </div>
+                        {hasActiveWave && (
+                            <div className="mb-4 space-y-2 rounded-lg border border-border bg-muted/30 px-4 py-3">
+                                <div className="flex items-center justify-between gap-3 text-sm">
+                                    <p>
+                                        <span className="text-muted-foreground">
+                                            Uploading —{' '}
+                                        </span>
+                                        <span className="font-medium">
+                                            {completedCount} of{' '}
+                                            {waveRows.length} files
+                                        </span>
+                                        {errorCount > 0 && (
+                                            <span className="text-destructive">
+                                                {' '}
+                                                · {errorCount} failed
+                                            </span>
+                                        )}
+                                    </p>
+                                    <span className="font-medium tabular-nums">
+                                        {wavePercent}%
+                                    </span>
+                                </div>
+                                <Progress
+                                    value={wavePercent}
+                                    className="h-1.5"
+                                />
+                            </div>
+                        )}
                         {quickResumable.length > 0 && (
                             <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3">
                                 <div className="flex items-center gap-2 text-sm">
@@ -208,119 +262,50 @@ export function UploadZone() {
                                 </Button>
                             </div>
                         )}
-                        <div className="space-y-3">
-                            {files.map((file) => (
-                                <div
-                                    key={file.id}
-                                    className="flex items-center gap-3 rounded-lg border border-border p-3"
-                                >
-                                    <UploadPreviewTile
-                                        blob={file.previewFile}
-                                        status={file.status}
-                                    />
-                                    <div className="flex-1 min-w-0">
-                                        <MiddleTruncateName
-                                            name={file.name}
-                                            className="font-medium"
-                                        />
-                                        <p className="text-sm text-muted-foreground">
-                                            {formatBytes(file.size)}
-                                        </p>
-                                        {(file.status === 'uploading' ||
-                                            file.status === 'paused' ||
-                                            file.status === 'resumable') && (
-                                            <Progress
-                                                value={file.progress}
-                                                className="mt-2 h-1"
-                                            />
-                                        )}
-                                        {file.status === 'queued' && (
-                                            <p className="mt-1 text-xs text-muted-foreground">
-                                                Waiting to upload
-                                            </p>
-                                        )}
-                                        {file.status === 'paused' && (
-                                            <p className="mt-1 text-xs text-amber-600">
-                                                Paused — waiting for your
-                                                connection
-                                            </p>
-                                        )}
-                                        {file.status === 'resumable' && (
-                                            <p className="mt-1 text-xs text-amber-600">
-                                                {file.isQuickResumable
-                                                    ? 'Interrupted — resume in one click'
-                                                    : 'Interrupted — re-add this file to resume'}
-                                            </p>
-                                        )}
-                                        {file.status === 'error' &&
-                                            file.error && (
-                                                <p className="mt-1 text-xs text-destructive">
-                                                    {file.error}
-                                                </p>
-                                            )}
-                                    </div>
-                                    {/* Removable while queued too: the pool
-                                        re-reads the row at start time, so a
-                                        removed row is simply skipped. */}
-                                    {(file.status === 'pending' ||
-                                        file.status === 'queued') && (
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            onClick={() => removeFile(file.id)}
-                                        >
-                                            <X className="h-4 w-4" />
-                                            <span className="sr-only">
-                                                Remove
-                                            </span>
-                                        </Button>
-                                    )}
-                                    {file.status === 'resumable' &&
-                                        file.isQuickResumable && (
-                                            <Button
-                                                size="sm"
-                                                onClick={() =>
-                                                    resumeWithHandle(file.id)
+                        {/* Contained scroll: the page must not grow with the
+                            selection. Rows are absolutely positioned by the
+                            virtualizer and measured (heights vary by status),
+                            with pb-3 standing in for the old space-y-3. */}
+                        <div
+                            ref={listScrollRef}
+                            data-testid="upload-queue"
+                            className="max-h-[min(24rem,55dvh)] overflow-y-auto overscroll-contain"
+                        >
+                            <div
+                                className="relative"
+                                style={{
+                                    height: rowVirtualizer.getTotalSize(),
+                                }}
+                            >
+                                {rowVirtualizer
+                                    .getVirtualItems()
+                                    .map((virtualRow) => {
+                                        const file = files[virtualRow.index];
+                                        return (
+                                            <div
+                                                key={file.id}
+                                                ref={
+                                                    rowVirtualizer.measureElement
                                                 }
-                                                disabled={isUploading}
+                                                data-index={virtualRow.index}
+                                                data-testid="upload-queue-row"
+                                                className="absolute inset-x-0 top-0 pb-3"
+                                                style={{
+                                                    transform: `translateY(${virtualRow.start}px)`,
+                                                }}
                                             >
-                                                <Play className="mr-2 h-4 w-4" />
-                                                Resume
-                                            </Button>
-                                        )}
-                                    {(file.status === 'uploading' ||
-                                        file.status === 'paused' ||
-                                        file.status === 'resumable') && (
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            onClick={() => cancelFile(file.id)}
-                                        >
-                                            <X className="h-4 w-4" />
-                                            <span className="sr-only">
-                                                Cancel upload
-                                            </span>
-                                        </Button>
-                                    )}
-                                    {file.status === 'error' && (
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            onClick={() => retryFile(file.id)}
-                                        >
-                                            <RotateCcw className="h-4 w-4" />
-                                            <span className="sr-only">
-                                                Retry upload
-                                            </span>
-                                        </Button>
-                                    )}
-                                    {file.status === 'complete' && (
-                                        <span className="text-xs font-medium text-green-500">
-                                            Uploaded
-                                        </span>
-                                    )}
-                                </div>
-                            ))}
+                                                <UploadQueueRow
+                                                    file={file}
+                                                    isUploading={isUploading}
+                                                    onRemove={removeFile}
+                                                    onCancel={cancelFile}
+                                                    onRetry={retryFile}
+                                                    onResume={resumeWithHandle}
+                                                />
+                                            </div>
+                                        );
+                                    })}
+                            </div>
                         </div>
                         <div className="mt-6 flex flex-col gap-4 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
                             <div className="space-y-1">
@@ -345,17 +330,6 @@ export function UploadZone() {
                                                     0
                                                 )
                                             )}
-                                        </span>
-                                    </p>
-                                )}
-                                {hasActiveWave && (
-                                    <p className="text-sm">
-                                        <span className="text-muted-foreground">
-                                            Uploaded:
-                                        </span>{' '}
-                                        <span className="font-medium">
-                                            {completedCount} of{' '}
-                                            {activeCount + attemptedCount} files
                                         </span>
                                     </p>
                                 )}
@@ -411,6 +385,118 @@ export function UploadZone() {
     );
 }
 
+interface UploadQueueRowProps {
+    file: UploadFile;
+    isUploading: boolean;
+    onRemove: (id: string) => void;
+    onCancel: (id: string) => void;
+    onRetry: (id: string) => void;
+    onResume: (id: string) => void;
+}
+
+/**
+ * One queue row, memoized: a progress tick re-renders only the row it moved.
+ * That only holds because `useUpload` hands out identity-stable row objects
+ * (unchanged rows project to the same reference) and stable callbacks — the
+ * memo is the last link in that chain, not a local optimization.
+ */
+const UploadQueueRow = memo(function UploadQueueRow({
+    file,
+    isUploading,
+    onRemove,
+    onCancel,
+    onRetry,
+    onResume,
+}: UploadQueueRowProps) {
+    return (
+        <div className="flex items-center gap-3 rounded-lg border border-border p-3">
+            <UploadPreviewTile blob={file.previewFile} status={file.status} />
+            <div className="flex-1 min-w-0">
+                <MiddleTruncateName name={file.name} className="font-medium" />
+                <p className="text-sm text-muted-foreground">
+                    {formatBytes(file.size)}
+                </p>
+                {(file.status === 'uploading' ||
+                    file.status === 'paused' ||
+                    file.status === 'resumable') && (
+                    <Progress value={file.progress} className="mt-2 h-1" />
+                )}
+                {file.status === 'queued' && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                        Waiting to upload
+                    </p>
+                )}
+                {file.status === 'paused' && (
+                    <p className="mt-1 text-xs text-amber-600">
+                        Paused — waiting for your connection
+                    </p>
+                )}
+                {file.status === 'resumable' && (
+                    <p className="mt-1 text-xs text-amber-600">
+                        {file.isQuickResumable
+                            ? 'Interrupted — resume in one click'
+                            : 'Interrupted — re-add this file to resume'}
+                    </p>
+                )}
+                {file.status === 'error' && file.error && (
+                    <p className="mt-1 text-xs text-destructive">
+                        {file.error}
+                    </p>
+                )}
+            </div>
+            {/* Removable while queued too: the pool re-reads the row at start
+                time, so a removed row is simply skipped. */}
+            {(file.status === 'pending' || file.status === 'queued') && (
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => onRemove(file.id)}
+                >
+                    <X className="h-4 w-4" />
+                    <span className="sr-only">Remove</span>
+                </Button>
+            )}
+            {file.status === 'resumable' && file.isQuickResumable && (
+                <Button
+                    size="sm"
+                    onClick={() => onResume(file.id)}
+                    disabled={isUploading}
+                >
+                    <Play className="mr-2 h-4 w-4" />
+                    Resume
+                </Button>
+            )}
+            {(file.status === 'uploading' ||
+                file.status === 'paused' ||
+                file.status === 'resumable') && (
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => onCancel(file.id)}
+                >
+                    <X className="h-4 w-4" />
+                    <span className="sr-only">Cancel upload</span>
+                </Button>
+            )}
+            {file.status === 'error' && (
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => onRetry(file.id)}
+                >
+                    <RotateCcw className="h-4 w-4" />
+                    <span className="sr-only">Retry upload</span>
+                </Button>
+            )}
+            {file.status === 'complete' && (
+                <span className="text-xs font-medium text-green-500">
+                    Uploaded
+                </span>
+            )}
+        </div>
+    );
+});
+
 /**
  * The row's 10x10 leading tile. Browser-decodable files get a local blob
  * preview in the same fixed box (no reflow, no server round-trip); the
@@ -433,14 +519,22 @@ function UploadPreviewTile({
             ? ('video' as const)
             : null;
 
-    const previewUrl = useMemo(
-        () => (blob && kind ? URL.createObjectURL(blob) : null),
+    // Images render a tile-sized thumbnail (decoded once, cached per File in
+    // lib/upload/thumbnails) — never the raw file, whose full-size decode is
+    // what buried the page under a 50-photo selection (#390).
+    const imageUrl = useImagePreviewUrl(blob && kind === 'image' ? blob : null);
+    // Videos keep a per-mount object URL: metadata preload paints the first
+    // frame without a retained decode, and virtualization bounds how many
+    // <video> elements exist at once.
+    const videoUrl = useMemo(
+        () => (blob && kind === 'video' ? URL.createObjectURL(blob) : null),
         [blob, kind]
     );
     useEffect(() => {
-        if (!previewUrl) return;
-        return () => URL.revokeObjectURL(previewUrl);
-    }, [previewUrl]);
+        if (!videoUrl) return;
+        return () => URL.revokeObjectURL(videoUrl);
+    }, [videoUrl]);
+    const previewUrl = imageUrl ?? videoUrl;
 
     // Pending and queued rows keep a clean preview — the scrim + icon only
     // takes over once the row has a state worth signalling.
@@ -494,4 +588,26 @@ function UploadPreviewTile({
             )}
         </div>
     );
+}
+
+/* Resolves a file's cached tile thumbnail. Starts null (the tile shows its
+   icon) and stays null for files that can't be decoded. The resolved URL is
+   stored with the blob it belongs to and matched on read, so a row whose blob
+   changes can't flash the previous file's thumbnail. */
+function useImagePreviewUrl(blob: File | null): string | null {
+    const [preview, setPreview] = useState<{
+        blob: File;
+        url: string | null;
+    } | null>(null);
+    useEffect(() => {
+        if (!blob) return;
+        let isActive = true;
+        void getImagePreviewUrl(blob).then((url) => {
+            if (isActive) setPreview({ blob, url });
+        });
+        return () => {
+            isActive = false;
+        };
+    }, [blob]);
+    return blob && preview?.blob === blob ? preview.url : null;
 }

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -39,6 +39,7 @@ import {
     partsProgress,
     toFileIdentity,
 } from '@/lib/upload/parts';
+import { patchRowById } from '@/lib/upload/rows';
 import {
     isFileSystemAccessSupported,
     reacquireMatchingFile,
@@ -238,9 +239,7 @@ export function useUpload() {
 
     const updateFile = useCallback(
         (id: string, updates: Partial<InternalUploadFile>) => {
-            setFiles((prev) =>
-                prev.map((f) => (f.id === id ? { ...f, ...updates } : f))
-            );
+            setFiles((prev) => patchRowById(prev, id, updates));
         },
         []
     );
@@ -968,8 +967,14 @@ export function useUpload() {
         },
         [abandonServerUpload]
     );
-    const removeFile = dropRow;
-    const cancelFile = dropRow;
+    // Row-facing callbacks go through a ref (same pattern as runQueuedRef):
+    // dropRow's identity changes every render because it closes over the
+    // per-render useMutation objects, and a fresh prop identity per render
+    // would defeat UploadQueueRow's memo.
+    const dropRowRef = useRef(dropRow);
+    dropRowRef.current = dropRow;
+    const removeFile = useCallback((id: string) => dropRowRef.current(id), []);
+    const cancelFile = removeFile;
 
     // Clear all empties the list; it is not a per-row "give up on this upload"
     // the way Cancel/Remove is. So it must not destroy multipart work the user
@@ -1065,13 +1070,14 @@ export function useUpload() {
         ]
     );
 
-    const resumeWithHandle = useCallback(
-        (id: string) => {
-            const row = filesRef.current.find((f) => f.id === id);
-            if (row) void resumeRows([row]);
-        },
-        [resumeRows]
-    );
+    // Ref-stable for the same reason as removeFile: resumeRows re-forms per
+    // render via the multipart engine's mutation deps.
+    const resumeRowsRef = useRef(resumeRows);
+    resumeRowsRef.current = resumeRows;
+    const resumeWithHandle = useCallback((id: string) => {
+        const row = filesRef.current.find((f) => f.id === id);
+        if (row) void resumeRowsRef.current([row]);
+    }, []);
 
     const resumeAllWithHandles = useCallback(() => {
         const rows = filesRef.current.filter(
@@ -1081,27 +1087,7 @@ export function useUpload() {
     }, [resumeRows]);
 
     // Expose only the public UploadFile shape (strip internal fields)
-    const publicFiles: UploadFile[] = files.map(
-        ({
-            id,
-            name,
-            size,
-            progress,
-            status,
-            error,
-            isQuickResumable,
-            file,
-        }) => ({
-            id,
-            name,
-            size,
-            progress,
-            status,
-            error,
-            isQuickResumable,
-            previewFile: file,
-        })
-    );
+    const publicFiles: UploadFile[] = files.map(toPublicUploadFile);
 
     return {
         files: publicFiles,
@@ -1115,6 +1101,31 @@ export function useUpload() {
         resumeWithHandle,
         resumeAllWithHandles,
     };
+}
+
+// Public projection, cached per internal row object. Internal rows are
+// immutable (updateFile replaces, never mutates), so an unchanged row projects
+// to the *same* public object across renders — which is what lets the
+// memoized queue row skip reconciling the 50+ siblings a progress tick
+// didn't touch.
+const publicRowCache = new WeakMap<InternalUploadFile, UploadFile>();
+
+function toPublicUploadFile(row: InternalUploadFile): UploadFile {
+    let cached = publicRowCache.get(row);
+    if (!cached) {
+        cached = {
+            id: row.id,
+            name: row.name,
+            size: row.size,
+            progress: row.progress,
+            status: row.status,
+            error: row.error,
+            isQuickResumable: row.isQuickResumable,
+            previewFile: row.file,
+        };
+        publicRowCache.set(row, cached);
+    }
+    return cached;
 }
 
 // Reopen the bytes behind a resumable row's persisted handle, verifying identity.

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -353,6 +353,18 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/upload'],
     },
     {
+        id: 'upload-large-selection-contained',
+        title: 'A 50-file selection stays contained: bounded page scroll, virtualized rows',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
+        id: 'upload-wave-progress',
+        title: 'Aggregate wave progress (byte-weighted bar + counts) shown while a wave runs',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
         id: 'upload-clear-keeps-resumable',
         title: 'Clear all empties the queue without destroying resumable uploads',
         area: 'upload',

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -24,6 +24,7 @@ import { fileName } from '../helpers/table';
 import { interceptTrpcCalls } from '../helpers/trpc';
 import { seedResumableUpload } from '../helpers/uploadStore';
 import {
+    makePngFile,
     makeTextFiles,
     stubS3Puts,
     writeLargeFiles,
@@ -102,6 +103,72 @@ test(
         await page.getByRole('button', { name: 'Clear all' }).click();
 
         await expect(page.getByText(/Selected Files/)).toBeHidden();
+    }
+);
+
+// A 50-file selection used to render 50 heavy rows into the page flow (#390):
+// kilometric scroll, and every progress tick reconciled all of them. The list
+// is now contained and virtualized — the page and the DOM stay bounded no
+// matter how many files are queued.
+test(
+    'a 50-file selection stays contained — bounded page scroll, virtualized rows',
+    {
+        tag: [
+            '@page:/dashboard/upload',
+            '@uc:upload-large-selection-contained',
+        ],
+    },
+    async ({ page, consoleErrors }) => {
+        // One real image among the text files, so the tile's decode → resize →
+        // cache pipeline runs in this tier and not only in a manual check.
+        const image = makePngFile('queue-large-photo.png');
+        const files = [image, ...makeTextFiles(49, 'queue-large')];
+
+        await page.goto(PAGE_URL);
+        await page.setInputFiles('input[type="file"]', files);
+
+        await expect(page.getByText('Selected Files (50)')).toBeVisible();
+        await expect(
+            page.getByRole('button', { name: 'Upload 50 files' })
+        ).toBeVisible();
+
+        // The image row's tile resolves to a generated thumbnail (a blob URL,
+        // never the raw file).
+        await expect(
+            page
+                .getByTestId('upload-queue-row')
+                .filter({ hasText: image.name })
+                .locator('img')
+        ).toBeVisible();
+
+        // The queue scrolls inside its own container, not the page…
+        const queue = page.getByTestId('upload-queue');
+        await expect(queue).toBeVisible();
+        expect(
+            await queue.evaluate((el) => el.scrollHeight > el.clientHeight)
+        ).toBe(true);
+        // …so the page stays within a few screens, where rendering every row
+        // into the page flow grew it by a row-height per file.
+        const viewportHeight = page.viewportSize()!.height;
+        expect(
+            await page.evaluate(() => document.documentElement.scrollHeight)
+        ).toBeLessThan(viewportHeight * 3);
+
+        // Virtualized: the DOM holds the visible window plus overscan, never
+        // every row — DOM size scaling with the selection is what melted the
+        // page.
+        const renderedRows = await page.getByTestId('upload-queue-row').count();
+        expect(renderedRows).toBeGreaterThan(0);
+        expect(renderedRows).toBeLessThan(files.length);
+
+        // Rows past the window really exist: scrolling the container to the
+        // bottom materializes the last file.
+        await queue.evaluate((el) => {
+            el.scrollTop = el.scrollHeight;
+        });
+        await expect(fileName(page, 'queue-large-48.txt')).toBeVisible();
+
+        expect(consoleErrors).toEqual([]);
     }
 );
 
@@ -406,7 +473,13 @@ test(
 // added while it runs queue as pending and a click folds them in.
 test(
     'files added mid-wave join the running wave',
-    { tag: ['@page:/dashboard/upload', '@uc:upload-add-mid-wave'] },
+    {
+        tag: [
+            '@page:/dashboard/upload',
+            '@uc:upload-add-mid-wave',
+            '@uc:upload-wave-progress',
+        ],
+    },
     async ({ page }) => {
         const puts = await stubS3Puts(page, { holdMs: 2000 });
         const first = makeTextFiles(MAX_CONCURRENT_FILES + 2, 'queue-first');
@@ -423,6 +496,16 @@ test(
         await expect(page.getByText('Waiting to upload').first()).toBeVisible({
             timeout: 15_000,
         });
+        // The wave is guaranteed live here (2s holds), so this is where the
+        // aggregate header is assertable without racing the wave's end: the
+        // per-row bars are useless at 50+ rows, the header is the summary.
+        // Full phrase, so only the header line matches (its inner spans and
+        // the "Uploading..." button each hold fragments).
+        await expect(
+            page.getByText(
+                new RegExp(`Uploading — \\d+ of ${first.length} files`)
+            )
+        ).toBeVisible();
         await expect(
             page.getByRole('button', { name: 'Remove' }).first()
         ).toBeVisible();

--- a/apps/web/e2e/helpers/uploadStubs.ts
+++ b/apps/web/e2e/helpers/uploadStubs.ts
@@ -89,6 +89,25 @@ export async function stubS3Puts(
     return seen;
 }
 
+/**
+ * A real decodable image (1x1 transparent PNG), for tests that need the
+ * preview/thumbnail pipeline to run rather than fall through to an icon tile.
+ */
+export function makePngFile(name: string): {
+    name: string;
+    mimeType: string;
+    buffer: Buffer;
+} {
+    return {
+        name,
+        mimeType: 'image/png',
+        buffer: Buffer.from(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+            'base64'
+        ),
+    };
+}
+
 /** Distinct text files, for driving a multi-file upload. */
 export function makeTextFiles(
     count: number,

--- a/apps/web/lib/upload/parts.test.ts
+++ b/apps/web/lib/upload/parts.test.ts
@@ -5,6 +5,7 @@ import {
     mergeParts,
     partByteRange,
     partsProgress,
+    waveProgress,
     isResumable,
 } from './parts';
 import type { ResumableUpload } from './uploadStore';
@@ -94,6 +95,23 @@ describe('partsProgress', () => {
 
     it('is 0 for zero total', () => {
         expect(partsProgress(0, 0)).toBe(0);
+    });
+});
+
+describe('waveProgress', () => {
+    it('weights by bytes, not by row count', () => {
+        // The big file at 50% dominates nine tiny finished files.
+        const rows = [
+            { size: 9_000, progress: 50 },
+            ...Array.from({ length: 9 }, () => ({ size: 100, progress: 100 })),
+        ];
+        expect(waveProgress(rows)).toBe(55);
+    });
+
+    it('is 100 when every byte is done and 0 for an empty wave', () => {
+        expect(waveProgress([{ size: 10, progress: 100 }])).toBe(100);
+        expect(waveProgress([])).toBe(0);
+        expect(waveProgress([{ size: 0, progress: 100 }])).toBe(0);
     });
 });
 

--- a/apps/web/lib/upload/parts.ts
+++ b/apps/web/lib/upload/parts.ts
@@ -69,6 +69,23 @@ export function partsProgress(completed: number, total: number): number {
     return Math.round((completed / total) * 100);
 }
 
+/**
+ * Aggregate progress of an upload wave as a 0-100 integer, byte-weighted:
+ * one 80GB video outweighs a folder of JPEGs. Callers pass the rows that
+ * belong to the wave; this doesn't know about statuses.
+ */
+export function waveProgress(
+    rows: { size: number; progress: number }[]
+): number {
+    const totalBytes = rows.reduce((acc, row) => acc + row.size, 0);
+    if (totalBytes <= 0) return 0;
+    const doneBytes = rows.reduce(
+        (acc, row) => acc + (row.size * row.progress) / 100,
+        0
+    );
+    return Math.round((doneBytes / totalBytes) * 100);
+}
+
 /** Snapshot the fields a re-added file must match against a persisted record. */
 export function toFileIdentity(file: File): FileIdentity {
     return {

--- a/apps/web/lib/upload/rows.test.ts
+++ b/apps/web/lib/upload/rows.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { patchRowById } from './rows';
+
+interface Row {
+    id: string;
+    progress: number;
+    status: string;
+    error?: string;
+}
+
+const rows: Row[] = [
+    { id: 'a', progress: 10, status: 'uploading' },
+    { id: 'b', progress: 0, status: 'pending' },
+];
+
+describe('patchRowById', () => {
+    it('returns the same array when the id is unknown', () => {
+        expect(patchRowById(rows, 'missing', { progress: 50 })).toBe(rows);
+    });
+
+    it('returns the same array when no field actually changes', () => {
+        expect(patchRowById(rows, 'a', { progress: 10 })).toBe(rows);
+        expect(
+            patchRowById(rows, 'a', { progress: 10, status: 'uploading' })
+        ).toBe(rows);
+        // An absent optional field patched to undefined is still a no-op.
+        expect(patchRowById(rows, 'a', { error: undefined })).toBe(rows);
+    });
+
+    it('patches the matching row and keeps sibling references', () => {
+        const next = patchRowById(rows, 'a', { progress: 11 });
+        expect(next).not.toBe(rows);
+        expect(next[0]).toEqual({ id: 'a', progress: 11, status: 'uploading' });
+        expect(next[1]).toBe(rows[1]);
+        // Input is untouched.
+        expect(rows[0].progress).toBe(10);
+    });
+
+    it('treats clearing a set field as a change', () => {
+        const failed: Row[] = [
+            { id: 'a', progress: 40, status: 'error', error: 'boom' },
+        ];
+        const next = patchRowById(failed, 'a', { error: undefined });
+        expect(next).not.toBe(failed);
+        expect(next[0].error).toBeUndefined();
+    });
+});

--- a/apps/web/lib/upload/rows.ts
+++ b/apps/web/lib/upload/rows.ts
@@ -1,0 +1,25 @@
+/**
+ * Identity-preserving patch for upload queue rows.
+ *
+ * Returns the *same* array when the patch changes nothing, so a
+ * `setState((prev) => patchRowById(prev, ...))` commits no render for a no-op
+ * update. That's the whole defense against progress-event floods: XHR fires
+ * `onprogress` per network buffer, but a row's rounded percent only moves ~100
+ * times per file, and every event in between must not reconcile the queue.
+ * Rows other than the patched one keep their references, which is what lets a
+ * memoized row component skip them.
+ */
+export function patchRowById<T extends { id: string }>(
+    rows: T[],
+    id: string,
+    updates: Partial<T>
+): T[] {
+    const index = rows.findIndex((row) => row.id === id);
+    if (index === -1) return rows;
+    const row = rows[index];
+    const keys = Object.keys(updates) as (keyof T)[];
+    if (keys.every((key) => Object.is(row[key], updates[key]))) return rows;
+    const next = rows.slice();
+    next[index] = { ...row, ...updates };
+    return next;
+}

--- a/apps/web/lib/upload/thumbnails.test.ts
+++ b/apps/web/lib/upload/thumbnails.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getImagePreviewUrl } from './thumbnails';
+
+// jsdom has no createImageBitmap, so these cover the contract the tile relies
+// on — undecodable input degrades to null (never a full-res URL), and the
+// per-File cache — not the happy decode path, which the flows e2e spec
+// exercises in a real browser.
+describe('getImagePreviewUrl', () => {
+    it('resolves null when the image cannot be decoded', async () => {
+        const file = new File(['not an image'], 'photo.png', {
+            type: 'image/png',
+        });
+        await expect(getImagePreviewUrl(file)).resolves.toBeNull();
+    });
+
+    it('caches per File: same file shares one promise, distinct files do not', () => {
+        const a = new File(['a'], 'a.png', { type: 'image/png' });
+        const b = new File(['b'], 'b.png', { type: 'image/png' });
+        const first = getImagePreviewUrl(a);
+        expect(getImagePreviewUrl(a)).toBe(first);
+        expect(getImagePreviewUrl(b)).not.toBe(first);
+    });
+});

--- a/apps/web/lib/upload/thumbnails.ts
+++ b/apps/web/lib/upload/thumbnails.ts
@@ -1,0 +1,78 @@
+/**
+ * Downscaled local previews for upload queue rows.
+ *
+ * The raw File must never reach an <img>: the browser decodes the whole image
+ * to paint even a 40px tile, and a 50-photo camera batch is gigabytes of
+ * decoded bitmap (#390). Each image is decoded once, scaled so its short side
+ * fits the tile, and re-encoded as a tiny blob whose object URL is what the
+ * tile renders. Cached per File because virtualized rows unmount on scroll —
+ * a remount must be a cache hit, not a re-decode.
+ *
+ * URLs are deliberately never revoked: the cache owns them for the session,
+ * several tiles can share one concurrently, and the blobs they pin are
+ * kilobytes.
+ */
+
+/* Tile short side at 2x DPR (the tile renders at 40px), with slack so
+   object-cover never upscales. */
+const TILE_SOURCE_PX = 96;
+
+const previewUrlCache = new WeakMap<File, Promise<string | null>>();
+
+/**
+ * Object URL for a tile-sized preview of an image file, or null when the file
+ * can't be decoded (the tile keeps its plain icon). No failure path may
+ * return the raw file's URL — that would reinstate the full-size decode this
+ * module exists to eliminate.
+ */
+export function getImagePreviewUrl(file: File): Promise<string | null> {
+    let cached = previewUrlCache.get(file);
+    if (!cached) {
+        cached = createTilePreviewUrl(file);
+        previewUrlCache.set(file, cached);
+    }
+    return cached;
+}
+
+async function createTilePreviewUrl(file: File): Promise<string | null> {
+    try {
+        const bitmap = await createImageBitmap(file);
+        try {
+            // Short side lands on TILE_SOURCE_PX so cover-fitting the square
+            // tile stays crisp for any aspect ratio; small images pass through
+            // unscaled.
+            const scale = Math.min(
+                TILE_SOURCE_PX / Math.min(bitmap.width, bitmap.height),
+                1
+            );
+            const width = Math.max(1, Math.round(bitmap.width * scale));
+            const height = Math.max(1, Math.round(bitmap.height * scale));
+            const blob = await drawToBlob(bitmap, width, height);
+            return blob ? URL.createObjectURL(blob) : null;
+        } finally {
+            // Release the full-size decode immediately — retaining it is the
+            // exact cost this module exists to avoid.
+            bitmap.close();
+        }
+    } catch {
+        // Undecodable (corrupt file, exotic subtype the mime check let
+        // through) — the tile falls back to its plain icon.
+        return null;
+    }
+}
+
+function drawToBlob(
+    bitmap: ImageBitmap,
+    width: number,
+    height: number
+): Promise<Blob | null> {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) return Promise.resolve(null);
+    context.drawImage(bitmap, 0, 0, width, height);
+    // webp where the encoder exists; toBlob falls back to png elsewhere,
+    // which keeps transparency either way.
+    return new Promise((resolve) => canvas.toBlob(resolve, 'image/webp', 0.8));
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
         "@sentry/nextjs": "^10.65.0",
         "@tanstack/react-form": "^1.27.7",
         "@tanstack/react-query": "^5.90.16",
+        "@tanstack/react-virtual": "^3.14.10",
         "@trpc/client": "^11.8.1",
         "@trpc/server": "^11.8.1",
         "@trpc/tanstack-react-query": "^11.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.16
         version: 5.90.16(react@19.2.3)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.10
+        version: 3.14.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@trpc/client':
         specifier: ^11.8.1
         version: 11.8.1(@trpc/server@11.8.1(typescript@5.9.3))(typescript@5.9.3)
@@ -2874,11 +2877,20 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.14.10':
+    resolution: {integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/store@0.7.7':
     resolution: {integrity: sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==}
 
   '@tanstack/store@0.8.0':
     resolution: {integrity: sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ==}
+
+  '@tanstack/virtual-core@3.17.8':
+    resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -8728,9 +8740,17 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       use-sync-external-store: 1.6.0(react@19.2.3)
 
+  '@tanstack/react-virtual@3.14.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.8
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   '@tanstack/store@0.7.7': {}
 
   '@tanstack/store@0.8.0': {}
+
+  '@tanstack/virtual-core@3.17.8': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -10043,7 +10063,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -10066,7 +10086,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10081,13 +10101,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -10119,7 +10139,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Closes #390

A ~50-file selection made `/dashboard/upload` crawl and stretched the page to several screens. Three client-side causes, three fixes:

## Render thrash
- `updateFile` now goes through `patchRowById` (`lib/upload/rows.ts`): a progress event that doesn't change a row's rounded percent returns the same array, so React commits nothing. Unchanged rows keep their references.
- The public projection in `useUpload` is cached per internal row (WeakMap), and the queue row is an extracted `memo` component — a progress tick re-renders only the row it moved. Row-facing callbacks (`removeFile`/`cancelFile`/`resumeWithHandle`) are ref-stable so the memo actually holds (they previously re-formed every render via react-query's per-render mutation objects).

## Full-resolution previews
- `lib/upload/thumbnails.ts`: images decode once via `createImageBitmap`, downscale to tile size (~96px short side), re-encode as a tiny blob, cached per `File`. The raw file never reaches an `<img>`; undecodable files fall back to the icon tile, never a full-res URL.

## Unbounded list
- Queue rows live in a contained scroll area (`max-h-[min(24rem,55dvh)]`) virtualized with `@tanstack/react-virtual` (measured rows, overscan 12 so small selections stay fully in the DOM for existing specs).
- New aggregate wave header: byte-weighted progress bar (`waveProgress` in `lib/upload/parts.ts`) + "X of Y files · n failed", replacing the footer's "Uploaded: X of Y" line, which was invisible below 50 rows.

## Tests
- Unit: `rows.test.ts`, `thumbnails.test.ts`, `waveProgress` cases in `parts.test.ts`.
- Flows: new `@uc:upload-large-selection-contained` spec (50 files incl. one real PNG asserting the thumbnail pipeline; bounded page height, internal scroll, windowed DOM, virtualized tail reachable) and a wave-header assertion (`@uc:upload-wave-progress`) in the mid-wave spec.
- Gates: `pnpm check` 12/12, smoke 47/47, flows 31/31, `e2e:coverage --check` 82/82.

Self-review (3-lane workflow) ran; 10 of 11 findings applied. Skipped: adopting `classifyMedia` for the tile's media-kind check — that's #362's scope (media classification is retyped in four places; unifying one of them here piecemeal doesn't move that issue).