### PR TITLE
feat: name the upload batch after the uploaded folder (#395)

### DIFF
--- a/apps/web/components/dashboard/upload-zone.tsx
+++ b/apps/web/components/dashboard/upload-zone.tsx
@@ -74,7 +74,12 @@ export function UploadZone() {
     // no path can regress into the silent ignore #388 was about: a capped walk
     // says what it kept, an empty folder says it had nothing.
     const addPickedBatch = useCallback(
-        ({ files: picked, truncated, emptySelection }: PickedFileBatch) => {
+        ({
+            files: picked,
+            truncated,
+            emptySelection,
+            folderName,
+        }: PickedFileBatch) => {
             if (truncated) {
                 toast.info(
                     `Large selection — only the first ${MAX_FILES_PER_DROP.toLocaleString()} files were added.`
@@ -85,7 +90,7 @@ export function UploadZone() {
                     toast.info('No files found in that folder.');
                 return;
             }
-            void addFiles(picked);
+            void addFiles(picked, folderName);
         },
         [addFiles]
     );

--- a/apps/web/components/dashboard/useUpload.ts
+++ b/apps/web/components/dashboard/useUpload.ts
@@ -39,7 +39,11 @@ import {
     partsProgress,
     toFileIdentity,
 } from '@/lib/upload/parts';
-import { patchRowById } from '@/lib/upload/rows';
+import {
+    patchRowById,
+    resolveUnanimousFolderName,
+    type FolderOrigin,
+} from '@/lib/upload/rows';
 import {
     isFileSystemAccessSupported,
     reacquireMatchingFile,
@@ -108,6 +112,9 @@ interface InternalUploadFile extends UploadFile {
     // Session batch the file belongs to — set once per Upload click and kept
     // across failures so a retry/resume rejoins the same batch.
     batchId?: string;
+    // Folder gesture that queued this row, when it came from one. Consulted
+    // only for rows still awaiting a batch — it names the batch they land in.
+    folderOrigin?: FolderOrigin;
     uploadId?: string;
     chunkSize?: number;
     totalParts?: number;
@@ -190,6 +197,8 @@ export function useUpload() {
     const [isUploading, setIsUploading] = useState(false);
     const filesRef = useRef(files);
     filesRef.current = files;
+    // Monotonic per-mount counter stamped on rows by `addFiles`; see FolderOrigin.
+    const folderGestureRef = useRef(0);
 
     const invalidateFileList = useInvalidateFileList();
 
@@ -746,10 +755,14 @@ export function useUpload() {
         // falls back to the server's auto-created single-file batch.
         let batchId: string | undefined;
         // Rows that already have a batch (retries, re-added resumables) keep
-        // it, so only mint a session batch when some file still needs one.
-        if (pending.some((f) => !f.batchId)) {
+        // it, so only mint a session batch when some file still needs one —
+        // and only those rows decide what the new batch is named after.
+        const rowsNeedingBatch = pending.filter((f) => !f.batchId);
+        if (rowsNeedingBatch.length > 0) {
             try {
-                ({ batchId } = await createBatchMutation.mutateAsync());
+                ({ batchId } = await createBatchMutation.mutateAsync({
+                    name: resolveUnanimousFolderName(rowsNeedingBatch),
+                }));
             } catch {
                 batchId = undefined;
             }
@@ -848,89 +861,100 @@ export function useUpload() {
         };
     }, [drive]);
 
-    const addFiles = useCallback(async (picked: PickedFile[]) => {
-        if (picked.length === 0) return;
+    const addFiles = useCallback(
+        async (picked: PickedFile[], folderName?: string) => {
+            if (picked.length === 0) return;
 
-        // Match each file against a persisted interrupted upload so a re-add
-        // resumes from where S3 left off instead of starting over. One store
-        // read for the whole batch (folder drops make it thousands of files),
-        // and one identity per file rather than one per comparison.
-        const records = await listUploads();
-        const matches = picked.map(({ file }) => {
-            const identity = toFileIdentity(file);
-            return records.find((record) => isFileMatch(record, identity));
-        });
+            // One id per call, so re-dropping the same folder counts as a
+            // second gesture rather than merging into the first.
+            const folderOrigin = folderName
+                ? { gestureId: ++folderGestureRef.current, name: folderName }
+                : undefined;
 
-        setFiles((prev) => {
-            // Reattach re-added files to their resumable rows (immutably), then
-            // append rows for everything that didn't match an existing row.
-            const reattach = new Map<string, PickedFile>();
-            const appended: InternalUploadFile[] = [];
+            // Match each file against a persisted interrupted upload so a re-add
+            // resumes from where S3 left off instead of starting over. One store
+            // read for the whole batch (folder drops make it thousands of files),
+            // and one identity per file rather than one per comparison.
+            const records = await listUploads();
+            const matches = picked.map(({ file }) => {
+                const identity = toFileIdentity(file);
+                return records.find((record) => isFileMatch(record, identity));
+            });
 
-            picked.forEach(({ file, handle }, i) => {
-                const match = matches[i];
-                const existing =
-                    match && isResumable(match)
-                        ? prev.find((f) => f.fileId === match.fileId)
-                        : undefined;
+            setFiles((prev) => {
+                // Reattach re-added files to their resumable rows (immutably), then
+                // append rows for everything that didn't match an existing row.
+                const reattach = new Map<string, PickedFile>();
+                const appended: InternalUploadFile[] = [];
 
-                if (match && isResumable(match) && existing) {
-                    // Re-add of an interrupted upload: queue it as resumable;
-                    // clicking Upload continues from the last completed part.
-                    reattach.set(existing.id, { file, handle });
-                    return;
-                }
-                if (match && isResumable(match)) {
+                picked.forEach(({ file, handle }, i) => {
+                    const match = matches[i];
+                    const existing =
+                        match && isResumable(match)
+                            ? prev.find((f) => f.fileId === match.fileId)
+                            : undefined;
+
+                    if (match && isResumable(match) && existing) {
+                        // Re-add of an interrupted upload: queue it as resumable;
+                        // clicking Upload continues from the last completed part.
+                        reattach.set(existing.id, { file, handle });
+                        return;
+                    }
+                    if (match && isResumable(match)) {
+                        appended.push({
+                            id: match.fileId,
+                            name: file.name,
+                            size: file.size,
+                            progress: partsProgress(
+                                match.completedParts.length,
+                                match.totalParts
+                            ),
+                            status: 'pending',
+                            file,
+                            fileHandle: handle,
+                            fileId: match.fileId,
+                            batchId: match.batchId,
+                            uploadId: match.uploadId,
+                            chunkSize: match.chunkSize,
+                            totalParts: match.totalParts,
+                            completedParts: match.completedParts,
+                            folderOrigin,
+                        });
+                        return;
+                    }
                     appended.push({
-                        id: match.fileId,
+                        id: randomId(),
                         name: file.name,
                         size: file.size,
-                        progress: partsProgress(
-                            match.completedParts.length,
-                            match.totalParts
-                        ),
+                        progress: 0,
                         status: 'pending',
                         file,
                         fileHandle: handle,
-                        fileId: match.fileId,
-                        batchId: match.batchId,
-                        uploadId: match.uploadId,
-                        chunkSize: match.chunkSize,
-                        totalParts: match.totalParts,
-                        completedParts: match.completedParts,
+                        folderOrigin,
                     });
-                    return;
-                }
-                appended.push({
-                    id: randomId(),
-                    name: file.name,
-                    size: file.size,
-                    progress: 0,
-                    status: 'pending',
-                    file,
-                    fileHandle: handle,
                 });
-            });
 
-            const updated = prev.map((f) => {
-                const reattached = reattach.get(f.id);
-                return reattached
-                    ? {
-                          ...f,
-                          file: reattached.file,
-                          // Keep any handle we already had if the re-add lacked one.
-                          fileHandle: reattached.handle ?? f.fileHandle,
-                          status: 'pending' as const,
-                          progress: partsProgress(
-                              f.completedParts?.length ?? 0,
-                              f.totalParts ?? 0
-                          ),
-                      }
-                    : f;
+                const updated = prev.map((f) => {
+                    const reattached = reattach.get(f.id);
+                    return reattached
+                        ? {
+                              ...f,
+                              file: reattached.file,
+                              // Keep any handle we already had if the re-add lacked one.
+                              fileHandle: reattached.handle ?? f.fileHandle,
+                              status: 'pending' as const,
+                              progress: partsProgress(
+                                  f.completedParts?.length ?? 0,
+                                  f.totalParts ?? 0
+                              ),
+                          }
+                        : f;
+                });
+                return [...updated, ...appended];
             });
-            return [...updated, ...appended];
-        });
-    }, []);
+        },
+        []
+    );
 
     // Release whatever the server already minted for a row we're dropping: the
     // S3 multipart session when there is one (plus its persisted state, so a

--- a/apps/web/e2e/coverage/manifest.ts
+++ b/apps/web/e2e/coverage/manifest.ts
@@ -353,6 +353,18 @@ export const USE_CASES: UseCaseEntry[] = [
         routes: ['/dashboard/upload'],
     },
     {
+        id: 'upload-folder-names-batch',
+        title: 'A whole-folder upload names its batch after the folder',
+        area: 'upload',
+        routes: ['/dashboard/upload', '/dashboard/files'],
+    },
+    {
+        id: 'upload-mixed-wave-fallback-name',
+        title: 'A wave mixing a folder with a loose file keeps the fallback batch name',
+        area: 'upload',
+        routes: ['/dashboard/upload'],
+    },
+    {
         id: 'upload-clear-queue',
         title: 'Clear the pending upload queue',
         area: 'upload',

--- a/apps/web/e2e/flows/upload-queue.spec.ts
+++ b/apps/web/e2e/flows/upload-queue.spec.ts
@@ -132,6 +132,92 @@ test(
     }
 );
 
+// The folder is the shoot (#395): a whole-folder upload carries its name to
+// the batch, which is the only label the file browser groups by. Same
+// `webkitdirectory` seam as the queue test above, driven all the way through
+// the upload so the header can be asserted on /dashboard/files.
+test(
+    'a whole-folder upload names its batch after the folder',
+    {
+        tag: [
+            '@page:/dashboard/upload',
+            '@page:/dashboard/files',
+            '@uc:upload-folder-names-batch',
+        ],
+    },
+    async ({ page, db, seedUserId }) => {
+        const folderName = 'shoot-2026-08-18';
+        const tree = await writeFolderTree({
+            name: folderName,
+            files: {
+                'IMG_0001.txt': 'frame one\n',
+                'day2/IMG_0002.txt': 'frame two\n',
+            },
+        });
+        try {
+            await stubS3Puts(page);
+            await page.goto(PAGE_URL);
+            await page.setInputFiles('[data-testid="folder-input"]', tree.dir);
+            await page.getByRole('button', { name: 'Upload 2 files' }).click();
+
+            await expect(
+                page.getByText('Uploaded', { exact: true })
+            ).toHaveCount(2, { timeout: 30_000 });
+
+            const batches = await db.query.uploadBatches.findMany({
+                where: (b, { eq }) => eq(b.userId, seedUserId),
+            });
+            expect(batches).toHaveLength(1);
+            expect(batches[0].name).toBe(folderName);
+
+            // The header already renders `batchName`; this is what the name is
+            // for, so assert the shoot is findable by it rather than by a date.
+            await page.goto('/dashboard/files');
+            await expect(
+                page.getByRole('button', { name: new RegExp(folderName) })
+            ).toBeVisible();
+        } finally {
+            await tree.cleanup();
+        }
+    }
+);
+
+// The naming rule's other half: a wave assembled from more than one gesture
+// isn't about one folder, so it keeps the timestamp label rather than
+// borrowing the name of whichever folder happened to be picked first.
+test(
+    'a wave mixing a folder with a loose file keeps the fallback batch name',
+    {
+        tag: ['@page:/dashboard/upload', '@uc:upload-mixed-wave-fallback-name'],
+    },
+    async ({ page, db, seedUserId }) => {
+        const tree = await writeFolderTree({
+            name: 'shoot-mixed',
+            files: { 'IMG_0001.txt': 'frame one\n' },
+        });
+        try {
+            await stubS3Puts(page);
+            await page.goto(PAGE_URL);
+            await page.setInputFiles('[data-testid="folder-input"]', tree.dir);
+            await page.setInputFiles('[data-testid="file-input"]', [FILE_A]);
+            await expect(page.getByText('Selected Files (2)')).toBeVisible();
+
+            await page.getByRole('button', { name: 'Upload 2 files' }).click();
+            await expect(
+                page.getByText('Uploaded', { exact: true })
+            ).toHaveCount(2, { timeout: 30_000 });
+
+            const batches = await db.query.uploadBatches.findMany({
+                where: (b, { eq }) => eq(b.userId, seedUserId),
+            });
+            expect(batches).toHaveLength(1);
+            expect(batches[0].name).toMatch(/^Upload \d{4}-\d{2}-\d{2} /);
+        } finally {
+            await tree.cleanup();
+        }
+    }
+);
+
 test(
     'clear-all empties the pending queue',
     { tag: ['@page:/dashboard/upload', '@uc:upload-clear-queue'] },
@@ -454,6 +540,7 @@ test(
             where: (b, { eq }) => eq(b.userId, seedUserId),
         });
         expect(batches).toHaveLength(1);
+        expect(batches[0].name).toMatch(/^Upload \d{4}-\d{2}-\d{2} /);
         const rows = await db.query.files.findMany({
             where: (f, { eq }) => eq(f.userId, seedUserId),
         });

--- a/apps/web/lib/upload/fileSystemAccess.test.ts
+++ b/apps/web/lib/upload/fileSystemAccess.test.ts
@@ -268,6 +268,7 @@ describe('pickedFilesFromDataTransfer', () => {
                 { file: imgB, handle: handleB },
             ],
             truncated: false,
+            folderName: 'shoot',
         });
     });
 
@@ -289,7 +290,34 @@ describe('pickedFilesFromDataTransfer', () => {
             files: [],
             truncated: false,
             emptySelection: true,
+            folderName: 'empty-shoot',
         });
+    });
+
+    it('leaves a folder dropped alongside a loose file unnamed', async () => {
+        (window as { showOpenFilePicker?: unknown }).showOpenFilePicker =
+            () => {};
+        const loose = makeFile('loose.txt', 1, 1);
+        const img = makeFile('IMG_1.NEF', 2, 2);
+        const looseHandle = stubHandle();
+        const imgHandle = fileHandleOf(img);
+        const dataTransfer = stubDataTransfer([
+            {
+                kind: 'file',
+                getAsFile: () => loose,
+                getAsFileSystemHandle: async () => looseHandle,
+            },
+            {
+                kind: 'file',
+                getAsFile: () => null,
+                getAsFileSystemHandle: async () =>
+                    stubDirectoryHandle('shoot', [imgHandle]),
+            },
+        ]);
+
+        const picked = await pickedFilesFromDataTransfer(dataTransfer);
+        expect(picked.files).toHaveLength(2);
+        expect(picked.folderName).toBeUndefined();
     });
 
     it('stops the walk at the cap and reports truncation', async () => {
@@ -314,6 +342,24 @@ describe('pickedFilesFromDataTransfer', () => {
         const picked = await pickedFilesFromDataTransfer(dataTransfer);
         expect(picked.files).toHaveLength(MAX_FILES_PER_DROP);
         expect(picked.truncated).toBe(true);
+    });
+
+    it('names a lone folder dropped on the legacy entry path', async () => {
+        const img = makeFile('IMG_1.NEF', 1, 1);
+        const dataTransfer = stubDataTransfer([
+            {
+                kind: 'file',
+                getAsFile: () => null,
+                webkitGetAsEntry: () =>
+                    stubDirectoryEntry('shoot', [[stubFileEntry(img)]]),
+            },
+        ]);
+
+        expect(await pickedFilesFromDataTransfer(dataTransfer)).toEqual({
+            files: [{ file: img }],
+            truncated: false,
+            folderName: 'shoot',
+        });
     });
 
     it('walks directories via webkitGetAsEntry when handles are unsupported', async () => {
@@ -366,6 +412,7 @@ describe('pickFolderWithHandles', () => {
         expect(await pickFolderWithHandles()).toEqual({
             files: [{ file: img, handle }],
             truncated: false,
+            folderName: 'shoot',
         });
     });
 
@@ -376,6 +423,7 @@ describe('pickFolderWithHandles', () => {
             files: [],
             truncated: false,
             emptySelection: true,
+            folderName: 'empty',
         });
 
         (window as { showDirectoryPicker?: unknown }).showDirectoryPicker =
@@ -411,6 +459,7 @@ describe('pickedFilesFromDirectoryInput', () => {
         expect(pickedFilesFromDirectoryInput(fileList)).toEqual({
             files: [{ file: imgA }, { file: imgB }],
             truncated: false,
+            folderName: 'shoot',
         });
     });
 
@@ -421,7 +470,18 @@ describe('pickedFilesFromDirectoryInput', () => {
         expect(pickedFilesFromDirectoryInput(fileList)).toEqual({
             files: [{ file: img }],
             truncated: false,
+            folderName: '.backup',
         });
+    });
+
+    it('leaves a multi-root selection unnamed', () => {
+        const imgA = makeTreeFile('IMG_1.NEF', 'shoot-a/IMG_1.NEF');
+        const imgB = makeTreeFile('IMG_2.NEF', 'shoot-b/IMG_2.NEF');
+        const fileList = [imgA, imgB] as unknown as FileList;
+
+        expect(
+            pickedFilesFromDirectoryInput(fileList).folderName
+        ).toBeUndefined();
     });
 
     it('flags a folder whose files were all filtered out', () => {

--- a/apps/web/lib/upload/fileSystemAccess.ts
+++ b/apps/web/lib/upload/fileSystemAccess.ts
@@ -24,11 +24,16 @@ export interface PickedFile {
  * none survived (an empty folder, or hidden litter only) — distinct from a
  * dismissed dialog or a text drag, which stay silent. Callers surface both
  * instead of silently shortchanging the selection (#388).
+ *
+ * `folderName` is the chosen folder's own name, set only when the gesture was
+ * exactly one folder and nothing else — it labels the upload batch (#395), so
+ * a mixed gesture leaves it unset rather than picking one of several roots.
  */
 export interface PickedFileBatch {
     files: PickedFile[];
     truncated: boolean;
     emptySelection?: boolean;
+    folderName?: string;
 }
 
 /** True when the browser exposes the picker + persistable handles (Chromium). */
@@ -186,6 +191,10 @@ export async function pickedFilesFromDataTransfer(
             if (sink.truncated) break;
             const handle = await handlePromise.catch(() => null);
             if (handle && handle.kind === 'directory') {
+                // A single dropped folder is the only composition we can name:
+                // a second item (another folder, or a loose file) makes the
+                // drop mixed. Same rule as the legacy branch below.
+                if (captured.length === 1) sink.folderName = handle.name;
                 await walkDirectoryHandle(
                     handle as FileSystemDirectoryHandle,
                     sink
@@ -218,6 +227,7 @@ export async function pickedFilesFromDataTransfer(
         sink.files = Array.from(dataTransfer.files).map((file) => ({ file }));
         return flagEmptySelection(sink, captured.length > 0);
     }
+    if (captured.length === 1) sink.folderName = captured[0].entry?.name;
     for (const { file, entry } of captured) {
         if (sink.truncated) break;
         if (entry?.isDirectory) {
@@ -244,6 +254,7 @@ export async function pickFolderWithHandles(): Promise<PickedFileBatch> {
         if (isAbortError(error)) return sink;
         throw error;
     }
+    sink.folderName = directory.name;
     await walkDirectoryHandle(directory, sink);
     // The user did choose a folder here, so an empty yield deserves feedback.
     return flagEmptySelection(sink, true);
@@ -271,7 +282,22 @@ export function pickedFilesFromDirectoryInput(
         files.length > MAX_FILES_PER_DROP
             ? { files: files.slice(0, MAX_FILES_PER_DROP), truncated: true }
             : { files, truncated: false };
+    // Computed before truncation so a capped selection still carries its name.
+    sink.folderName = getSoleRootSegment(files);
     return flagEmptySelection(sink, true);
+}
+
+/**
+ * The chosen root of a `webkitdirectory` selection: the first path segment,
+ * when every file shares it. Unset for a pathless (synthetic) FileList, and
+ * for the multi-root selections the input permits on some platforms.
+ */
+function getSoleRootSegment(files: PickedFile[]): string | undefined {
+    const rootOf = (picked: PickedFile) =>
+        picked.file.webkitRelativePath.split('/')[0];
+    const root = files[0] ? rootOf(files[0]) : undefined;
+    if (!root) return undefined;
+    return files.every((picked) => rootOf(picked) === root) ? root : undefined;
 }
 
 /**

--- a/apps/web/lib/upload/rows.test.ts
+++ b/apps/web/lib/upload/rows.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { patchRowById } from './rows';
+import { patchRowById, resolveUnanimousFolderName } from './rows';
 
 interface Row {
     id: string;
@@ -43,5 +43,40 @@ describe('patchRowById', () => {
         const next = patchRowById(failed, 'a', { error: undefined });
         expect(next).not.toBe(failed);
         expect(next[0].error).toBeUndefined();
+    });
+});
+
+describe('resolveUnanimousFolderName', () => {
+    const shoot = { gestureId: 1, name: 'shoot-2026-08-18' };
+
+    it('names a wave that came entirely from one folder gesture', () => {
+        expect(
+            resolveUnanimousFolderName([
+                { folderOrigin: shoot },
+                { folderOrigin: shoot },
+            ])
+        ).toBe('shoot-2026-08-18');
+    });
+
+    it('declines a wave holding a file from no folder', () => {
+        expect(
+            resolveUnanimousFolderName([{ folderOrigin: shoot }, {}])
+        ).toBeUndefined();
+        expect(
+            resolveUnanimousFolderName([{}, { folderOrigin: shoot }])
+        ).toBeUndefined();
+    });
+
+    it('declines two folder gestures, even same-named ones', () => {
+        expect(
+            resolveUnanimousFolderName([
+                { folderOrigin: shoot },
+                { folderOrigin: { gestureId: 2, name: shoot.name } },
+            ])
+        ).toBeUndefined();
+    });
+
+    it('declines an empty wave', () => {
+        expect(resolveUnanimousFolderName([])).toBeUndefined();
     });
 });

--- a/apps/web/lib/upload/rows.ts
+++ b/apps/web/lib/upload/rows.ts
@@ -23,3 +23,30 @@ export function patchRowById<T extends { id: string }>(
     next[index] = { ...row, ...updates };
     return next;
 }
+
+/**
+ * The folder gesture a row arrived on. `gestureId` is what makes "one folder"
+ * decidable — two drops of same-named folders are two gestures, and only a
+ * wave that is unanimously one of them gets named after it (#395). An explicit
+ * id rather than object identity, so the rule survives a row being cloned.
+ */
+export interface FolderOrigin {
+    gestureId: number;
+    name: string;
+}
+
+/**
+ * The folder name to label a wave's batch with, or undefined to leave it to the
+ * server's timestamp fallback. Set only when every row joining the new batch
+ * came from the same folder gesture — a loose file or a second folder in the
+ * mix makes the batch about more than one folder, so it stays generically named.
+ */
+export function resolveUnanimousFolderName(
+    rows: { folderOrigin?: FolderOrigin }[]
+): string | undefined {
+    const origin = rows[0]?.folderOrigin;
+    if (!origin) return undefined;
+    return rows.every((row) => row.folderOrigin?.gestureId === origin.gestureId)
+        ? origin.name
+        : undefined;
+}

--- a/apps/web/server/services/files.test.ts
+++ b/apps/web/server/services/files.test.ts
@@ -265,6 +265,20 @@ describe('files service', () => {
                 })
             );
         });
+
+        it('uses the caller-supplied name when given one', async () => {
+            const batch = createUploadBatchFixture();
+            mocks.returning.mockResolvedValueOnce([batch]);
+
+            await fileService.createBatch(db, TEST_USER_ID, 'shoot-2026-08-18');
+
+            expect(mocks.values).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: TEST_USER_ID,
+                    name: 'shoot-2026-08-18',
+                })
+            );
+        });
     });
 
     describe('formatFallbackBatchName', () => {

--- a/apps/web/server/services/files.ts
+++ b/apps/web/server/services/files.ts
@@ -77,8 +77,13 @@ interface CreateBatchResult {
 
 // Pre-create a session batch so every file in a multi-file upload joins the
 // same batch (the per-file initiate calls pass this id back as input.batchId).
-async function createBatch(db: DB, userId: string): Promise<CreateBatchResult> {
-    return { batchId: (await insertBatch(db, userId)).id };
+// `name` labels a whole-folder upload after its folder (#395).
+async function createBatch(
+    db: DB,
+    userId: string,
+    name?: string
+): Promise<CreateBatchResult> {
+    return { batchId: (await insertBatch(db, userId, name)).id };
 }
 
 interface InitiateUploadResult {

--- a/apps/web/server/trpc/routers/files.ts
+++ b/apps/web/server/trpc/routers/files.ts
@@ -5,6 +5,10 @@ import { fileService } from '@/server/services/files';
 import { retrievalService } from '@/server/services/retrieval';
 import { protectedProcedure, router } from '../init';
 
+// One rule for both ways a batch gets named: per-file on `upload`, and up front
+// on `createBatch`.
+const batchNameSchema = z.string().min(1).max(255);
+
 const uploadInputSchema = z.object({
     name: z.string().min(1).max(255),
     sizeBytes: z.number().positive(),
@@ -12,7 +16,7 @@ const uploadInputSchema = z.object({
     // Join an existing batch by id, or seed a new one with a custom name.
     // Omit both to get an auto-named single-file batch.
     batchId: z.string().uuid().optional(),
-    batchName: z.string().min(1).max(255).optional(),
+    batchName: batchNameSchema.optional(),
 });
 
 export const filesRouter = router({
@@ -89,11 +93,14 @@ export const filesRouter = router({
             return fileRepo.findByUserAndId(ctx.session.user.id, input.id);
         }),
 
-    // Pre-create a session batch (fallback-named) so a multi-file upload can
-    // pass one batchId to every per-file initiate call.
-    createBatch: protectedProcedure.mutation(({ ctx }) =>
-        fileService.createBatch(ctx.db, ctx.session.user.id)
-    ),
+    // Pre-create a session batch so a multi-file upload can pass one batchId to
+    // every per-file initiate call. `name` labels a whole-folder upload after
+    // its folder; without it the batch gets the timestamp fallback name.
+    createBatch: protectedProcedure
+        .input(z.object({ name: batchNameSchema.optional() }).prefault({}))
+        .mutation(({ ctx, input }) =>
+            fileService.createBatch(ctx.db, ctx.session.user.id, input.name)
+        ),
 
     upload: protectedProcedure
         .input(uploadInputSchema)


### PR DESCRIPTION
## Summary

A dropped shoot folder used to land in a batch called `Upload 2026-08-18 21:14` — the one label the file browser groups by said nothing about the shoot. #388 made folders ingestable; this carries the folder's name through to the batch.

The plumbing already existed (`insertBatch` took a name, `uploadInputSchema` carried `batchName`); only `createBatch` dropped it on the floor. The new work is the ingest side: each folder gesture now reports the folder it picked, and the Upload click uses that name when — and only when — the whole wave came from one folder gesture.

Closes #395

## Changes

- `files.createBatch` takes an optional `name`, validated by a `batchNameSchema` now shared with `uploadInputSchema.batchName`, and passes it through `fileService.createBatch` → `insertBatch`.
- `PickedFileBatch.folderName`, set by all three folder paths: directory drop (both the File System Access and legacy `webkitGetAsEntry` branches), `showDirectoryPicker`, and the `webkitdirectory` input. A gesture that isn't exactly one folder — a second folder, a folder plus a loose file, a multi-root selection — leaves it unset rather than picking a winner.
- Rows carry a `FolderOrigin` (`{ gestureId, name }`) stamped once per `addFiles` call. `resolveUnanimousFolderName` (in `lib/upload/rows.ts`, unit-tested) names the batch only when every row still needing one shares a gesture id — so two drops of same-named folders stay two gestures and keep the fallback.
- No UI change: `BatchHeader` already renders `batchName`.

## Test Plan

- [x] `pnpm check` — 12/12 green, including new unit tests for `resolveUnanimousFolderName` (unanimous / no-origin / two gestures / empty), the three folder ingest paths, and `createBatch` honoring a supplied name
- [x] `pnpm -F web test:e2e:flows` — 37/37. New `upload-folder-names-batch` drives the fallback input with a real folder tree, uploads, asserts `upload_batches.name` is the folder name, then asserts the batch header on `/dashboard/files` is findable by it
- [x] Fallback path asserted both ways: new `upload-mixed-wave-fallback-name` (folder + loose file in one wave) and a name assertion added to the existing `upload-concurrent-wave` test
- [x] `pnpm -F web test:e2e:smoke` — 47/47
- [x] `pnpm -F web e2e:coverage --check` — 17/17 pages, 87/87 use-cases
- [x] Resume paths untouched and still green in the flows tier: rows with a persisted `batchId` are excluded from the batch-mint decision, so they never join or rename a session batch

## Self-review notes

Six low-severity findings were deliberately skipped:

- **`gestureId` vs object-reference identity.** One `FolderOrigin` object per `addFiles` call is shared by reference across its rows, so `===` would work today. Rejected: reference equality as a correctness invariant in React state breaks silently under any clone or serialization, and the explicit id is two lines.
- **Dropping the mixed-wave test's upload wait** in favor of polling the DB right after the click. Rejected: `afterEach` calls `resetUserData`, so ending the test mid-flight would delete rows out from under in-flight confirms and corrupt the next test in this serial spec.
- **Removing the now-unused `uploadInputSchema.batchName` path.** Pre-existing, and #395 cites it as intentional plumbing — removal is a separate call.
- Three test-duplication nits (a shared fallback-name regex across two tiers, a local drive helper for the two new specs) where the repetition reads clearer than the helper would.