### PR TITLE
feat: accept folder drops and folder picking in the upload zone (#388)

### DIFF
--- a/apps/web/components/dashboard/upload-zone.tsx
+++ b/apps/web/components/dashboard/upload-zone.tsx
@@ -17,6 +17,7 @@ import {
     History,
     Play,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
@@ -24,10 +25,15 @@ import { cn } from '@/lib/cn';
 import { formatBytes } from '@/lib/format';
 import { useTRPC } from '@/lib/trpc/client';
 import {
+    isDirectoryPickerSupported,
     isFileSystemAccessSupported,
     pickFilesWithHandles,
+    pickFolderWithHandles,
     pickedFilesFromDataTransfer,
+    pickedFilesFromDirectoryInput,
+    type PickedFileBatch,
 } from '@/lib/upload/fileSystemAccess';
+import { MAX_FILES_PER_DROP } from '@/lib/upload/limits';
 import { waveProgress } from '@/lib/upload/parts';
 import { preflightQuota } from '@/lib/upload/preflight';
 import { getImagePreviewUrl } from '@/lib/upload/thumbnails';
@@ -62,16 +68,39 @@ export function UploadZone() {
         null
     );
     const inputRef = useRef<HTMLInputElement>(null);
+    const folderInputRef = useRef<HTMLInputElement>(null);
+
+    // The one queueing seam for every ingest gesture. Feedback lives here so
+    // no path can regress into the silent ignore #388 was about: a capped walk
+    // says what it kept, an empty folder says it had nothing.
+    const addPickedBatch = useCallback(
+        ({ files: picked, truncated, emptySelection }: PickedFileBatch) => {
+            if (truncated) {
+                toast.info(
+                    `Large selection — only the first ${MAX_FILES_PER_DROP.toLocaleString()} files were added.`
+                );
+            }
+            if (picked.length === 0) {
+                if (emptySelection)
+                    toast.info('No files found in that folder.');
+                return;
+            }
+            void addFiles(picked);
+        },
+        [addFiles]
+    );
 
     const handleDrop = useCallback(
         (e: React.DragEvent) => {
             e.preventDefault();
             setIsDragOver(false);
-            // Read the DataTransfer synchronously — its items are only live
-            // during the event — then queue the files (with handles when present).
-            void pickedFilesFromDataTransfer(e.dataTransfer).then(addFiles);
+            // The DataTransfer is read synchronously inside — its items are
+            // only live during the event.
+            void pickedFilesFromDataTransfer(e.dataTransfer).then(
+                addPickedBatch
+            );
         },
-        [addFiles]
+        [addPickedBatch]
     );
 
     // On Chromium the picker captures persistable handles for zero-touch resume;
@@ -79,13 +108,21 @@ export function UploadZone() {
     // at click time so there's no SSR/client mismatch and no render-time state.
     const handleBrowse = useCallback(() => {
         if (isFileSystemAccessSupported()) {
-            void pickFilesWithHandles().then((picked) => {
-                if (picked.length > 0) void addFiles(picked);
-            });
+            void pickFilesWithHandles().then(addPickedBatch);
         } else {
             inputRef.current?.click();
         }
-    }, [addFiles]);
+    }, [addPickedBatch]);
+
+    // Folder flavor of the same split: native directory picker on Chromium,
+    // hidden `webkitdirectory` input everywhere else.
+    const handleBrowseFolder = useCallback(() => {
+        if (isDirectoryPickerSupported()) {
+            void pickFolderWithHandles().then(addPickedBatch);
+        } else {
+            folderInputRef.current?.click();
+        }
+    }, [addPickedBatch]);
 
     const handleDragOver = (e: React.DragEvent) => {
         e.preventDefault();
@@ -193,7 +230,7 @@ export function UploadZone() {
                             <Upload className="h-8 w-8 text-primary" />
                         </div>
                         <h3 className="mb-2 text-lg font-semibold">
-                            Drop files here to upload
+                            Drop files or folders here to upload
                         </h3>
                         <p className="mb-4 text-sm text-muted-foreground">
                             or click to browse your computer
@@ -206,6 +243,7 @@ export function UploadZone() {
                             type="file"
                             multiple
                             className="hidden"
+                            data-testid="file-input"
                             onChange={(e) => {
                                 const picked = Array.from(
                                     e.target.files ?? []
@@ -216,12 +254,39 @@ export function UploadZone() {
                                 e.target.value = '';
                             }}
                         />
+                        {/* The folder twin of the input above. `webkitdirectory`
+                            isn't in React's prop types, hence the spread. */}
+                        <input
+                            ref={folderInputRef}
+                            type="file"
+                            className="hidden"
+                            data-testid="folder-input"
+                            {...{ webkitdirectory: '' }}
+                            onChange={(e) => {
+                                if (e.target.files) {
+                                    addPickedBatch(
+                                        pickedFilesFromDirectoryInput(
+                                            e.target.files
+                                        )
+                                    );
+                                }
+                                e.target.value = '';
+                            }}
+                        />
                         {/* Deliberately enabled mid-wave (drag-drop always
                             was): added files queue as pending and the Upload
                             button lets them join the running wave. */}
-                        <Button variant="outline" onClick={handleBrowse}>
-                            Browse files
-                        </Button>
+                        <div className="flex flex-wrap items-center justify-center gap-3">
+                            <Button variant="outline" onClick={handleBrowse}>
+                                Browse files
+                            </Button>
+                            <Button
+                                variant="outline"
+                                onClick={handleBrowseFolder}
+                            >
+                                Browse folder
+                            </Button>
+                        </div>
                     </div>
                 </CardContent>
             </Card>

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -26,13 +26,13 @@ import {
 import {
     addCompletedPart,
     deleteUpload,
-    findUploadByIdentity,
     listUploads,
     putUpload,
     type CompletedPart,
 } from '@/lib/upload/uploadStore';
 import {
     computeRemainingPartNumbers,
+    isFileMatch,
     isResumable,
     mergeParts,
     partByteRange,
@@ -852,10 +852,14 @@ export function useUpload() {
         if (picked.length === 0) return;
 
         // Match each file against a persisted interrupted upload so a re-add
-        // resumes from where S3 left off instead of starting over.
-        const matches = await Promise.all(
-            picked.map(({ file }) => findUploadByIdentity(toFileIdentity(file)))
-        );
+        // resumes from where S3 left off instead of starting over. One store
+        // read for the whole batch (folder drops make it thousands of files),
+        // and one identity per file rather than one per comparison.
+        const records = await listUploads();
+        const matches = picked.map(({ file }) => {
+            const identity = toFileIdentity(file);
+            return records.find((record) => isFileMatch(record, identity));
+        });
 
         setFiles((prev) => {
             // Reattach re-added files to their resumable rows (immutably), then

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -347,6 +347,12 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/upload'],
     },
     {
+        id: 'upload-add-folder-queue',
+        title: 'Select a whole folder — nested files join the queue, hidden entries are skipped',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
         id: 'upload-clear-queue',
         title: 'Clear the pending upload queue',
         area: 'upload',

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -30,6 +30,7 @@ import {
     makePngFile,
     makeTextFiles,
     stubS3Puts,
+    writeFolderTree,
     writeLargeFiles,
 } from '../helpers/uploadStubs';
 
@@ -69,7 +70,10 @@ test(
     async ({ page, consoleErrors }) => {
         await page.goto(PAGE_URL);
 
-        await page.setInputFiles('input[type="file"]', [FILE_A, FILE_B]);
+        await page.setInputFiles('[data-testid="file-input"]', [
+            FILE_A,
+            FILE_B,
+        ]);
 
         await expect(page.getByText('Selected Files (2)')).toBeVisible();
         // fileName(): queue rows render names through MiddleTruncateName,
@@ -94,13 +98,50 @@ test(
     }
 );
 
+// A shoot is a folder (#388): selecting one queues the whole directory —
+// nested files included, dotfile litter skipped. This drives the hidden
+// `webkitdirectory` input directly; the native pickers and the drop-walk
+// recursion can't be driven synthetically and are covered by unit tests.
+test(
+    'selecting a folder queues its files — nested included, hidden skipped',
+    { tag: ['@page:/dashboard/upload', '@uc:upload-add-folder-queue'] },
+    async ({ page, consoleErrors }) => {
+        const tree = await writeFolderTree({
+            name: 'shoot-2026-08-18',
+            files: {
+                'IMG_0001.txt': 'frame one\n',
+                'day2/IMG_0002.txt': 'frame two\n',
+                '.DS_Store': 'finder litter\n',
+            },
+        });
+        try {
+            await page.goto(PAGE_URL);
+            await page.setInputFiles('[data-testid="folder-input"]', tree.dir);
+
+            await expect(page.getByText('Selected Files (2)')).toBeVisible();
+            await expect(fileName(page, 'IMG_0001.txt')).toBeVisible();
+            await expect(fileName(page, 'IMG_0002.txt')).toBeVisible();
+            await expect(
+                page.getByRole('button', { name: 'Upload 2 files' })
+            ).toBeVisible();
+
+            expect(consoleErrors).toEqual([]);
+        } finally {
+            await tree.cleanup();
+        }
+    }
+);
+
 test(
     'clear-all empties the pending queue',
     { tag: ['@page:/dashboard/upload', '@uc:upload-clear-queue'] },
     async ({ page }) => {
         await page.goto(PAGE_URL);
 
-        await page.setInputFiles('input[type="file"]', [FILE_A, FILE_B]);
+        await page.setInputFiles('[data-testid="file-input"]', [
+            FILE_A,
+            FILE_B,
+        ]);
         await expect(page.getByText('Selected Files (2)')).toBeVisible();
 
         await page.getByRole('button', { name: 'Clear all' }).click();
@@ -128,7 +169,7 @@ test(
         const files = [image, ...makeTextFiles(49, 'queue-large')];
 
         await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', files);
+        await page.setInputFiles('[data-testid="file-input"]', files);
 
         await expect(page.getByText('Selected Files (50)')).toBeVisible();
         await expect(
@@ -181,7 +222,9 @@ test(
     async ({ page, consoleErrors }) => {
         await page.goto(PAGE_URL);
         // Wait for the app to open the IndexedDB store before seeding it.
-        await expect(page.getByText('Drop files here to upload')).toBeVisible();
+        await expect(
+            page.getByText('Drop files or folders here to upload')
+        ).toBeVisible();
 
         // Seed a half-finished multipart upload (5 of 10 parts) with no persisted
         // handle, as if a prior session had been interrupted before this feature.
@@ -214,7 +257,9 @@ test(
     { tag: ['@page:/dashboard/upload', '@uc:upload-clear-keeps-resumable'] },
     async ({ page, consoleErrors }) => {
         await page.goto(PAGE_URL);
-        await expect(page.getByText('Drop files here to upload')).toBeVisible();
+        await expect(
+            page.getByText('Drop files or folders here to upload')
+        ).toBeVisible();
 
         await seedResumableUpload(page);
         await page.reload();
@@ -245,7 +290,9 @@ test(
     { tag: ['@page:/dashboard/upload', '@uc:upload-cancel-guard'] },
     async ({ page }) => {
         await page.goto(PAGE_URL);
-        await expect(page.getByText('Drop files here to upload')).toBeVisible();
+        await expect(
+            page.getByText('Drop files or folders here to upload')
+        ).toBeVisible();
 
         await seedResumableUpload(page);
         await page.reload();
@@ -273,7 +320,9 @@ test(
         // races the store and resurrects the upload under load.
         await expect.poll(() => readResumableUploadIds(page)).toEqual([]);
         await page.reload();
-        await expect(page.getByText('Drop files here to upload')).toBeVisible();
+        await expect(
+            page.getByText('Drop files or folders here to upload')
+        ).toBeVisible();
         await expect(fileName(page, 'big-shoot.zip')).toBeHidden();
     }
 );
@@ -283,7 +332,9 @@ test(
     { tag: ['@page:/dashboard/upload', '@uc:upload-resume-one-click'] },
     async ({ page, consoleErrors }) => {
         await page.goto(PAGE_URL);
-        await expect(page.getByText('Drop files here to upload')).toBeVisible();
+        await expect(
+            page.getByText('Drop files or folders here to upload')
+        ).toBeVisible();
 
         // Seed an interrupted upload that captured a File System Access handle.
         // A plain stand-in is enough for the surfacing: the app keys the
@@ -330,7 +381,7 @@ test(
 
         await page.goto(PAGE_URL);
 
-        await page.setInputFiles('input[type="file"]', [FILE_A]);
+        await page.setInputFiles('[data-testid="file-input"]', [FILE_A]);
         await page.getByRole('button', { name: 'Upload 1 file' }).click();
 
         // First attempt fails → inline error + retry affordance.
@@ -361,7 +412,7 @@ test(
         const files = makeTextFiles(MAX_CONCURRENT_FILES * 2, 'queue-wave');
 
         await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', files);
+        await page.setInputFiles('[data-testid="file-input"]', files);
         await page
             .getByRole('button', { name: `Upload ${files.length} files` })
             .click();
@@ -445,7 +496,7 @@ test(
 
         try {
             await page.goto(PAGE_URL);
-            await page.setInputFiles('input[type="file"]', large.paths);
+            await page.setInputFiles('[data-testid="file-input"]', large.paths);
             await page
                 .getByRole('button', {
                     name: `Upload ${MAX_CONCURRENT_FILES} files`,
@@ -485,7 +536,7 @@ test(
         await stubS3Puts(page, { holdMs: 200, failFor: doomed });
 
         await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', files);
+        await page.setInputFiles('[data-testid="file-input"]', files);
         await page
             .getByRole('button', { name: `Upload ${files.length} files` })
             .click();
@@ -531,7 +582,7 @@ test(
         const late = makeTextFiles(2, 'queue-late');
 
         await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', first);
+        await page.setInputFiles('[data-testid="file-input"]', first);
         await page
             .getByRole('button', { name: `Upload ${first.length} files` })
             .click();
@@ -557,7 +608,7 @@ test(
 
         // Adding files mid-wave re-arms the Upload button for just the new
         // rows; clicking it joins the wave already in flight.
-        await page.setInputFiles('input[type="file"]', late);
+        await page.setInputFiles('[data-testid="file-input"]', late);
         await page.getByRole('button', { name: 'Upload 2 files' }).click();
 
         await expect(page.getByText('Uploaded', { exact: true })).toHaveCount(
@@ -578,7 +629,7 @@ test(
         const files = makeTextFiles(MAX_CONCURRENT_FILES * 2, 'queue-offline');
 
         await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', files);
+        await page.setInputFiles('[data-testid="file-input"]', files);
         await page
             .getByRole('button', { name: `Upload ${files.length} files` })
             .click();
@@ -623,7 +674,7 @@ test(
         // fetch can otherwise lose the race to the insert, and the pre-flight
         // would see the parked row and disable Upload.
         await expect(page.getByText('0 Bytes of')).toBeVisible();
-        await page.setInputFiles('input[type="file"]', files);
+        await page.setInputFiles('[data-testid="file-input"]', files);
         await insertStorageUsage(db, {
             userId: seedUserId,
             usedBytes: Math.floor(PLAN_LIMITS.starter * SOFT_LIMIT_MULTIPLIER),
@@ -675,7 +726,7 @@ test(
         });
 
         await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', [FILE_A]);
+        await page.setInputFiles('[data-testid="file-input"]', [FILE_A]);
 
         await expect(page.getByText(/Not enough storage —/)).toBeVisible();
         await expect(
@@ -701,7 +752,7 @@ test(
         });
 
         await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', [FILE_A]);
+        await page.setInputFiles('[data-testid="file-input"]', [FILE_A]);
 
         await expect(
             page.getByText('This upload will put you over your storage limit.')
@@ -735,7 +786,7 @@ test(
             ).map((f) => f.status);
 
         await page.goto(PAGE_URL);
-        await page.setInputFiles('input[type="file"]', [FILE_A]);
+        await page.setInputFiles('[data-testid="file-input"]', [FILE_A]);
         await page.getByRole('button', { name: 'Upload 1 file' }).click();
 
         // Cancel only cleans up what `files.upload` already minted, so wait for

--- a/apps/web/e2e/helpers/uploadStubs.ts
+++ b/apps/web/e2e/helpers/uploadStubs.ts
@@ -161,3 +161,31 @@ export async function writeLargeFiles(options: {
     }
     return { paths, cleanup: () => rm(dir, { recursive: true, force: true }) };
 }
+
+/**
+ * A real on-disk directory tree for driving the folder input
+ * (`setInputFiles` accepts a directory path for `webkitdirectory` inputs and
+ * enumerates it recursively, setting each file's `webkitRelativePath`).
+ * Keys are paths relative to the root, values the file contents. Returns the
+ * root directory path and a cleanup to call once the test is done.
+ */
+export async function writeFolderTree(options: {
+    name: string;
+    files: Record<string, string>;
+}): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+    const { mkdtemp, mkdir, writeFile, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join, dirname } = await import('node:path');
+
+    const parent = await mkdtemp(join(tmpdir(), 'nexus-e2e-folder-'));
+    const dir = join(parent, options.name);
+    for (const [relativePath, content] of Object.entries(options.files)) {
+        const path = join(dir, relativePath);
+        await mkdir(dirname(path), { recursive: true });
+        await writeFile(path, content);
+    }
+    return {
+        dir,
+        cleanup: () => rm(parent, { recursive: true, force: true }),
+    };
+}

--- a/apps/web/e2e/smoke/authenticated/dashboard.spec.ts
+++ b/apps/web/e2e/smoke/authenticated/dashboard.spec.ts
@@ -46,7 +46,7 @@ test.describe('Dashboard Pages', () => {
                 page.getByRole('heading', { name: 'Upload Files', exact: true })
             ).toBeVisible();
             await expect(
-                page.getByText('Drop files here to upload')
+                page.getByText('Drop files or folders here to upload')
             ).toBeVisible();
 
             expect(consoleErrors).toEqual([]);

--- a/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
+++ b/apps/web/e2e/validate/upload-batches-and-quota.spec.ts
@@ -72,7 +72,7 @@ test.describe('upload batches + storage quota', () => {
             const fileBuf = Buffer.from('hello upload batches validate\n');
             const fileName = `validate-${Date.now()}.txt`;
 
-            await page.setInputFiles('input[type="file"]', {
+            await page.setInputFiles('[data-testid="file-input"]', {
                 name: fileName,
                 mimeType: 'text/plain',
                 buffer: fileBuf,
@@ -205,7 +205,10 @@ test.describe('upload batches + storage quota', () => {
                 `validate-multi-${Date.now()}`
             );
 
-            await page.setInputFiles('input[type="file"]', filesToUpload);
+            await page.setInputFiles(
+                '[data-testid="file-input"]',
+                filesToUpload
+            );
             await expect(
                 page.getByText(`Selected Files (${filesToUpload.length})`)
             ).toBeVisible();
@@ -283,7 +286,7 @@ test.describe('upload batches + storage quota', () => {
             ).toBeVisible();
 
             const rejectedName = `quota-rejected-${Date.now()}.txt`;
-            await page.setInputFiles('input[type="file"]', {
+            await page.setInputFiles('[data-testid="file-input"]', {
                 name: rejectedName,
                 mimeType: 'text/plain',
                 buffer: Buffer.from('over-quota attempt\n'),

--- a/apps/web/lib/upload/fileSystemAccess.test.ts
+++ b/apps/web/lib/upload/fileSystemAccess.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it, vi, afterEach } from 'vitest';
 import {
     isFileSystemAccessSupported,
     pickFilesWithHandles,
+    pickFolderWithHandles,
     pickedFilesFromDataTransfer,
+    pickedFilesFromDirectoryInput,
     reacquireMatchingFile,
 } from './fileSystemAccess';
+import { MAX_FILES_PER_DROP } from './limits';
 
 function makeFile(name: string, size: number, lastModified: number): File {
     return new File([new Uint8Array(size)], name, { lastModified });
@@ -44,8 +47,64 @@ function stubHandle(opts: HandleStub = {}): FileSystemFileHandle {
     } as unknown as FileSystemFileHandle;
 }
 
+/** A lean file handle for walk tests — one shared File keeps the cap test cheap. */
+function fileHandleOf(file: File, name = file.name): FileSystemFileHandle {
+    return {
+        kind: 'file',
+        name,
+        getFile: async () => file,
+    } as unknown as FileSystemFileHandle;
+}
+
+function stubDirectoryHandle(
+    name: string,
+    entries: Iterable<FileSystemFileHandle | FileSystemDirectoryHandle>
+): FileSystemDirectoryHandle {
+    return {
+        kind: 'directory',
+        name,
+        values: async function* () {
+            yield* entries;
+        },
+    } as unknown as FileSystemDirectoryHandle;
+}
+
+function stubFileEntry(file: File): FileSystemFileEntry {
+    return {
+        isFile: true,
+        isDirectory: false,
+        name: file.name,
+        file: (resolve: (file: File) => void) => resolve(file),
+    } as unknown as FileSystemFileEntry;
+}
+
+/** Entries arrive in batches, mirroring readEntries' ~100-entry pages. */
+function stubDirectoryEntry(
+    name: string,
+    batches: FileSystemEntry[][]
+): FileSystemDirectoryEntry {
+    let next = 0;
+    return {
+        isFile: false,
+        isDirectory: true,
+        name,
+        createReader: () => ({
+            readEntries: (resolve: (entries: FileSystemEntry[]) => void) =>
+                resolve(batches[next++] ?? []),
+        }),
+    } as unknown as FileSystemDirectoryEntry;
+}
+
+function stubDataTransfer(
+    items: Record<string, unknown>[],
+    files: File[] = []
+): DataTransfer {
+    return { files, items } as unknown as DataTransfer;
+}
+
 afterEach(() => {
     delete (window as { showOpenFilePicker?: unknown }).showOpenFilePicker;
+    delete (window as { showDirectoryPicker?: unknown }).showDirectoryPicker;
     vi.restoreAllMocks();
 });
 
@@ -109,8 +168,11 @@ describe('reacquireMatchingFile', () => {
 });
 
 describe('pickFilesWithHandles', () => {
-    it('returns [] when unsupported', async () => {
-        expect(await pickFilesWithHandles()).toEqual([]);
+    it('returns an empty batch when unsupported', async () => {
+        expect(await pickFilesWithHandles()).toEqual({
+            files: [],
+            truncated: false,
+        });
     });
 
     it('pairs each chosen file with its handle', async () => {
@@ -118,19 +180,22 @@ describe('pickFilesWithHandles', () => {
         (window as { showOpenFilePicker?: unknown }).showOpenFilePicker = vi.fn(
             async () => [handle]
         );
-        const picked = await pickFilesWithHandles();
-        expect(picked).toHaveLength(1);
-        expect(picked[0].handle).toBe(handle);
-        expect(picked[0].file.name).toBe(IDENTITY.name);
+        const { files } = await pickFilesWithHandles();
+        expect(files).toHaveLength(1);
+        expect(files[0].handle).toBe(handle);
+        expect(files[0].file.name).toBe(IDENTITY.name);
     });
 
-    it('returns [] when the user dismisses the dialog (AbortError)', async () => {
+    it('returns an empty batch when the user dismisses the dialog (AbortError)', async () => {
         (window as { showOpenFilePicker?: unknown }).showOpenFilePicker = vi.fn(
             async () => {
                 throw new DOMException('cancelled', 'AbortError');
             }
         );
-        expect(await pickFilesWithHandles()).toEqual([]);
+        expect(await pickFilesWithHandles()).toEqual({
+            files: [],
+            truncated: false,
+        });
     });
 });
 
@@ -141,13 +206,10 @@ describe('pickedFilesFromDataTransfer', () => {
             IDENTITY.size,
             IDENTITY.lastModified
         );
-        const dataTransfer = {
-            files: [file],
-            items: [],
-        } as unknown as DataTransfer;
+        const dataTransfer = stubDataTransfer([], [file]);
 
         const picked = await pickedFilesFromDataTransfer(dataTransfer);
-        expect(picked).toEqual([{ file }]);
+        expect(picked).toEqual({ files: [{ file }], truncated: false });
     });
 
     it('captures a handle per dropped item when supported', async () => {
@@ -159,18 +221,218 @@ describe('pickedFilesFromDataTransfer', () => {
             IDENTITY.lastModified
         );
         const handle = stubHandle();
-        const dataTransfer = {
-            files: [file],
-            items: [
+        const dataTransfer = stubDataTransfer(
+            [
                 {
                     kind: 'file',
                     getAsFile: () => file,
                     getAsFileSystemHandle: async () => handle,
                 },
             ],
-        } as unknown as DataTransfer;
+            [file]
+        );
 
         const picked = await pickedFilesFromDataTransfer(dataTransfer);
-        expect(picked).toEqual([{ file, handle }]);
+        expect(picked).toEqual({
+            files: [{ file, handle }],
+            truncated: false,
+        });
+    });
+
+    it('walks a dropped directory recursively, skipping hidden entries', async () => {
+        (window as { showOpenFilePicker?: unknown }).showOpenFilePicker =
+            () => {};
+        const imgA = makeFile('IMG_1.NEF', 1, 1);
+        const imgB = makeFile('IMG_2.NEF', 2, 2);
+        const litter = makeFile('.DS_Store', 3, 3);
+        const handleA = fileHandleOf(imgA);
+        const handleB = fileHandleOf(imgB);
+        const directory = stubDirectoryHandle('shoot', [
+            fileHandleOf(litter),
+            handleA,
+            stubDirectoryHandle('day2', [handleB]),
+            stubDirectoryHandle('.cache', [fileHandleOf(litter, 'tmp.bin')]),
+        ]);
+        const dataTransfer = stubDataTransfer([
+            {
+                kind: 'file',
+                getAsFile: () => null,
+                getAsFileSystemHandle: async () => directory,
+            },
+        ]);
+
+        const picked = await pickedFilesFromDataTransfer(dataTransfer);
+        expect(picked).toEqual({
+            files: [
+                { file: imgA, handle: handleA },
+                { file: imgB, handle: handleB },
+            ],
+            truncated: false,
+        });
+    });
+
+    it('flags a directory that walks to nothing, instead of silence', async () => {
+        (window as { showOpenFilePicker?: unknown }).showOpenFilePicker =
+            () => {};
+        const directory = stubDirectoryHandle('empty-shoot', [
+            fileHandleOf(makeFile('.DS_Store', 1, 1)),
+        ]);
+        const dataTransfer = stubDataTransfer([
+            {
+                kind: 'file',
+                getAsFile: () => null,
+                getAsFileSystemHandle: async () => directory,
+            },
+        ]);
+
+        expect(await pickedFilesFromDataTransfer(dataTransfer)).toEqual({
+            files: [],
+            truncated: false,
+            emptySelection: true,
+        });
+    });
+
+    it('stops the walk at the cap and reports truncation', async () => {
+        (window as { showOpenFilePicker?: unknown }).showOpenFilePicker =
+            () => {};
+        const shared = makeFile('frame.NEF', 1, 1);
+        const directory = stubDirectoryHandle('shoot', {
+            *[Symbol.iterator]() {
+                for (let i = 0; i < MAX_FILES_PER_DROP + 2; i++) {
+                    yield fileHandleOf(shared, `frame-${i}.NEF`);
+                }
+            },
+        });
+        const dataTransfer = stubDataTransfer([
+            {
+                kind: 'file',
+                getAsFile: () => null,
+                getAsFileSystemHandle: async () => directory,
+            },
+        ]);
+
+        const picked = await pickedFilesFromDataTransfer(dataTransfer);
+        expect(picked.files).toHaveLength(MAX_FILES_PER_DROP);
+        expect(picked.truncated).toBe(true);
+    });
+
+    it('walks directories via webkitGetAsEntry when handles are unsupported', async () => {
+        const loose = makeFile('loose.txt', 1, 1);
+        const imgA = makeFile('IMG_1.NEF', 2, 2);
+        const imgB = makeFile('IMG_2.NEF', 3, 3);
+        const directory = stubDirectoryEntry('shoot', [
+            // Two batches, so the readEntries-until-empty loop is exercised.
+            [stubFileEntry(imgA), stubFileEntry(makeFile('.DS_Store', 4, 4))],
+            [stubDirectoryEntry('day2', [[stubFileEntry(imgB)]])],
+        ]);
+        const dataTransfer = stubDataTransfer(
+            [
+                {
+                    kind: 'file',
+                    getAsFile: () => loose,
+                    webkitGetAsEntry: () => stubFileEntry(loose),
+                },
+                {
+                    kind: 'file',
+                    getAsFile: () => null,
+                    webkitGetAsEntry: () => directory,
+                },
+            ],
+            [loose]
+        );
+
+        const picked = await pickedFilesFromDataTransfer(dataTransfer);
+        expect(picked).toEqual({
+            files: [{ file: loose }, { file: imgA }, { file: imgB }],
+            truncated: false,
+        });
+    });
+});
+
+describe('pickFolderWithHandles', () => {
+    it('returns an empty batch when unsupported', async () => {
+        expect(await pickFolderWithHandles()).toEqual({
+            files: [],
+            truncated: false,
+        });
+    });
+
+    it('walks the picked folder', async () => {
+        const img = makeFile('IMG_1.NEF', 1, 1);
+        const handle = fileHandleOf(img);
+        (window as { showDirectoryPicker?: unknown }).showDirectoryPicker =
+            vi.fn(async () => stubDirectoryHandle('shoot', [handle]));
+
+        expect(await pickFolderWithHandles()).toEqual({
+            files: [{ file: img, handle }],
+            truncated: false,
+        });
+    });
+
+    it('flags an empty pick, but not a dismissed dialog', async () => {
+        (window as { showDirectoryPicker?: unknown }).showDirectoryPicker =
+            vi.fn(async () => stubDirectoryHandle('empty', []));
+        expect(await pickFolderWithHandles()).toEqual({
+            files: [],
+            truncated: false,
+            emptySelection: true,
+        });
+
+        (window as { showDirectoryPicker?: unknown }).showDirectoryPicker =
+            vi.fn(async () => {
+                throw new DOMException('cancelled', 'AbortError');
+            });
+        expect(await pickFolderWithHandles()).toEqual({
+            files: [],
+            truncated: false,
+        });
+    });
+});
+
+describe('pickedFilesFromDirectoryInput', () => {
+    function makeTreeFile(name: string, relativePath: string): File {
+        const file = makeFile(name, 1, 1);
+        Object.defineProperty(file, 'webkitRelativePath', {
+            value: relativePath,
+        });
+        return file;
+    }
+
+    it('maps files, filtering hidden entries below the chosen root', () => {
+        const imgA = makeTreeFile('IMG_1.NEF', 'shoot/IMG_1.NEF');
+        const imgB = makeTreeFile('IMG_2.NEF', 'shoot/day2/IMG_2.NEF');
+        const fileList = [
+            imgA,
+            makeTreeFile('.DS_Store', 'shoot/.DS_Store'),
+            imgB,
+            makeTreeFile('tmp.bin', 'shoot/.cache/tmp.bin'),
+        ] as unknown as FileList;
+
+        expect(pickedFilesFromDirectoryInput(fileList)).toEqual({
+            files: [{ file: imgA }, { file: imgB }],
+            truncated: false,
+        });
+    });
+
+    it('keeps files when the chosen root itself is hidden', () => {
+        const img = makeTreeFile('IMG_1.NEF', '.backup/IMG_1.NEF');
+        const fileList = [img] as unknown as FileList;
+
+        expect(pickedFilesFromDirectoryInput(fileList)).toEqual({
+            files: [{ file: img }],
+            truncated: false,
+        });
+    });
+
+    it('flags a folder whose files were all filtered out', () => {
+        const fileList = [
+            makeTreeFile('.DS_Store', 'shoot/.DS_Store'),
+        ] as unknown as FileList;
+
+        expect(pickedFilesFromDirectoryInput(fileList)).toEqual({
+            files: [],
+            truncated: false,
+            emptySelection: true,
+        });
     });
 });

--- a/apps/web/lib/upload/fileSystemAccess.ts
+++ b/apps/web/lib/upload/fileSystemAccess.ts
@@ -1,5 +1,6 @@
 import { isFileMatch, toFileIdentity, type FileIdentity } from './parts';
 import { isAbortError } from './errors';
+import { MAX_FILES_PER_DROP } from './limits';
 
 /**
  * Thin, feature-detected wrapper over the File System Access API. On Chromium a
@@ -16,63 +17,261 @@ export interface PickedFile {
     handle?: FileSystemFileHandle;
 }
 
+/**
+ * The result of one ingest gesture (a drop, a picker, a fallback input).
+ * `truncated` means the walk stopped at `MAX_FILES_PER_DROP` with files left
+ * behind; `emptySelection` means the gesture offered real file entries but
+ * none survived (an empty folder, or hidden litter only) — distinct from a
+ * dismissed dialog or a text drag, which stay silent. Callers surface both
+ * instead of silently shortchanging the selection (#388).
+ */
+export interface PickedFileBatch {
+    files: PickedFile[];
+    truncated: boolean;
+    emptySelection?: boolean;
+}
+
 /** True when the browser exposes the picker + persistable handles (Chromium). */
 export function isFileSystemAccessSupported(): boolean {
     return typeof window !== 'undefined' && 'showOpenFilePicker' in window;
 }
 
+/** True when the browser can open a native folder picker (Chromium). */
+export function isDirectoryPickerSupported(): boolean {
+    return typeof window !== 'undefined' && 'showDirectoryPicker' in window;
+}
+
+/**
+ * Dotfiles are skipped during directory walks: a photographer's shoot folder
+ * reliably carries `.DS_Store`-style litter that would pad the queue and the
+ * quota. Only walked *children* are filtered — an explicitly dropped or picked
+ * entry is taken at the user's word, hidden or not.
+ */
+function isHiddenEntryName(name: string): boolean {
+    return name.startsWith('.');
+}
+
 /**
  * Open the native picker and pair each chosen file with its persistable handle.
- * Returns `[]` when unsupported or when the user dismisses the dialog (the API
- * rejects with an AbortError, which isn't a real failure).
+ * Returns an empty batch when unsupported or when the user dismisses the
+ * dialog (the API rejects with an AbortError, which isn't a real failure).
  */
-export async function pickFilesWithHandles(): Promise<PickedFile[]> {
-    if (!isFileSystemAccessSupported()) return [];
+export async function pickFilesWithHandles(): Promise<PickedFileBatch> {
+    if (!isFileSystemAccessSupported()) return { files: [], truncated: false };
     let handles: FileSystemFileHandle[];
     try {
         handles = await window.showOpenFilePicker({ multiple: true });
     } catch (error) {
-        if (isAbortError(error)) return [];
+        if (isAbortError(error)) return { files: [], truncated: false };
         throw error;
     }
-    return Promise.all(
+    const files = await Promise.all(
         handles.map(async (handle) => ({
             file: await handle.getFile(),
             handle,
         }))
     );
+    return { files, truncated: false };
 }
 
 /**
- * Read a drop's files, capturing a `FileSystemFileHandle` per item on Chromium so
- * a dragged file is zero-touch resumable just like a picked one. The synchronous
- * `getAsFile()` / `getAsFileSystemHandle()` reads happen before the first await,
- * since the DataTransferItems are only live during the drop event.
+ * Append one file to a walk's batch, dropping it (and marking the batch
+ * truncated) once the cap is reached. Truncation is only ever set here, at the
+ * moment a real file is lost — never for leftover litter or empty directories.
+ */
+function pushPickedFile(sink: PickedFileBatch, picked: PickedFile): void {
+    if (sink.files.length >= MAX_FILES_PER_DROP) {
+        sink.truncated = true;
+        return;
+    }
+    sink.files.push(picked);
+}
+
+/** Flag a batch whose gesture offered file entries but yielded nothing. */
+function flagEmptySelection(
+    sink: PickedFileBatch,
+    sawEntries: boolean
+): PickedFileBatch {
+    if (sawEntries && sink.files.length === 0) sink.emptySelection = true;
+    return sink;
+}
+
+/**
+ * Depth-first walk of a directory handle, collecting every visible file with
+ * its handle so walked files resume exactly like picked ones. An entry that
+ * can't be read (moved or locked mid-walk) is skipped rather than sinking the
+ * whole folder.
+ */
+async function walkDirectoryHandle(
+    directory: FileSystemDirectoryHandle,
+    sink: PickedFileBatch
+): Promise<void> {
+    for await (const entry of directory.values()) {
+        if (sink.truncated) return;
+        if (isHiddenEntryName(entry.name)) continue;
+        if (entry.kind === 'directory') {
+            await walkDirectoryHandle(entry, sink);
+            continue;
+        }
+        try {
+            pushPickedFile(sink, {
+                file: await entry.getFile(),
+                handle: entry,
+            });
+        } catch {
+            // Skip the unreadable entry.
+        }
+    }
+}
+
+/**
+ * Same walk over the legacy `webkitGetAsEntry` tree (Firefox/Safari drops) —
+ * no handles there, so these files take the manual re-add path on resume.
+ * `readEntries` hands out at most ~100 entries per call and must be re-called
+ * until it returns an empty batch.
+ */
+async function walkDirectoryEntry(
+    directory: FileSystemDirectoryEntry,
+    sink: PickedFileBatch
+): Promise<void> {
+    const reader = directory.createReader();
+    for (;;) {
+        const batch = await new Promise<FileSystemEntry[]>((resolve, reject) =>
+            reader.readEntries(resolve, reject)
+        ).catch(() => []);
+        if (batch.length === 0) return;
+        for (const entry of batch) {
+            if (sink.truncated) return;
+            if (isHiddenEntryName(entry.name)) continue;
+            if (entry.isDirectory) {
+                await walkDirectoryEntry(
+                    entry as FileSystemDirectoryEntry,
+                    sink
+                );
+                continue;
+            }
+            if (!entry.isFile) continue;
+            try {
+                const file = await new Promise<File>((resolve, reject) =>
+                    (entry as FileSystemFileEntry).file(resolve, reject)
+                );
+                pushPickedFile(sink, { file });
+            } catch {
+                // Skip the unreadable entry.
+            }
+        }
+    }
+}
+
+/**
+ * Read a drop's files, walking any dropped directory and capturing a
+ * `FileSystemFileHandle` per file on Chromium so a dragged file is zero-touch
+ * resumable just like a picked one. The synchronous `getAsFile()` /
+ * `getAsFileSystemHandle()` / `webkitGetAsEntry()` reads happen before the
+ * first await, since the DataTransferItems are only live during the drop event
+ * (the handles and entries they yield stay usable after it).
  */
 export async function pickedFilesFromDataTransfer(
     dataTransfer: DataTransfer
-): Promise<PickedFile[]> {
-    if (!isFileSystemAccessSupported()) {
-        return Array.from(dataTransfer.files).map((file) => ({ file }));
+): Promise<PickedFileBatch> {
+    const sink: PickedFileBatch = { files: [], truncated: false };
+    if (isFileSystemAccessSupported()) {
+        const captured = Array.from(dataTransfer.items)
+            .filter((item) => item.kind === 'file')
+            .map((item) => ({
+                file: item.getAsFile(),
+                handlePromise: item.getAsFileSystemHandle(),
+            }));
+        for (const { file, handlePromise } of captured) {
+            if (sink.truncated) break;
+            const handle = await handlePromise.catch(() => null);
+            if (handle && handle.kind === 'directory') {
+                await walkDirectoryHandle(
+                    handle as FileSystemDirectoryHandle,
+                    sink
+                );
+            } else if (file) {
+                pushPickedFile(
+                    sink,
+                    handle && handle.kind === 'file'
+                        ? { file, handle: handle as FileSystemFileHandle }
+                        : { file }
+                );
+            }
+        }
+        return flagEmptySelection(sink, captured.length > 0);
     }
+    // No File System Access API: `webkitGetAsEntry` is the only way to see
+    // into a dropped directory on Firefox/Safari.
     const captured = Array.from(dataTransfer.items)
         .filter((item) => item.kind === 'file')
         .map((item) => ({
             file: item.getAsFile(),
-            handlePromise: item.getAsFileSystemHandle(),
+            entry:
+                typeof item.webkitGetAsEntry === 'function'
+                    ? item.webkitGetAsEntry()
+                    : null,
         }));
-    const picked = await Promise.all(
-        captured.map(
-            async ({ file, handlePromise }): Promise<PickedFile | null> => {
-                if (!file) return null;
-                const handle = await handlePromise.catch(() => null);
-                return handle && handle.kind === 'file'
-                    ? { file, handle: handle as FileSystemFileHandle }
-                    : { file };
-            }
+    if (!captured.some(({ entry }) => entry?.isDirectory)) {
+        // Plain files only — keep the simple path, which also covers synthetic
+        // drops whose `items` don't back the entry API.
+        sink.files = Array.from(dataTransfer.files).map((file) => ({ file }));
+        return flagEmptySelection(sink, captured.length > 0);
+    }
+    for (const { file, entry } of captured) {
+        if (sink.truncated) break;
+        if (entry?.isDirectory) {
+            await walkDirectoryEntry(entry as FileSystemDirectoryEntry, sink);
+        } else if (file) {
+            pushPickedFile(sink, { file });
+        }
+    }
+    return flagEmptySelection(sink, true);
+}
+
+/**
+ * Open the native folder picker and walk the chosen directory. Returns an
+ * empty batch when unsupported (callers fall back to a `webkitdirectory`
+ * input) or when the user dismisses the dialog.
+ */
+export async function pickFolderWithHandles(): Promise<PickedFileBatch> {
+    const sink: PickedFileBatch = { files: [], truncated: false };
+    if (!isDirectoryPickerSupported()) return sink;
+    let directory: FileSystemDirectoryHandle;
+    try {
+        directory = await window.showDirectoryPicker();
+    } catch (error) {
+        if (isAbortError(error)) return sink;
+        throw error;
+    }
+    await walkDirectoryHandle(directory, sink);
+    // The user did choose a folder here, so an empty yield deserves feedback.
+    return flagEmptySelection(sink, true);
+}
+
+/**
+ * Map a `webkitdirectory` input's selection to picked files (the input API
+ * predates handles, so none are captured). Hidden entries are filtered the
+ * same way the walks do — by path segments *below* the chosen root, so a
+ * deliberately picked hidden folder isn't emptied out.
+ */
+export function pickedFilesFromDirectoryInput(
+    fileList: FileList
+): PickedFileBatch {
+    const files = Array.from(fileList)
+        .filter(
+            (file) =>
+                !file.webkitRelativePath
+                    .split('/')
+                    .slice(1)
+                    .some(isHiddenEntryName)
         )
-    );
-    return picked.filter((p): p is PickedFile => p !== null);
+        .map((file) => ({ file }));
+    const sink: PickedFileBatch =
+        files.length > MAX_FILES_PER_DROP
+            ? { files: files.slice(0, MAX_FILES_PER_DROP), truncated: true }
+            : { files, truncated: false };
+    return flagEmptySelection(sink, true);
 }
 
 /**

--- a/apps/web/lib/upload/limits.ts
+++ b/apps/web/lib/upload/limits.ts
@@ -39,3 +39,12 @@ export const S3_CONNECTION_BUDGET = 6;
  * it; it exists for videographer-scale files.
  */
 export const MAX_IN_FLIGHT_BYTES = 32 * 1024 ** 3; // 32 GiB
+
+/**
+ * Ceiling on files one gesture (a drop or a folder pick) may add to the queue.
+ * The queue itself survives far more (#390) — this bounds the directory walk,
+ * so dropping a home folder by accident stops early instead of grinding
+ * through the whole disk. Sized for the ICP's worst case: a multi-day wedding
+ * shoot is a few thousand frames, not five thousand.
+ */
+export const MAX_FILES_PER_DROP = 5000;

--- a/apps/web/lib/upload/uploadStore.test.ts
+++ b/apps/web/lib/upload/uploadStore.test.ts
@@ -6,7 +6,6 @@ import {
     getUpload,
     listUploads,
     deleteUpload,
-    findUploadByIdentity,
     addCompletedPart,
     resetUploadStoreForTests,
     type ResumableUpload,
@@ -79,49 +78,6 @@ describe('uploadStore', () => {
         await deleteUpload('file-1');
 
         expect(await getUpload('file-1')).toBeUndefined();
-    });
-
-    describe('findUploadByIdentity', () => {
-        it('matches on name + size + lastModified', async () => {
-            await putUpload(
-                makeRecord({
-                    fileId: 'a',
-                    name: 'a.zip',
-                    size: 1,
-                    lastModified: 1,
-                })
-            );
-            await putUpload(
-                makeRecord({
-                    fileId: 'b',
-                    name: 'b.zip',
-                    size: 2,
-                    lastModified: 2,
-                })
-            );
-
-            const found = await findUploadByIdentity({
-                name: 'b.zip',
-                size: 2,
-                lastModified: 2,
-            });
-
-            expect(found?.fileId).toBe('b');
-        });
-
-        it('returns undefined when size differs (same name)', async () => {
-            await putUpload(
-                makeRecord({ name: 'a.zip', size: 1, lastModified: 1 })
-            );
-
-            const found = await findUploadByIdentity({
-                name: 'a.zip',
-                size: 999,
-                lastModified: 1,
-            });
-
-            expect(found).toBeUndefined();
-        });
     });
 
     describe('addCompletedPart', () => {

--- a/apps/web/lib/upload/uploadStore.ts
+++ b/apps/web/lib/upload/uploadStore.ts
@@ -89,24 +89,6 @@ export async function deleteUpload(fileId: string): Promise<void> {
 }
 
 /**
- * Find a persisted upload matching a re-added file's identity. In-progress
- * uploads are few, so a full scan is fine and avoids a composite-key index.
- */
-export async function findUploadByIdentity(identity: {
-    name: string;
-    size: number;
-    lastModified: number;
-}): Promise<ResumableUpload | undefined> {
-    const all = await listUploads();
-    return all.find(
-        (u) =>
-            u.name === identity.name &&
-            u.size === identity.size &&
-            u.lastModified === identity.lastModified
-    );
-}
-
-/**
  * Record a completed part. Read-modify-write inside a single readwrite
  * transaction; IndexedDB serializes overlapping-scope transactions, so the
  * concurrent chunk uploads can't lose each other's writes. Dedupes by part

--- a/apps/web/types/file-system-access.d.ts
+++ b/apps/web/types/file-system-access.d.ts
@@ -20,10 +20,23 @@ interface OpenFilePickerOptions {
     excludeAcceptAllOption?: boolean;
 }
 
+interface DirectoryPickerOptions {
+    mode?: 'read' | 'readwrite';
+}
+
 interface Window {
     showOpenFilePicker(
         options?: OpenFilePickerOptions
     ): Promise<FileSystemFileHandle[]>;
+    showDirectoryPicker(
+        options?: DirectoryPickerOptions
+    ): Promise<FileSystemDirectoryHandle>;
+}
+
+interface FileSystemDirectoryHandle {
+    values(): AsyncIterableIterator<
+        FileSystemFileHandle | FileSystemDirectoryHandle
+    >;
 }
 
 interface DataTransferItem {


### PR DESCRIPTION
## Summary

A shoot is a folder, but neither ingest path accepted one: the drop reader kept only file-kind items (a dropped directory vanished silently) and the picker could only select files. Both paths now walk directories — on Chromium via `FileSystemDirectoryHandle` recursion that keeps a per-file handle, so walked files get the same zero-touch resume as picked ones; on Firefox/Safari via `webkitGetAsEntry` recursion (no handles there, so those files take the existing manual re-add path). The picker side gains a "Browse folder" button (`showDirectoryPicker` on Chromium, a hidden `webkitdirectory` input elsewhere).

Files are flattened into the queue: the data model has no path/folder concept, so "preserving paths" today would mean stuffing `dir/sub/name.NEF` into `files.name` and leaking it into S3 key shapes with no UI to show for it. Real folder hierarchy (and naming the batch after the dropped folder) is left to a follow-up issue.

Guardrails: walks stop at `MAX_FILES_PER_DROP` (5,000 — sized above a multi-day wedding shoot) with a toast when files were actually left behind; hidden entries (`.DS_Store` litter) are skipped inside walked folders but never for an explicitly chosen root; a folder that yields nothing toasts "No files found" instead of doing nothing — the silence was the bug. Uploads still don't auto-start, so the queue itself is the confirmation for accidental big drops.

Closes #388

## Changes

- `lib/upload/fileSystemAccess.ts` — directory walks for both drop branches, `pickFolderWithHandles`, `pickedFilesFromDirectoryInput`; all gestures now return a `PickedFileBatch` (`files`, `truncated`, `emptySelection`) so feedback can't be skipped per-path
- `components/dashboard/upload-zone.tsx` — "Browse folder" button + hidden `webkitdirectory` fallback input, folder-aware copy, one `addPickedBatch` seam that owns the cap/empty toasts
- `components/dashboard/useUpload.ts` — `addFiles` matches resumable records via one `listUploads()` instead of a full store scan per file (folder drops make N large); `uploadStore.findUploadByIdentity` deleted with its tests (no callers left)
- `lib/upload/limits.ts` — `MAX_FILES_PER_DROP`
- `types/file-system-access.d.ts` — `showDirectoryPicker`, `FileSystemDirectoryHandle.values()`
- Unit tests for both walkers, cap truncation, hidden-entry filtering, empty-selection flagging, folder picker abort
- E2E: folder-selection flows test on a real on-disk tree (`writeFolderTree` helper), `upload-add-folder-queue` manifest entry; existing specs moved from `input[type="file"]` to `data-testid` selectors since a second file input now exists

Self-review findings deliberately skipped (all low): unifying the two walkers behind an iterator adapter (indirection over two genuinely different legacy APIs), sharing the cap logic between the walk and the `webkitdirectory` slice (three lines, different shapes), a `makeTempDir` extraction in e2e helpers, and hoisting repeated spec selector literals into shared constants (pre-existing pattern).

## Test Plan

- [x] `pnpm check` green (lint + build + unit; includes the new walker/picker/input tests)
- [x] `pnpm -F web test:e2e:smoke` 47/47
- [x] `pnpm -F web test:e2e:flows` 35/35, including the new folder test: Playwright uploads a real directory tree through the `webkitdirectory` input — nested file queued, `.DS_Store` filtered, correct queue count
- [x] `pnpm -F web e2e:coverage --check` 100% pages and use-cases
- [ ] Real OS-level folder drag-drop and the native `showDirectoryPicker` dialog — not automatable (Playwright can't synthesize a directory `DataTransfer` or drive native dialogs); the walk logic behind both is unit-tested with handle/entry stubs